### PR TITLE
Fixed showing message in push notification

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -35,6 +35,11 @@
 		55D1D851287B78FC00F94A4E /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 55D1D850287B78FC00F94A4E /* SnapKit */; };
 		55D1D855287B890300F94A4E /* AddressGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D1D854287B890300F94A4E /* AddressGeneratorTests.swift */; };
 		55E69E172868D7920025D82E /* CheckmarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E69E162868D7920025D82E /* CheckmarkView.swift */; };
+		55FBAAF528C54B230066E629 /* Nodes+Allowance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBAAF428C54B230066E629 /* Nodes+Allowance.swift */; };
+		55FBAAF628C54B2F0066E629 /* Nodes+Allowance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBAAF428C54B230066E629 /* Nodes+Allowance.swift */; };
+		55FBAAF728C54B2F0066E629 /* Nodes+Allowance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBAAF428C54B230066E629 /* Nodes+Allowance.swift */; };
+		55FBAAF828C54B300066E629 /* Nodes+Allowance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBAAF428C54B230066E629 /* Nodes+Allowance.swift */; };
+		55FBAAFB28C550920066E629 /* NodesAllowanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBAAFA28C550920066E629 /* NodesAllowanceTests.swift */; };
 		6403F5DB2272389800D58779 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6403F5DE22723C6800D58779 /* DashMainnet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6403F5DD22723C6800D58779 /* DashMainnet.swift */; };
 		6403F5E022723F6400D58779 /* DashWalletRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6403F5DF22723F6400D58779 /* DashWalletRouter.swift */; };
@@ -644,6 +649,8 @@
 		557AC307287B1365004699D7 /* CheckmarkRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckmarkRowView.swift; sourceTree = "<group>"; };
 		55D1D854287B890300F94A4E /* AddressGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressGeneratorTests.swift; sourceTree = "<group>"; };
 		55E69E162868D7920025D82E /* CheckmarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckmarkView.swift; sourceTree = "<group>"; };
+		55FBAAF428C54B230066E629 /* Nodes+Allowance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Nodes+Allowance.swift"; sourceTree = "<group>"; };
+		55FBAAFA28C550920066E629 /* NodesAllowanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodesAllowanceTests.swift; sourceTree = "<group>"; };
 		6403F5DD22723C6800D58779 /* DashMainnet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashMainnet.swift; sourceTree = "<group>"; };
 		6403F5DF22723F6400D58779 /* DashWalletRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashWalletRouter.swift; sourceTree = "<group>"; };
 		6403F5E122723F7500D58779 /* DashWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashWallet.swift; sourceTree = "<group>"; };
@@ -1820,6 +1827,7 @@
 				553B1283281C6EE100FFF24C /* GCDUtilites.swift */,
 				5522A43F28B758530029B543 /* UIKitUtilites.swift */,
 				550698B528C00AED000E8A2B /* CollectionUtilites.swift */,
+				55FBAAF428C54B230066E629 /* Nodes+Allowance.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1975,6 +1983,7 @@
 				E95F85B6200A4D8F0070534A /* TestTools.swift */,
 				55D1D854287B890300F94A4E /* AddressGeneratorTests.swift */,
 				551F66E72895B3DA00DE5D69 /* AdamantHealthCheckServiceTests.swift */,
+				55FBAAFA28C550920066E629 /* NodesAllowanceTests.swift */,
 				E9EC344820066D4A00C0E546 /* Info.plist */,
 			);
 			path = AdamantTests;
@@ -2429,6 +2438,7 @@
 				E9079A91229DF1AC0022CA0D /* Date+adamant.swift in Sources */,
 				E9079A8C229DF19A0022CA0D /* AdamantAvatarService.swift in Sources */,
 				E9079A93229DF1CB0022CA0D /* ExtensionsApi.swift in Sources */,
+				55FBAAF828C54B300066E629 /* Nodes+Allowance.swift in Sources */,
 				E9D664C822A003B800733F8A /* WarningView.swift in Sources */,
 				E9079A96229DF1DA0022CA0D /* ChatAsset.swift in Sources */,
 				E9079A9A229DF1DA0022CA0D /* StateAsset.swift in Sources */,
@@ -2588,6 +2598,7 @@
 				E9E7CDB32002B9FB00DFC4DB /* LoginRoutes.swift in Sources */,
 				E9771DA022997D320099AAC7 /* AdamantUtilities.swift in Sources */,
 				E941CCDE20E7B70200C96220 /* WalletCollectionViewCell.swift in Sources */,
+				55FBAAF528C54B230066E629 /* Nodes+Allowance.swift in Sources */,
 				E9AA8BFA212C166600F9249F /* EthWalletService+Send.swift in Sources */,
 				6449BA68235CA0930033B936 /* ERC20WalletService.swift in Sources */,
 				644793C32166314A00FC4CF5 /* OnboardPage.swift in Sources */,
@@ -2784,6 +2795,7 @@
 				E957E161229C4BEA0019732A /* Crypto.swift in Sources */,
 				64E3D52624B258F800660641 /* ERC20Provider.swift in Sources */,
 				E957E16A229C53980019732A /* DogeProvider.swift in Sources */,
+				55FBAAF728C54B2F0066E629 /* Nodes+Allowance.swift in Sources */,
 				E957E15B229C42B20019732A /* KeychainStore.swift in Sources */,
 				E957E16F229C564B0019732A /* NotificationContent.swift in Sources */,
 				E957E169229C53980019732A /* AdamantProvider.swift in Sources */,
@@ -2850,6 +2862,7 @@
 				E9771D9622996FEB0099AAC7 /* StateType.swift in Sources */,
 				E9771D9522996FEB0099AAC7 /* StateAsset.swift in Sources */,
 				E9771D9222996FEB0099AAC7 /* TransactionAsset.swift in Sources */,
+				55FBAAF628C54B2F0066E629 /* Nodes+Allowance.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2863,6 +2876,7 @@
 				E94883E7203F07CD00F6E1B0 /* PassphraseValidation.swift in Sources */,
 				E95F85B7200A4D8F0070534A /* TestTools.swift in Sources */,
 				E95F85BC200A4E670070534A /* ParsingModelsTests.swift in Sources */,
+				55FBAAFB28C550920066E629 /* NodesAllowanceTests.swift in Sources */,
 				E96D64C02295C06400CA5587 /* JSModels.swift in Sources */,
 				E96D64BE2295C06400CA5587 /* JSAdamantCore.swift in Sources */,
 				E95F85752007E4790070534A /* HexAndBytesUtilitiesTest.swift in Sources */,

--- a/Adamant/ServiceProtocols/HealthCheckService.swift
+++ b/Adamant/ServiceProtocols/HealthCheckService.swift
@@ -17,5 +17,4 @@ protocol HealthCheckService: AnyObject {
     var delegate: HealthCheckDelegate? { get set }
     
     func healthCheck()
-    func getAllowedNodes(sortedBySpeedDescending: Bool, needWS: Bool) -> [Node]
 }

--- a/Adamant/Services/AdamantNodesSource.swift
+++ b/Adamant/Services/AdamantNodesSource.swift
@@ -58,7 +58,7 @@ class AdamantNodesSource: NodesSource {
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            self?.healthCheckService.healthCheck()
+            self?.healthCheck()
         }
         
         guard
@@ -84,14 +84,14 @@ class AdamantNodesSource: NodesSource {
     }
     
     func getAllowedNodes(needWS: Bool) -> [Node] {
-        healthCheckService.getAllowedNodes(
+        healthCheckService.nodes.getAllowedNodes(
             sortedBySpeedDescending: preferTheFastestNode,
             needWS: needWS
         )
     }
     
     func nodesUpdate() {
-        healthCheckService.healthCheck()
+        healthCheck()
         saveNodes()
     }
     
@@ -154,6 +154,7 @@ class AdamantNodesSource: NodesSource {
 extension AdamantNodesSource: HealthCheckDelegate {
     func healthCheckUpdate() {
         sendNodesUpdateNotification()
+        saveNodes()
     }
 }
 

--- a/Adamant/Services/ApiService/AdamantApiService.swift
+++ b/Adamant/Services/ApiService/AdamantApiService.swift
@@ -102,9 +102,7 @@ class AdamantApiService: ApiService {
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            self?.semaphore.wait()
             self?.updateCurrentNodes()
-            self?.semaphore.signal()
         }
     }
     
@@ -286,7 +284,9 @@ class AdamantApiService: ApiService {
     }
     
     private func updateCurrentNodes() {
+        semaphore.wait()
         currentNodes = nodesSource?.getAllowedNodes(needWS: false) ?? []
+        semaphore.signal()
     }
     
     private func sendCurrentNodeUpdateNotification() {

--- a/Adamant/SharedViews/CheckmarkView.swift
+++ b/Adamant/SharedViews/CheckmarkView.swift
@@ -67,6 +67,8 @@ final class CheckmarkView: UIView {
     }
     
     func setIsChecked(_ isChecked: Bool, animated: Bool) {
+        guard self.isChecked != isChecked else { return }
+        
         self.isChecked = isChecked
         updateImage(animated: animated)
     }

--- a/AdamantShared/ExtensionsTools/ExtensionsApi.swift
+++ b/AdamantShared/ExtensionsTools/ExtensionsApi.swift
@@ -15,18 +15,21 @@ class ExtensionsApi {
     let keychainStore: KeychainStore
     
     private(set) lazy var nodes: [Node] = {
+        let nodes: [Node]
         if let raw = keychainStore.get(nodesStoreKey), let data = raw.data(using: String.Encoding.utf8) {
             do {
-                return try JSONDecoder().decode([Node].self, from: data)
+                nodes = try JSONDecoder().decode([Node].self, from: data)
             } catch {
-                return AdamantResources.nodes
+                nodes = AdamantResources.nodes
             }
         } else {
-            return AdamantResources.nodes
+            nodes = AdamantResources.nodes
         }
+        
+        return nodes.getAllowedNodes(sortedBySpeedDescending: true, needWS: false).reversed()
     }()
     
-    private var currentNode: Node? = nil
+    private var currentNode: Node?
     
     private func selectNewNode() {
         currentNode = nodes.popLast()

--- a/AdamantShared/Helpers/Nodes+Allowance.swift
+++ b/AdamantShared/Helpers/Nodes+Allowance.swift
@@ -1,0 +1,26 @@
+//
+//  Nodes+Allowance.swift
+//  Adamant
+//
+//  Created by Andrey on 05.09.2022.
+//  Copyright © 2022 Adamant. All rights reserved.
+//
+
+extension Collection where Element: Node {
+    func getAllowedNodes(sortedBySpeedDescending: Bool, needWS: Bool) -> [Node] {
+        var allowedNodes = filter {
+            $0.connectionStatus == .allowed
+                && (!needWS || $0.status?.wsEnabled ?? false)
+        }
+        
+        if allowedNodes.isEmpty && !needWS {
+            allowedNodes = filter { $0.isEnabled }
+        }
+        
+        return sortedBySpeedDescending
+            ? allowedNodes.sorted {
+                $0.status?.ping ?? .greatestFiniteMagnitude < $1.status?.ping ?? .greatestFiniteMagnitude
+            }
+            : allowedNodes.shuffled()
+    }
+}

--- a/AdamantShared/Helpers/UIKitUtilites.swift
+++ b/AdamantShared/Helpers/UIKitUtilites.swift
@@ -10,6 +10,8 @@ import UIKit
 
 extension UICollectionView {
     func scrollToLastItem(animated: Bool) {
+        guard numberOfSections > .zero else { return }
+        
         let indexPath = IndexPath(
             row: numberOfItems(inSection: numberOfSections - 1) - 1,
             section: numberOfSections - 1

--- a/AdamantTests/AdamantHealthCheckServiceTests.swift
+++ b/AdamantTests/AdamantHealthCheckServiceTests.swift
@@ -23,89 +23,6 @@ class AdamantHealthCheckServiceTests: XCTestCase {
         service = nil
     }
     
-    // MARK: - Allowed nodes tests without WS support
-    
-    func testOneAllowedNode() {
-        let node = makeTestNode(connectionStatus: .allowed)
-        service.nodes = [node]
-        
-        XCTAssertEqual([node], allowedNodes(ws: false))
-    }
-    
-    func testOneNodeWithoutConnectionStatusIsAllowed() {
-        let node = makeTestNode()
-        service.nodes = [node]
-        
-        XCTAssertEqual([node], allowedNodes(ws: false))
-    }
-    
-    func testOneDisabledNodeIsNotAllowed() {
-        let node = makeTestNode()
-        node.isEnabled = false
-        service.nodes = [node]
-        
-        XCTAssert(allowedNodes(ws: false).isEmpty)
-    }
-    
-    func testOneOfflineNodeIsAllowed() {
-        let node = makeTestNode(connectionStatus: .offline)
-        service.nodes = [node]
-        
-        XCTAssertEqual([node], allowedNodes(ws: false))
-    }
-    
-    func testManyAllowedNodesSortedBySpeedDescending() {
-        let nodes: [Node] = (0 ..< 100).map { ping in
-            let node = makeTestNode(connectionStatus: .allowed)
-            node.status = .init(ping: TimeInterval(ping), wsEnabled: false, height: nil, version: nil)
-            return node
-        }
-        
-        service.nodes = nodes.shuffled()
-        
-        XCTAssertEqual(nodes, allowedNodes(ws: false))
-    }
-    
-    // MARK: - Allowed nodes tests with WS support
-    
-    func testOneAllowedNodeWithoutWSIsNotAllowedWS() {
-        let node = makeTestNode(connectionStatus: .allowed)
-        node.status = .init(ping: .zero, wsEnabled: false, height: nil, version: nil)
-        service.nodes = [node]
-        
-        XCTAssert(allowedNodes(ws: true).isEmpty)
-    }
-    
-    func testOneAllowedWSNodeIsAllowedWS() {
-        let node = makeTestNode(connectionStatus: .allowed)
-        node.status = .init(ping: .zero, wsEnabled: true, height: nil, version: nil)
-        service.nodes = [node]
-        
-        XCTAssertEqual([node], allowedNodes(ws: true))
-    }
-    
-    func testOneWSNodeWithoutConnectionStatusIsNotAllowedWS() {
-        let node = makeTestNode()
-        node.status = .init(ping: .zero, wsEnabled: true, height: nil, version: nil)
-        service.nodes = [node]
-        
-        XCTAssert(allowedNodes(ws: true).isEmpty)
-    }
-    
-    func testManyAllowedNodesSortedBySpeedDescendingWS() {
-        let nodes: [Node] = (0 ..< 100).map { ping in
-            let node = makeTestNode(connectionStatus: .allowed)
-            node.status = .init(ping: TimeInterval(ping), wsEnabled: true, height: nil, version: nil)
-            return node
-        }
-        
-        service.nodes = nodes.shuffled()
-        
-        XCTAssertEqual(nodes, allowedNodes(ws: true))
-    }
-    
-    // MARK: - Health check tests
-    
     func testOneNodeWithoutStatusIsSync() {
         let node = makeTestNode()
         
@@ -196,10 +113,6 @@ class AdamantHealthCheckServiceTests: XCTestCase {
     }
     
     // MARK: - Helpers
-    
-    private func allowedNodes(ws: Bool) -> [Node] {
-        service.getAllowedNodes(sortedBySpeedDescending: true, needWS: ws)
-    }
     
     private func makeTestNode(connectionStatus: Node.ConnectionStatus = .synchronizing) -> Node {
         let node = Node(scheme: .default, host: "", port: nil)

--- a/AdamantTests/NodesAllowanceTests.swift
+++ b/AdamantTests/NodesAllowanceTests.swift
@@ -1,0 +1,112 @@
+//
+//  NodesAllowanceTests.swift
+//  AdamantTests
+//
+//  Created by Andrey on 05.09.2022.
+//  Copyright © 2022 Adamant. All rights reserved.
+//
+
+import XCTest
+@testable import Adamant
+
+class NodesAllowanceTests: XCTest {
+    var nodes = [Node]()
+    
+    override func setUp() {
+        super.setUp()
+        nodes = []
+    }
+    
+    // MARK: - Allowed nodes tests without WS support
+    
+    func testOneAllowedNode() {
+        let node = makeTestNode(connectionStatus: .allowed)
+        nodes = [node]
+        
+        XCTAssertEqual([node], allowedNodes(ws: false))
+    }
+    
+    func testOneNodeWithoutConnectionStatusIsAllowed() {
+        let node = makeTestNode()
+        nodes = [node]
+        
+        XCTAssertEqual([node], allowedNodes(ws: false))
+    }
+    
+    func testOneDisabledNodeIsNotAllowed() {
+        let node = makeTestNode()
+        node.isEnabled = false
+        nodes = [node]
+        
+        XCTAssert(allowedNodes(ws: false).isEmpty)
+    }
+    
+    func testOneOfflineNodeIsAllowed() {
+        let node = makeTestNode(connectionStatus: .offline)
+        nodes = [node]
+        
+        XCTAssertEqual([node], allowedNodes(ws: false))
+    }
+    
+    func testManyAllowedNodesSortedBySpeedDescending() {
+        let nodes: [Node] = (0 ..< 100).map { ping in
+            let node = makeTestNode(connectionStatus: .allowed)
+            node.status = .init(ping: TimeInterval(ping), wsEnabled: false, height: nil, version: nil)
+            return node
+        }
+        
+        self.nodes = nodes.shuffled()
+        
+        XCTAssertEqual(nodes, allowedNodes(ws: false))
+    }
+    
+    // MARK: - Allowed nodes tests with WS support
+    
+    func testOneAllowedNodeWithoutWSIsNotAllowedWS() {
+        let node = makeTestNode(connectionStatus: .allowed)
+        node.status = .init(ping: .zero, wsEnabled: false, height: nil, version: nil)
+        self.nodes = [node]
+        
+        XCTAssert(allowedNodes(ws: true).isEmpty)
+    }
+    
+    func testOneAllowedWSNodeIsAllowedWS() {
+        let node = makeTestNode(connectionStatus: .allowed)
+        node.status = .init(ping: .zero, wsEnabled: true, height: nil, version: nil)
+        self.nodes = [node]
+        
+        XCTAssertEqual([node], allowedNodes(ws: true))
+    }
+    
+    func testOneWSNodeWithoutConnectionStatusIsNotAllowedWS() {
+        let node = makeTestNode()
+        node.status = .init(ping: .zero, wsEnabled: true, height: nil, version: nil)
+        self.nodes = [node]
+        
+        XCTAssert(allowedNodes(ws: true).isEmpty)
+    }
+    
+    func testManyAllowedNodesSortedBySpeedDescendingWS() {
+        let nodes: [Node] = (0 ..< 100).map { ping in
+            let node = makeTestNode(connectionStatus: .allowed)
+            node.status = .init(ping: TimeInterval(ping), wsEnabled: true, height: nil, version: nil)
+            return node
+        }
+        
+        self.nodes = nodes.shuffled()
+        
+        XCTAssertEqual(nodes, allowedNodes(ws: true))
+    }
+    
+    // MARK: - Helpers
+    
+    private func allowedNodes(ws: Bool) -> [Node] {
+        nodes.getAllowedNodes(sortedBySpeedDescending: true, needWS: ws)
+    }
+    
+    private func makeTestNode(connectionStatus: Node.ConnectionStatus = .synchronizing) -> Node {
+        let node = Node(scheme: .default, host: "", port: nil)
+        node.connectionStatus = connectionStatus
+        return node
+    }
+}


### PR DESCRIPTION
Починил показ сообщений в пуш уведомлениях. Проблема была в том, что health check никак не влиял на запросы от экстеншена для получения пуш уведомления. И запросы могли идти к отключенным и неработающим нодам.

Как все работает теперь:
1. Пока приложение активно, проводится хелс чек и его результаты сохраняются в память.
2. Когда приходит пуш уведомление, ноды со своими статусами достаются из памяти и запрос идет к доступной ноде. Если она возвращает ошибку, запрос идет к следующей доступной ноде и т. д.