### PR TITLE
Scroll bug when update message status

### DIFF
--- a/Adamant/Stories/Chats/ChatViewController+MessageKit.swift
+++ b/Adamant/Stories/Chats/ChatViewController+MessageKit.swift
@@ -619,12 +619,12 @@ extension ChatViewController: MessageInputBarDelegate {
         
         chatsProvider.sendMessage(message, recipientId: partner, from: chatroom, completion: { [weak self] result in
             switch result {
-            case .success:
-                DispatchQueue.main.async {
-                    self?.scrollDown()
+            case .success(let transaction):
+                if transaction.statusEnum == .pending {
+                    DispatchQueue.main.async {
+                        self?.scrollDown()
+                    }
                 }
-                break
-                
             case .failure(let error):
                 var showFreeToken = false
                 switch error {


### PR DESCRIPTION
При обновлении статуса сообщения (после отправки) - чат скроллит вниз 2 раза (вместо 1). 
Причина: метод `sendMessage` возвращает `completion` два раза: один раз сразу и второй раз после отправки на сервер 