### PR TITLE
Email sending fix

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		64F085D920E2D7600006DE68 /* AdmTransactionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F085D820E2D7600006DE68 /* AdmTransactionsViewController.swift */; };
 		64FA53CD20E1300B006783C9 /* EthTransactionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FA53CC20E1300A006783C9 /* EthTransactionsViewController.swift */; };
 		64FA53D120E24942006783C9 /* TransactionDetailsViewControllerBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FA53D020E24941006783C9 /* TransactionDetailsViewControllerBase.swift */; };
+		9345769528FD0C34004E6C7A /* UIViewController+email.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9345769428FD0C34004E6C7A /* UIViewController+email.swift */; };
 		A50AEB04262C815200B37C22 /* EFQRCode in Frameworks */ = {isa = PBXBuildFile; productRef = A50AEB03262C815200B37C22 /* EFQRCode */; };
 		A50AEB0C262C81E300B37C22 /* QRCodeReader in Frameworks */ = {isa = PBXBuildFile; productRef = A50AEB0B262C81E300B37C22 /* QRCodeReader */; };
 		A50AEB14262C837900B37C22 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = A50AEB13262C837900B37C22 /* Alamofire */; };
@@ -756,6 +757,7 @@
 		64FA53CC20E1300A006783C9 /* EthTransactionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthTransactionsViewController.swift; sourceTree = "<group>"; };
 		64FA53D020E24941006783C9 /* TransactionDetailsViewControllerBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionDetailsViewControllerBase.swift; sourceTree = "<group>"; };
 		74D5744703A7ECC98E244B14 /* Pods-AdmCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdmCore.debug.xcconfig"; path = "Target Support Files/Pods-AdmCore/Pods-AdmCore.debug.xcconfig"; sourceTree = "<group>"; };
+		9345769428FD0C34004E6C7A /* UIViewController+email.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+email.swift"; sourceTree = "<group>"; };
 		A578BDE42623051C00090141 /* DashWalletService+Transactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DashWalletService+Transactions.swift"; sourceTree = "<group>"; };
 		A5BBD810262C657300B5C40C /* ByteBackpacker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByteBackpacker.swift; sourceTree = "<group>"; };
 		AD258997F050B24C0051CC8D /* Pods-Adamant.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adamant.release.xcconfig"; path = "Target Support Files/Pods-Adamant/Pods-Adamant.release.xcconfig"; sourceTree = "<group>"; };
@@ -1417,6 +1419,7 @@
 				645AE06521E67D3300AD3623 /* UITextField+adamant.swift */,
 				41935847287841E20083363B /* MacOSDeterminer.swift */,
 				4E9EE86E28CE793D008359F7 /* SafeDecimalRow.swift */,
+				9345769428FD0C34004E6C7A /* UIViewController+email.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2644,6 +2647,7 @@
 				E9AA8BFA212C166600F9249F /* EthWalletService+Send.swift in Sources */,
 				6449BA68235CA0930033B936 /* ERC20WalletService.swift in Sources */,
 				644793C32166314A00FC4CF5 /* OnboardPage.swift in Sources */,
+				9345769528FD0C34004E6C7A /* UIViewController+email.swift in Sources */,
 				3AE89DDB2837F5D30051D3A9 /* ChatRoomsChats.swift in Sources */,
 				64E1C831222E9617006C4DA7 /* DogeWalletService.swift in Sources */,
 				E91947B22000246A001362F8 /* AdamantError.swift in Sources */,

--- a/Adamant/Assets/l18n/de.lproj/Localizable.strings
+++ b/Adamant/Assets/l18n/de.lproj/Localizable.strings
@@ -763,9 +763,6 @@
 /* Shared alert notification: body message for no internet connection. */
 "Shared.NoInternet.Body" = "Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut";
 
-/* Shared alert notification: message for no Mail services. */
-"Shared.NoMail" = "Mail services are not available";
-
 /* Shared alert 'Ok' button. Used anywhere */
 "Shared.Ok" = "Ok";
 

--- a/Adamant/Assets/l18n/en.lproj/Localizable.strings
+++ b/Adamant/Assets/l18n/en.lproj/Localizable.strings
@@ -751,9 +751,6 @@
 /* Shared alert notification: body message for no internet connection. */
 "Shared.NoInternet.Body" = "Please check your internet connection and try again";
 
-/* Shared alert notification: message for no Mail services. */
-"Shared.NoMail" = "Mail services are not available";
-
 /* Shared alert 'Ok' button. Used anywhere */
 "Shared.Ok" = "OK";
 

--- a/Adamant/Assets/l18n/ru.lproj/Localizable.strings
+++ b/Adamant/Assets/l18n/ru.lproj/Localizable.strings
@@ -748,9 +748,6 @@
 /* Shared alert notification: body message for no internet connection. */
 "Shared.NoInternet.Body" = "Проверьте соединение и повторите попытку";
 
-/* Shared alert notification: message for no Mail services. */
-"Shared.NoMail" = "Отправка почты недоступна";
-
 /* Shared alert 'Ok' button. Used anywhere */
 "Shared.Ok" = "OK";
 

--- a/Adamant/Helpers/UIViewController+email.swift
+++ b/Adamant/Helpers/UIViewController+email.swift
@@ -12,8 +12,8 @@ import UIKit
 extension UIViewController {
     func openEmailScreen(
         recipient: String,
-        subject: String,
-        body: String,
+        subject: String?,
+        body: String?,
         delegate: MFMailComposeViewControllerDelegate?
     ) {
         if MFMailComposeViewController.canSendMail() {
@@ -27,16 +27,20 @@ extension UIViewController {
 private extension UIViewController {
     func showEmailVC(
         recipient: String,
-        subject: String,
-        body: String,
+        subject: String?,
+        body: String?,
         delegate: MFMailComposeViewControllerDelegate?
     ) {
-        let html = body.replacingOccurrences(of: "\n", with: "<br>")
         let mailVC = MFMailComposeViewController()
+        subject.map { mailVC.setSubject($0) }
+        
+        if let body = body {
+            let html = body.replacingOccurrences(of: "\n", with: "<br>")
+            mailVC.setMessageBody(html, isHTML: true)
+        }
+        
         mailVC.mailComposeDelegate = delegate
         mailVC.setToRecipients([recipient])
-        mailVC.setSubject(subject)
-        mailVC.setMessageBody(html, isHTML: true)
         mailVC.modalPresentationStyle = .overFullScreen
         present(mailVC, animated: true, completion: nil)
     }

--- a/Adamant/Helpers/UIViewController+email.swift
+++ b/Adamant/Helpers/UIViewController+email.swift
@@ -1,0 +1,43 @@
+//
+//  UIViewController+email.swift
+//  Adamant
+//
+//  Created by Andrey Golubenko on 17.10.2022.
+//  Copyright © 2022 Adamant. All rights reserved.
+//
+
+import MessageUI
+import UIKit
+
+extension UIViewController {
+    func openEmailScreen(
+        recipient: String,
+        subject: String,
+        body: String,
+        delegate: MFMailComposeViewControllerDelegate?
+    ) {
+        if MFMailComposeViewController.canSendMail() {
+            showEmailVC(recipient: recipient, subject: subject, body: body, delegate: delegate)
+        } else {
+            AdamantUtilities.openEmailApp(recipient: recipient, subject: subject, body: body)
+        }
+    }
+}
+
+private extension UIViewController {
+    func showEmailVC(
+        recipient: String,
+        subject: String,
+        body: String,
+        delegate: MFMailComposeViewControllerDelegate?
+    ) {
+        let html = body.replacingOccurrences(of: "\n", with: "<br>")
+        let mailVC = MFMailComposeViewController()
+        mailVC.mailComposeDelegate = delegate
+        mailVC.setToRecipients([recipient])
+        mailVC.setSubject(subject)
+        mailVC.setMessageBody(html, isHTML: true)
+        mailVC.modalPresentationStyle = .overFullScreen
+        present(mailVC, animated: true, completion: nil)
+    }
+}

--- a/Adamant/ServiceProtocols/DialogService.swift
+++ b/Adamant/ServiceProtocols/DialogService.swift
@@ -13,8 +13,6 @@ extension String.adamantLocalized.alert {
     static let share = NSLocalizedString("Shared.Share", comment: "Shared alert 'Share' button. Used anywhere for presenting standart iOS 'Share' menu.")
     static let generateQr = NSLocalizedString("Shared.GenerateQRCode", comment: "Shared alert 'Generate QR' button. Used to generate QR codes with addresses and passphrases. Used with sharing and saving, anywhere.")
     static let saveToPhotolibrary = NSLocalizedString("Shared.SaveToPhotolibrary", comment: "Shared alert 'Save to Photos'. Used with saving images to photolibrary")
-    
-    static let noMailService = NSLocalizedString("Shared.NoMail", comment: "Shared alert notification: message for no Mail services")
 }
 
 enum ShareType {

--- a/Adamant/Services/AdamantDialogService.swift
+++ b/Adamant/Services/AdamantDialogService.swift
@@ -123,33 +123,28 @@ extension AdamantDialogService {
                     presenter = vc
                 }
                 
-                if !MFMailComposeViewController.canSendMail() {
-                    print("Mail services are not available")
-                    dialogService.showWarning(withMessage: String.adamantLocalized.alert.noMailService)
-                    return
-                }
-                
-                let mailVC = MFMailComposeViewController()
-                mailVC.mailComposeDelegate = dialogService.mailDelegate
-                mailVC.setToRecipients([AdamantResources.supportEmail])
-                mailVC.setSubject(String.adamantLocalized.alert.emailErrorMessageTitle)
-                
-                let systemVersion = UIDevice.current.systemVersion
-                let model = AdamantUtilities.deviceModelCode
-                let deviceInfo = "Model: \(model)\n" + "iOS: \(systemVersion)\n" + "App version: \(AdamantUtilities.applicationVersion)"
-                
                 let body: String
                 
                 if let error = error {
                     let errorDescription = String(describing: error)
-                    body = String(format: String.adamantLocalized.alert.emailErrorMessageBodyWithDescription, message, errorDescription, deviceInfo)
+                    body = String(format: String.adamantLocalized.alert.emailErrorMessageBodyWithDescription, message,
+                        errorDescription,
+                        AdamantUtilities.deviceInfo
+                    )
                 } else {
-                    body = String(format: String.adamantLocalized.alert.emailErrorMessageBody, message, deviceInfo)
+                    body = String(
+                        format: String.adamantLocalized.alert.emailErrorMessageBody,
+                        message,
+                        AdamantUtilities.deviceInfo
+                    )
                 }
                 
-                mailVC.setMessageBody(body, isHTML: false)
-                mailVC.modalPresentationStyle = .overFullScreen
-                presenter.present(mailVC, animated: true, completion: nil)
+                presenter.openEmailScreen(
+                    recipient: AdamantResources.supportEmail,
+                    subject: .adamantLocalized.alert.emailErrorMessageTitle,
+                    body: body,
+                    delegate: dialogService.mailDelegate
+                )
             }
         }
         

--- a/Adamant/Stories/Settings/AboutViewController.swift
+++ b/Adamant/Stories/Settings/AboutViewController.swift
@@ -265,18 +265,12 @@ class AboutViewController: FormViewController {
         }.cellUpdate { (cell, _) in
             cell.accessoryType = .disclosureIndicator
         }.onCellSelection { [weak self] (_, _) in
-            let mailVC = MFMailComposeViewController()
-            mailVC.mailComposeDelegate = self
-            mailVC.setToRecipients([AdamantResources.supportEmail])
-            
-            let systemVersion = UIDevice.current.systemVersion
-            let model = AdamantUtilities.deviceModelCode
-            let deviceInfo = "\n\n\nModel: \(model)\n" + "iOS: \(systemVersion)\n" + "App version: \(AdamantUtilities.applicationVersion)"
-            
-            mailVC.setSubject("ADAMANT iOS")
-            mailVC.setMessageBody(deviceInfo, isHTML: false)
-            mailVC.modalPresentationStyle = .overFullScreen
-            self?.present(mailVC, animated: true, completion: nil)
+            self?.openEmailScreen(
+                recipient: AdamantResources.supportEmail,
+                subject: "ADAMANT Support",
+                body: "\n\n\n" + AdamantUtilities.deviceInfo,
+                delegate: self
+            )
         }
             
         /*


### PR DESCRIPTION
Пофиксил краш при попытке отправить email в поддержку.

Теперь, если не получается показать экран с отправкой сообщения, вызывается диплинк, который обработается приложением для отправки эл. писем.

Также пофиксил получение названия модели устройства. Macbook показывался как iPad. Теперь все норм.
<img width="209" alt="Screen Shot 2022-10-18 at 06 29 21" src="https://user-images.githubusercontent.com/31865236/196307841-f81386bf-52b2-4215-8caf-9984ea421629.png">

Единственное, оставил iPadOS. Способа достоверно получить версию MacOS на мультиплатформенных приложениях я так и не нашел. При получении сообщения нужно будет находить версию MacOS по [такому соответствию](https://stackoverflow.com/questions/63581114/mac-catalyst-version).
