### PR TITLE
Fixed incorrect connection label showing

### DIFF
--- a/Adamant/ServiceProtocols/ReachabilityMonitor.swift
+++ b/Adamant/ServiceProtocols/ReachabilityMonitor.swift
@@ -25,12 +25,8 @@ extension AdamantUserInfoKey {
     }
 }
 
-enum AdamantConnection {
-    case none, wifi, cellular
-}
-
 protocol ReachabilityMonitor {
-    var connection: AdamantConnection { get }
+    var connection: Bool { get }
     
     func start()
     func stop()

--- a/Adamant/Services/AdamantAccountService.swift
+++ b/Adamant/Services/AdamantAccountService.swift
@@ -140,25 +140,24 @@ class AdamantAccountService: AccountService {
             case .failure(let error):
                 switch error {
                 case .networkError:
-                    NotificationCenter.default.addObserver(forName: Notification.Name.AdamantReachabilityMonitor.reachabilityChanged, object: nil, queue: nil) { notification in
-                        guard let connection = notification.userInfo?[AdamantUserInfoKey.ReachabilityMonitor.connection] as? AdamantConnection else {
-                            return
-                        }
+                    NotificationCenter.default.addObserver(
+                        forName: Notification.Name.AdamantReachabilityMonitor.reachabilityChanged,
+                        object: nil, queue: nil
+                    ) { notification in
+                        guard (notification.userInfo?[AdamantUserInfoKey.ReachabilityMonitor.connection] as? Bool) == true
+                        else { return }
                         
-                        switch connection {
-                        case .none:
-                            break
-                            
-                        case .wifi, .cellular:
-                            ethWallet.initiateNetwork(apiUrl: url) { result in
-                                switch result {
-                                case .success:
-                                    NotificationCenter.default.removeObserver(self, name: Notification.Name.AdamantReachabilityMonitor.reachabilityChanged, object: nil)
-                                    
-                                case .failure(let error):
-//                                    self.dialogService.showRichError(error: error)
-                                    print(error)
-                                }
+                        ethWallet.initiateNetwork(apiUrl: url) { result in
+                            switch result {
+                            case .success:
+                                NotificationCenter.default.removeObserver(
+                                    self,
+                                    name: Notification.Name.AdamantReachabilityMonitor.reachabilityChanged,
+                                    object: nil
+                                )
+                                
+                            case .failure(let error):
+                                print(error)
                             }
                         }
                     }

--- a/Adamant/Services/AdamantReachability.swift
+++ b/Adamant/Services/AdamantReachability.swift
@@ -10,57 +10,43 @@ import Foundation
 import Reachability
 import Network
 
-// MAKR: - Convinients
-extension Reachability.Connection {
-    var adamantConnection: AdamantConnection {
-        switch self {
-        case .none, .unavailable:
-            return .none
-        
-        case .wifi:
-            return .wifi
-            
-        case .cellular:
-            return .cellular
-        }
-    }
-}
-
 // MARK: - AdamantReachability wrapper
 class AdamantReachability: ReachabilityMonitor {
-    let monitorForWifi = NWPathMonitor(requiredInterfaceType: .wifi)
-    let monitorForCellular = NWPathMonitor(requiredInterfaceType: .cellular)
-    private var wifiStatus: NWPath.Status = .satisfied
-    private var cellularStatus: NWPath.Status = .satisfied
-
-    var connection: AdamantConnection {
-        if wifiStatus     == .satisfied     { return AdamantConnection.wifi     }
-        if cellularStatus == .satisfied     { return AdamantConnection.cellular }
-        return AdamantConnection.none
-    }
+    private let monitor = NWPathMonitor()
+    private(set) var connection = true
     
     func start() {
-        monitorForWifi.pathUpdateHandler = { [weak self] path in
-            self?.wifiStatus = path.status
-            let status = path.status == .satisfied ? AdamantConnection.wifi : AdamantConnection.none
-            let userInfo: [String:Any] = [AdamantUserInfoKey.ReachabilityMonitor.connection: status]
-            NotificationCenter.default.post(name: Notification.Name.AdamantReachabilityMonitor.reachabilityChanged, object: self, userInfo: userInfo)
-        }
-        monitorForCellular.pathUpdateHandler = { [weak self] path in
-            self?.cellularStatus = path.status
-            let status = path.status == .satisfied ? AdamantConnection.cellular : AdamantConnection.none
-            let userInfo: [String:Any] = [AdamantUserInfoKey.ReachabilityMonitor.connection: status]
-            NotificationCenter.default.post(name: Notification.Name.AdamantReachabilityMonitor.reachabilityChanged, object: self, userInfo: userInfo)
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self = self else { return }
+            self.updateConnection()
+            
+            let userInfo: [String: Any] = [
+                AdamantUserInfoKey.ReachabilityMonitor.connection: self.connection
+            ]
+            
+            NotificationCenter.default.post(
+                name: Notification.Name.AdamantReachabilityMonitor.reachabilityChanged,
+                object: self,
+                userInfo: userInfo
+            )
         }
 
         let queue = DispatchQueue(label: "NetworkMonitor")
-        monitorForCellular.start(queue: queue)
-        monitorForWifi.start(queue: queue)
+        monitor.start(queue: queue)
     }
 
     func stop() {
-        monitorForWifi.cancel()
-        monitorForCellular.cancel()
+        monitor.cancel()
     }
     
+    private func updateConnection() {
+        switch monitor.currentPath.status {
+        case .satisfied:
+            connection = true
+        case .unsatisfied, .requiresConnection:
+            connection = false
+        @unknown default:
+            connection = false
+        }
+    }
 }

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -41,7 +41,6 @@ class AdamantChatsProvider: ChatsProvider {
     public var isChatLoaded: [String : Bool] = [:]
     public var chatMaxMessages: [String : Int] = [:]
     public var chatLoadedMessages: [String : Int] = [:]
-    private var connection: AdamantConnection?
     private var isConnectedToTheInternet = true
     private var onConnectionToTheInternetRestored: (() -> Void)?
     
@@ -143,21 +142,21 @@ class AdamantChatsProvider: ChatsProvider {
             queue: nil
         ) { [weak self] notification in
             guard let connection = notification
-                .userInfo?[AdamantUserInfoKey.ReachabilityMonitor.connection] as? AdamantConnection
+                .userInfo?[AdamantUserInfoKey.ReachabilityMonitor.connection] as? Bool
             else {
                 return
             }
-            self?.connection = connection
-            switch self?.connection {
-            case .some(.cellular), .some(.wifi):
-                if self?.isConnectedToTheInternet == false {
-                    self?.onConnectionToTheInternetRestored?()
-                    self?.onConnectionToTheInternetRestored = nil
-                }
-                self?.isConnectedToTheInternet = true
-            case nil, .some(.none):
+            
+            guard connection == true else {
                 self?.isConnectedToTheInternet = false
+                return
             }
+            
+            if self?.isConnectedToTheInternet == false {
+                self?.onConnectionToTheInternetRestored?()
+                self?.onConnectionToTheInternetRestored = nil
+            }
+            self?.isConnectedToTheInternet = true
         }
     }
     


### PR DESCRIPTION
Пофиксил мониторинг подключения к интернету.

Возможно (так и не удалось больше воспроизвести) баг был из-за рассинхрона двух мониторов, поэтому объединил их в один.

Нигде в приложении не имело значения, подключение идет через Wifi или через сотовую связь, поэтому мониторы можно спокойно объединять. К тому же это упрощает логику мониторинга интернета.