### PR TITLE
Macos popups fix

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 		55FBAAF728C54B2F0066E629 /* Nodes+Allowance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBAAF428C54B230066E629 /* Nodes+Allowance.swift */; };
 		55FBAAF828C54B300066E629 /* Nodes+Allowance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBAAF428C54B230066E629 /* Nodes+Allowance.swift */; };
 		55FBAAFB28C550920066E629 /* NodesAllowanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FBAAFA28C550920066E629 /* NodesAllowanceTests.swift */; };
-		6403F5DB2272389800D58779 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		6403F5DB2272389800D58779 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		6403F5DE22723C6800D58779 /* DashMainnet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6403F5DD22723C6800D58779 /* DashMainnet.swift */; };
 		6403F5E022723F6400D58779 /* DashWalletRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6403F5DF22723F6400D58779 /* DashWalletRouter.swift */; };
 		6403F5E222723F7500D58779 /* DashWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6403F5E122723F7500D58779 /* DashWallet.swift */; };
@@ -173,6 +173,7 @@
 		93E5D4DC293000BE00439298 /* UnregisteredTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E5D4DA293000BE00439298 /* UnregisteredTransaction.swift */; };
 		93E5D4DD293000BE00439298 /* UnregisteredTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E5D4DA293000BE00439298 /* UnregisteredTransaction.swift */; };
 		93E5D4E02930029300439298 /* AdamantCore+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E5D4DF2930029300439298 /* AdamantCore+Extensions.swift */; };
+		93FA403629401BFC00D20DB6 /* PopupKit in Frameworks */ = {isa = PBXBuildFile; productRef = 93FA403529401BFC00D20DB6 /* PopupKit */; };
 		A50A41072822F8CE006BDFE1 /* BtcWalletRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50A41032822F8CE006BDFE1 /* BtcWalletRoutes.swift */; };
 		A50A41082822F8CE006BDFE1 /* BtcWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50A41042822F8CE006BDFE1 /* BtcWalletService.swift */; };
 		A50A41092822F8CE006BDFE1 /* BtcWalletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50A41052822F8CE006BDFE1 /* BtcWalletViewController.swift */; };
@@ -187,7 +188,7 @@
 		A5241B70262DEDE1009FA43E /* Clibsodium in Frameworks */ = {isa = PBXBuildFile; productRef = A5241B6F262DEDE1009FA43E /* Clibsodium */; };
 		A5241B77262DEDEF009FA43E /* Clibsodium in Frameworks */ = {isa = PBXBuildFile; productRef = A5241B76262DEDEF009FA43E /* Clibsodium */; };
 		A5241B7E262DEDFE009FA43E /* Clibsodium in Frameworks */ = {isa = PBXBuildFile; productRef = A5241B7D262DEDFE009FA43E /* Clibsodium */; };
-		A530B0D82842110D003F0210 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		A530B0D82842110D003F0210 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 		A544F0D4262C9878001F1A6D /* Eureka in Frameworks */ = {isa = PBXBuildFile; productRef = A544F0D3262C9878001F1A6D /* Eureka */; };
 		A57282CA262C94CD00C96FA8 /* DateToolsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A57282C9262C94CD00C96FA8 /* DateToolsSwift */; };
 		A57282D1262C94DA00C96FA8 /* DateToolsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A57282D0262C94DA00C96FA8 /* DateToolsSwift */; };
@@ -1163,11 +1164,12 @@
 				A57839FB262C95BF00428183 /* KeychainAccess in Frameworks */,
 				A5DBBABD262C7221004AC028 /* Clibsodium in Frameworks */,
 				A50AEB14262C837900B37C22 /* Alamofire in Frameworks */,
-				A530B0D82842110D003F0210 /* (null) in Frameworks */,
+				A530B0D82842110D003F0210 /* BuildFile in Frameworks */,
 				A5DBBADC262C729B004AC028 /* CryptoSwift in Frameworks */,
 				A5D87BA3262CA01D00DC28F0 /* ProcedureKit in Frameworks */,
 				A5C99E0E262C9E3A00F7B1B7 /* Reachability in Frameworks */,
 				A5DBBAF0262C72EF004AC028 /* LiskKit in Frameworks */,
+				93FA403629401BFC00D20DB6 /* PopupKit in Frameworks */,
 				A5DBBAEE262C72EF004AC028 /* BitcoinKit in Frameworks */,
 				A57282CA262C94CD00C96FA8 /* DateToolsSwift in Frameworks */,
 			);
@@ -2210,6 +2212,7 @@
 				3A8875EE27BBF38D00436195 /* Parchment */,
 				557AC305287B10D8004699D7 /* SnapKit */,
 				416F5EA3290162EB00EF0400 /* SocketIO */,
+				93FA403529401BFC00D20DB6 /* PopupKit */,
 			);
 			productName = Adamant;
 			productReference = E913C8EE1FFFA51D001A83F7 /* Adamant.app */;
@@ -2356,24 +2359,24 @@
 			);
 			mainGroup = E913C8E51FFFA51D001A83F7;
 			packageReferences = (
-				A5785ADD262C63580001BC66 /* XCRemoteSwiftPackageReference "web3swift" */,
-				A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium" */,
-				A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
-				A50AEB02262C815200B37C22 /* XCRemoteSwiftPackageReference "EFQRCode" */,
-				A50AEB0A262C81E300B37C22 /* XCRemoteSwiftPackageReference "QRCodeReader.swift" */,
-				A50AEB12262C837900B37C22 /* XCRemoteSwiftPackageReference "Alamofire" */,
-				A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit" */,
-				A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools" */,
-				A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess" */,
-				A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor" */,
-				A544F0D2262C9878001F1A6D /* XCRemoteSwiftPackageReference "Eureka" */,
-				A5F0A049262C9CA90009672A /* XCRemoteSwiftPackageReference "Swinject" */,
-				A5C99E0C262C9E3A00F7B1B7 /* XCRemoteSwiftPackageReference "Reachability" */,
-				A5D87BA1262CA01D00DC28F0 /* XCRemoteSwiftPackageReference "ProcedureKit" */,
+				A5785ADD262C63580001BC66 /* XCRemoteSwiftPackageReference "web3swift.git" */,
+				A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium.git" */,
+				A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift.git" */,
+				A50AEB02262C815200B37C22 /* XCRemoteSwiftPackageReference "EFQRCode.git" */,
+				A50AEB0A262C81E300B37C22 /* XCRemoteSwiftPackageReference "QRCodeReader.swift.git" */,
+				A50AEB12262C837900B37C22 /* XCRemoteSwiftPackageReference "Alamofire.git" */,
+				A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit.git" */,
+				A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools.git" */,
+				A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess.git" */,
+				A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor.git" */,
+				A544F0D2262C9878001F1A6D /* XCRemoteSwiftPackageReference "Eureka.git" */,
+				A5F0A049262C9CA90009672A /* XCRemoteSwiftPackageReference "Swinject.git" */,
+				A5C99E0C262C9E3A00F7B1B7 /* XCRemoteSwiftPackageReference "Reachability.swift" */,
+				A5D87BA1262CA01D00DC28F0 /* XCRemoteSwiftPackageReference "ProcedureKit.git" */,
 				A5AC8DFD262E0B030053A7E2 /* XCRemoteSwiftPackageReference "SipHash" */,
 				3A8875ED27BBF38D00436195 /* XCRemoteSwiftPackageReference "Parchment" */,
-				557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit" */,
-				416F5EA2290162EB00EF0400 /* XCRemoteSwiftPackageReference "socket" */,
+				557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit.git" */,
+				416F5EA2290162EB00EF0400 /* XCRemoteSwiftPackageReference "socket.io-client-swift" */,
 			);
 			productRefGroup = E913C8EF1FFFA51D001A83F7 /* Products */;
 			projectDirPath = "";
@@ -2548,7 +2551,6 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Adamant/Pods-Adamant-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/FTIndicator/FTIndicator.framework",
 				"${BUILT_PRODUCTS_DIR}/FreakingSimpleRoundImageView/FreakingSimpleRoundImageView.framework",
 				"${BUILT_PRODUCTS_DIR}/MessageInputBar/MessageInputBar.framework",
 				"${BUILT_PRODUCTS_DIR}/MessageKit/MessageKit.framework",
@@ -2557,7 +2559,6 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FTIndicator.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FreakingSimpleRoundImageView.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessageInputBar.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessageKit.framework",
@@ -2722,7 +2723,7 @@
 				A50A41112822FC35006BDFE1 /* BtcWalletService+RichMessageProviderWithStatusCheck.swift in Sources */,
 				E926E032213EC43B005E536B /* FullscreenAlertView.swift in Sources */,
 				644EC35B20EFB8E900F40C73 /* AdamantDelegateCell.swift in Sources */,
-				6403F5DB2272389800D58779 /* (null) in Sources */,
+				6403F5DB2272389800D58779 /* BuildFile in Sources */,
 				6416B1A521AEE157006089AC /* LskWalletService+Transfers.swift in Sources */,
 				648DD7A62237DC4000B811FD /* DogeTransferViewController.swift in Sources */,
 				E9960B3421F5154300C840A8 /* BaseAccount+CoreDataProperties.swift in Sources */,
@@ -3181,7 +3182,7 @@
 				CURRENT_PROJECT_VERSION = 231;
 				DEVELOPMENT_TEAM = J2L77FMN46;
 				INFOPLIST_FILE = MessageNotificationContentExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3210,7 +3211,7 @@
 				CURRENT_PROJECT_VERSION = 231;
 				DEVELOPMENT_TEAM = J2L77FMN46;
 				INFOPLIST_FILE = MessageNotificationContentExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3281,7 +3282,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ADAMANT;
@@ -3337,7 +3338,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = ADAMANT;
 				SDKROOT = iphoneos;
@@ -3360,7 +3361,7 @@
 				DISPLAY_NAME = ADM.Dev;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
 				INFOPLIST_FILE = Adamant/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3388,7 +3389,7 @@
 				DISPLAY_NAME = Adamant;
 				EXCLUDED_SOURCE_FILE_NAMES = Debug.xcassets;
 				INFOPLIST_FILE = Adamant/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3414,7 +3415,7 @@
 				CURRENT_PROJECT_VERSION = 231;
 				DEVELOPMENT_TEAM = J2L77FMN46;
 				INFOPLIST_FILE = TransferNotificationContentExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3443,7 +3444,7 @@
 				CURRENT_PROJECT_VERSION = 231;
 				DEVELOPMENT_TEAM = J2L77FMN46;
 				INFOPLIST_FILE = TransferNotificationContentExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3473,7 +3474,7 @@
 				CURRENT_PROJECT_VERSION = 231;
 				DEVELOPMENT_TEAM = J2L77FMN46;
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3502,7 +3503,7 @@
 				CURRENT_PROJECT_VERSION = 231;
 				DEVELOPMENT_TEAM = J2L77FMN46;
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3530,7 +3531,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = J2L77FMN46;
 				INFOPLIST_FILE = AdamantTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3553,7 +3554,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = J2L77FMN46;
 				INFOPLIST_FILE = AdamantTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3636,7 +3637,7 @@
 				kind = branch;
 			};
 		};
-		416F5EA2290162EB00EF0400 /* XCRemoteSwiftPackageReference "socket" */ = {
+		416F5EA2290162EB00EF0400 /* XCRemoteSwiftPackageReference "socket.io-client-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/socketio/socket.io-client-swift";
 			requirement = {
@@ -3644,7 +3645,7 @@
 				kind = branch;
 			};
 		};
-		557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+		557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
 			requirement = {
@@ -3652,7 +3653,7 @@
 				minimumVersion = 5.0.0;
 			};
 		};
-		A50AEB02262C815200B37C22 /* XCRemoteSwiftPackageReference "EFQRCode" */ = {
+		A50AEB02262C815200B37C22 /* XCRemoteSwiftPackageReference "EFQRCode.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EFPrefix/EFQRCode.git";
 			requirement = {
@@ -3660,7 +3661,7 @@
 				minimumVersion = 6.1.0;
 			};
 		};
-		A50AEB0A262C81E300B37C22 /* XCRemoteSwiftPackageReference "QRCodeReader.swift" */ = {
+		A50AEB0A262C81E300B37C22 /* XCRemoteSwiftPackageReference "QRCodeReader.swift.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/yannickl/QRCodeReader.swift.git";
 			requirement = {
@@ -3668,7 +3669,7 @@
 				minimumVersion = 10.1.1;
 			};
 		};
-		A50AEB12262C837900B37C22 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+		A50AEB12262C837900B37C22 /* XCRemoteSwiftPackageReference "Alamofire.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
 			requirement = {
@@ -3676,7 +3677,7 @@
 				minimumVersion = 5.4.2;
 			};
 		};
-		A544F0D2262C9878001F1A6D /* XCRemoteSwiftPackageReference "Eureka" */ = {
+		A544F0D2262C9878001F1A6D /* XCRemoteSwiftPackageReference "Eureka.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/xmartlabs/Eureka.git";
 			requirement = {
@@ -3684,7 +3685,7 @@
 				minimumVersion = 5.3.3;
 			};
 		};
-		A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools" */ = {
+		A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maniramezan/DateTools.git";
 			requirement = {
@@ -3692,7 +3693,7 @@
 				kind = branch;
 			};
 		};
-		A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {
+		A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess.git";
 			requirement = {
@@ -3700,7 +3701,7 @@
 				minimumVersion = 4.2.2;
 			};
 		};
-		A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor" */ = {
+		A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RNCryptor/RNCryptor.git";
 			requirement = {
@@ -3708,7 +3709,7 @@
 				minimumVersion = 5.1.0;
 			};
 		};
-		A5785ADD262C63580001BC66 /* XCRemoteSwiftPackageReference "web3swift" */ = {
+		A5785ADD262C63580001BC66 /* XCRemoteSwiftPackageReference "web3swift.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/skywinder/web3swift.git";
 			requirement = {
@@ -3724,7 +3725,7 @@
 				minimumVersion = 1.2.2;
 			};
 		};
-		A5C99E0C262C9E3A00F7B1B7 /* XCRemoteSwiftPackageReference "Reachability" */ = {
+		A5C99E0C262C9E3A00F7B1B7 /* XCRemoteSwiftPackageReference "Reachability.swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ashleymills/Reachability.swift";
 			requirement = {
@@ -3732,7 +3733,7 @@
 				minimumVersion = 5.1.0;
 			};
 		};
-		A5D87BA1262CA01D00DC28F0 /* XCRemoteSwiftPackageReference "ProcedureKit" */ = {
+		A5D87BA1262CA01D00DC28F0 /* XCRemoteSwiftPackageReference "ProcedureKit.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ProcedureKit/ProcedureKit.git";
 			requirement = {
@@ -3740,7 +3741,7 @@
 				minimumVersion = 5.2.0;
 			};
 		};
-		A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium" */ = {
+		A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jedisct1/swift-sodium.git";
 			requirement = {
@@ -3748,7 +3749,7 @@
 				minimumVersion = 0.9.1;
 			};
 		};
-		A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */ = {
+		A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzyzanowskim/CryptoSwift.git";
 			requirement = {
@@ -3756,7 +3757,7 @@
 				minimumVersion = 1.5.0;
 			};
 		};
-		A5F0A049262C9CA90009672A /* XCRemoteSwiftPackageReference "Swinject" */ = {
+		A5F0A049262C9CA90009672A /* XCRemoteSwiftPackageReference "Swinject.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Swinject/Swinject.git";
 			requirement = {
@@ -3764,7 +3765,7 @@
 				minimumVersion = 2.7.1;
 			};
 		};
-		A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit" */ = {
+		A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/bmoliveira/MarkdownKit.git";
 			requirement = {
@@ -3782,122 +3783,126 @@
 		};
 		416F5EA3290162EB00EF0400 /* SocketIO */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 416F5EA2290162EB00EF0400 /* XCRemoteSwiftPackageReference "socket" */;
+			package = 416F5EA2290162EB00EF0400 /* XCRemoteSwiftPackageReference "socket.io-client-swift" */;
 			productName = SocketIO;
 		};
 		557AC305287B10D8004699D7 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			package = 557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit.git" */;
 			productName = SnapKit;
 		};
 		55D1D84E287B78F200F94A4E /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			package = 557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit.git" */;
 			productName = SnapKit;
 		};
 		55D1D850287B78FC00F94A4E /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			package = 557AC304287B10D8004699D7 /* XCRemoteSwiftPackageReference "SnapKit.git" */;
 			productName = SnapKit;
+		};
+		93FA403529401BFC00D20DB6 /* PopupKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PopupKit;
 		};
 		A50AEB03262C815200B37C22 /* EFQRCode */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A50AEB02262C815200B37C22 /* XCRemoteSwiftPackageReference "EFQRCode" */;
+			package = A50AEB02262C815200B37C22 /* XCRemoteSwiftPackageReference "EFQRCode.git" */;
 			productName = EFQRCode;
 		};
 		A50AEB0B262C81E300B37C22 /* QRCodeReader */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A50AEB0A262C81E300B37C22 /* XCRemoteSwiftPackageReference "QRCodeReader.swift" */;
+			package = A50AEB0A262C81E300B37C22 /* XCRemoteSwiftPackageReference "QRCodeReader.swift.git" */;
 			productName = QRCodeReader;
 		};
 		A50AEB13262C837900B37C22 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A50AEB12262C837900B37C22 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			package = A50AEB12262C837900B37C22 /* XCRemoteSwiftPackageReference "Alamofire.git" */;
 			productName = Alamofire;
 		};
 		A5241B6F262DEDE1009FA43E /* Clibsodium */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium" */;
+			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium.git" */;
 			productName = Clibsodium;
 		};
 		A5241B76262DEDEF009FA43E /* Clibsodium */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium" */;
+			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium.git" */;
 			productName = Clibsodium;
 		};
 		A5241B7D262DEDFE009FA43E /* Clibsodium */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium" */;
+			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium.git" */;
 			productName = Clibsodium;
 		};
 		A544F0D3262C9878001F1A6D /* Eureka */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A544F0D2262C9878001F1A6D /* XCRemoteSwiftPackageReference "Eureka" */;
+			package = A544F0D2262C9878001F1A6D /* XCRemoteSwiftPackageReference "Eureka.git" */;
 			productName = Eureka;
 		};
 		A57282C9262C94CD00C96FA8 /* DateToolsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools" */;
+			package = A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools.git" */;
 			productName = DateToolsSwift;
 		};
 		A57282D0262C94DA00C96FA8 /* DateToolsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools" */;
+			package = A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools.git" */;
 			productName = DateToolsSwift;
 		};
 		A57282D2262C94DF00C96FA8 /* DateToolsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools" */;
+			package = A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools.git" */;
 			productName = DateToolsSwift;
 		};
 		A57282D4262C94E500C96FA8 /* DateToolsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools" */;
+			package = A57282C8262C94CD00C96FA8 /* XCRemoteSwiftPackageReference "DateTools.git" */;
 			productName = DateToolsSwift;
 		};
 		A57839FA262C95BF00428183 /* KeychainAccess */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+			package = A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess.git" */;
 			productName = KeychainAccess;
 		};
 		A5783A01262C95CA00428183 /* KeychainAccess */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+			package = A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess.git" */;
 			productName = KeychainAccess;
 		};
 		A5783A08262C95D000428183 /* KeychainAccess */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+			package = A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess.git" */;
 			productName = KeychainAccess;
 		};
 		A5783A0A262C95D500428183 /* KeychainAccess */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+			package = A57839F9262C95BF00428183 /* XCRemoteSwiftPackageReference "KeychainAccess.git" */;
 			productName = KeychainAccess;
 		};
 		A5783A0D262C964500428183 /* RNCryptor */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor" */;
+			package = A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor.git" */;
 			productName = RNCryptor;
 		};
 		A5783A14262C965000428183 /* RNCryptor */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor" */;
+			package = A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor.git" */;
 			productName = RNCryptor;
 		};
 		A5783A1B262C965600428183 /* RNCryptor */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor" */;
+			package = A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor.git" */;
 			productName = RNCryptor;
 		};
 		A5783A1D262C965D00428183 /* RNCryptor */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor" */;
+			package = A5783A0C262C964500428183 /* XCRemoteSwiftPackageReference "RNCryptor.git" */;
 			productName = RNCryptor;
 		};
 		A5785ADE262C63580001BC66 /* web3swift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5785ADD262C63580001BC66 /* XCRemoteSwiftPackageReference "web3swift" */;
+			package = A5785ADD262C63580001BC66 /* XCRemoteSwiftPackageReference "web3swift.git" */;
 			productName = web3swift;
 		};
 		A5AC8DFE262E0B030053A7E2 /* SipHash */ = {
@@ -3907,37 +3912,37 @@
 		};
 		A5C99E0D262C9E3A00F7B1B7 /* Reachability */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5C99E0C262C9E3A00F7B1B7 /* XCRemoteSwiftPackageReference "Reachability" */;
+			package = A5C99E0C262C9E3A00F7B1B7 /* XCRemoteSwiftPackageReference "Reachability.swift" */;
 			productName = Reachability;
 		};
 		A5D87BA2262CA01D00DC28F0 /* ProcedureKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5D87BA1262CA01D00DC28F0 /* XCRemoteSwiftPackageReference "ProcedureKit" */;
+			package = A5D87BA1262CA01D00DC28F0 /* XCRemoteSwiftPackageReference "ProcedureKit.git" */;
 			productName = ProcedureKit;
 		};
 		A5DBBABC262C7221004AC028 /* Clibsodium */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium" */;
+			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium.git" */;
 			productName = Clibsodium;
 		};
 		A5DBBADB262C729B004AC028 /* CryptoSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
+			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift.git" */;
 			productName = CryptoSwift;
 		};
 		A5DBBAE2262C72B0004AC028 /* CryptoSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
+			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift.git" */;
 			productName = CryptoSwift;
 		};
 		A5DBBAE4262C72B7004AC028 /* CryptoSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
+			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift.git" */;
 			productName = CryptoSwift;
 		};
 		A5DBBAE6262C72BD004AC028 /* CryptoSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
+			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift.git" */;
 			productName = CryptoSwift;
 		};
 		A5DBBAED262C72EF004AC028 /* BitcoinKit */ = {
@@ -3950,27 +3955,27 @@
 		};
 		A5F0A04A262C9CA90009672A /* Swinject */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5F0A049262C9CA90009672A /* XCRemoteSwiftPackageReference "Swinject" */;
+			package = A5F0A049262C9CA90009672A /* XCRemoteSwiftPackageReference "Swinject.git" */;
 			productName = Swinject;
 		};
 		A5F92993262C855B00C3E60A /* MarkdownKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit" */;
+			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit.git" */;
 			productName = MarkdownKit;
 		};
 		A5F929AE262C857D00C3E60A /* MarkdownKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit" */;
+			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit.git" */;
 			productName = MarkdownKit;
 		};
 		A5F929B5262C858700C3E60A /* MarkdownKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit" */;
+			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit.git" */;
 			productName = MarkdownKit;
 		};
 		A5F929B7262C858F00C3E60A /* MarkdownKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit" */;
+			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit.git" */;
 			productName = MarkdownKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Adamant.xcworkspace/contents.xcworkspacedata
+++ b/Adamant.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:PopupKit">
+   </FileRef>
+   <FileRef
       location = "group:LiskKit">
    </FileRef>
    <FileRef

--- a/Adamant/AppDelegate.swift
+++ b/Adamant/AppDelegate.swift
@@ -135,7 +135,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         window!.makeKeyAndVisible()
         
-        // MARK: 4. Show login
+        // MARK: 4. Setup dialog service
+        dialogService.setup()
+        
+        // MARK: 5. Show login
         let login = router.get(scene: AdamantScene.Login.login) as! LoginViewController
         let welcomeIsShown = UserDefaults.standard.bool(forKey: StoreKey.application.welcomeScreensIsShown)
         
@@ -150,7 +153,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             UserDefaults.standard.set(true, forKey: StoreKey.application.welcomeScreensIsShown)
         }
     
-        // MARK: 5 Reachability & Autoupdate
+        // MARK: 6 Reachability & Autoupdate
         repeater = RepeaterService()
         
         // Configure reachability
@@ -217,7 +220,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             dialogService.showError(withMessage: "Failed to register CurrencyInfoService autoupdate. Please, report a bug", error: nil)
         }
         
-        // MARK: 6. Logout reset
+        // MARK: 7. Logout reset
         NotificationCenter.default.addObserver(forName: Notification.Name.AdamantAccountService.userLoggedOut, object: nil, queue: OperationQueue.main) { [weak self] _ in
             // On logout, pop all navigators to root.
             guard let tbc = self?.window?.rootViewController as? UITabBarController, let vcs = tbc.viewControllers else {
@@ -229,10 +232,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
-        // MARK: 7. Welcome messages
+        // MARK: 8. Welcome messages
         NotificationCenter.default.addObserver(forName: Notification.Name.AdamantChatsProvider.initiallySyncedChanged, object: nil, queue: OperationQueue.main, using: handleWelcomeMessages)
         
-        // MARK: 8. Notifications
+        // MARK: 9. Notifications
         pushNotificationsTokenService.sendTokenDeletionTransactions()
         UNUserNotificationCenter.current().delegate = self
         

--- a/Adamant/AppDelegate.swift
+++ b/Adamant/AppDelegate.swift
@@ -75,22 +75,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         // MARK: 2. Init UI
-        window = UIWindow(frame: UIScreen.main.bounds)
-        window!.rootViewController = UITabBarController()
-        window!.rootViewController!.view.backgroundColor = .white
-        window!.tintColor = UIColor.adamant.primary
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        self.window = window
+        window.rootViewController = UITabBarController()
+        window.rootViewController!.view.backgroundColor = .white
+        window.tintColor = UIColor.adamant.primary
         
         // MARK: 3. Prepare pages
         guard let router = container.resolve(Router.self) else {
             fatalError("Failed to get Router")
         }
         
-        if let tabbar = window?.rootViewController as? UITabBarController {
+        if let tabbar = window.rootViewController as? UITabBarController {
             // MARK: Chats
             let chats = UISplitViewController()
             chats.tabBarItem.title = String.adamantLocalized.tabItems.chats
             chats.tabBarItem.image = #imageLiteral(resourceName: "chats_tab")
-            chats.preferredDisplayMode = .allVisible
+            chats.preferredDisplayMode = .oneBesideSecondary
             chats.tabBarItem.badgeColor = UIColor.adamant.primary
             
             let chatList = UINavigationController(rootViewController: router.get(scene: AdamantScene.Chats.chatList))
@@ -99,7 +100,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let accounts = UISplitViewController()
             accounts.tabBarItem.title = String.adamantLocalized.tabItems.account
             accounts.tabBarItem.image = #imageLiteral(resourceName: "account-tab")
-            accounts.preferredDisplayMode = .allVisible
+            accounts.preferredDisplayMode = .oneBesideSecondary
             accounts.tabBarItem.badgeColor = UIColor.adamant.primary
             
             let account = UINavigationController(rootViewController: router.get(scene: AdamantScene.Account.account))
@@ -133,10 +134,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             tabbar.setViewControllers([chats, accounts], animated: false)
         }
         
-        window!.makeKeyAndVisible()
+        window.makeKeyAndVisible()
         
         // MARK: 4. Setup dialog service
-        dialogService.setup()
+        dialogService.setup(window: window)
         
         // MARK: 5. Show login
         let login = router.get(scene: AdamantScene.Login.login) as! LoginViewController
@@ -144,7 +145,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         login.requestBiometryOnFirstTimeActive = welcomeIsShown
         login.modalPresentationStyle = .overFullScreen
-        window!.rootViewController?.present(login, animated: false, completion: nil)
+        window.rootViewController?.present(login, animated: false, completion: nil)
         
         if !welcomeIsShown {
             let welcome = router.get(scene: AdamantScene.Onboard.welcome)

--- a/Adamant/ServiceProtocols/DialogService.swift
+++ b/Adamant/ServiceProtocols/DialogService.swift
@@ -91,7 +91,7 @@ struct AdamantAlertAction {
 }
 
 protocol DialogService: AnyObject {
-    func setup()
+    func setup(window: UIWindow)
     
     func getTopmostViewController() -> UIViewController?
     

--- a/Adamant/ServiceProtocols/DialogService.swift
+++ b/Adamant/ServiceProtocols/DialogService.swift
@@ -91,6 +91,7 @@ struct AdamantAlertAction {
 }
 
 protocol DialogService: AnyObject {
+    func setup()
     
     func getTopmostViewController() -> UIViewController?
     

--- a/Adamant/Services/AdamantDialogService.swift
+++ b/Adamant/Services/AdamantDialogService.swift
@@ -16,13 +16,15 @@ class AdamantDialogService: DialogService {
     private let router: Router
     private let popupManager = PopupManager()
     private let mailDelegate = MailDelegate()
+    private weak var window: UIWindow?
     
     // Configure notifications
     init(router: Router) {
         self.router = router
     }
     
-    func setup() {
+    func setup(window: UIWindow) {
+        self.window = window
         popupManager.setup()
     }
 }
@@ -38,7 +40,7 @@ extension AdamantDialogService {
     }
     
     func getTopmostViewController() -> UIViewController? {
-        if var topController = UIApplication.shared.keyWindow?.rootViewController {
+        if var topController = window?.rootViewController {
             if let tab = topController as? UITabBarController, let selected = tab.selectedViewController {
                 topController = selected
             }
@@ -76,21 +78,27 @@ extension AdamantDialogService {
 // MARK: - Indicators
 extension AdamantDialogService {
     func showProgress(withMessage message: String?, userInteractionEnable enabled: Bool) {
-        popupManager.showProgressAlert(message: message, userInteractionEnabled: enabled)
+        DispatchQueue.onMainAsync { [weak popupManager] in
+            popupManager?.showProgressAlert(message: message, userInteractionEnabled: enabled)
+        }
     }
     
     func dismissProgress() {
-        DispatchQueue.onMainAsync { [popupManager] in
-            popupManager.dismissAlert()
+        DispatchQueue.onMainAsync { [weak popupManager] in
+            popupManager?.dismissAlert()
         }
     }
     
     func showSuccess(withMessage message: String) {
-        popupManager.showSuccessAlert(message: message)
+        DispatchQueue.onMainAsync { [weak popupManager] in
+            popupManager?.showSuccessAlert(message: message)
+        }
     }
     
     func showWarning(withMessage message: String) {
-        popupManager.showWarningAlert(message: message)
+        DispatchQueue.onMainAsync { [weak popupManager] in
+            popupManager?.showWarningAlert(message: message)
+        }
     }
     
     func showError(withMessage message: String, error: Error? = nil) {
@@ -179,34 +187,42 @@ extension AdamantDialogService {
     }
     
     func showNoConnectionNotification() {
-        popupManager.showNotification(
-            icon: #imageLiteral(resourceName: "error"),
-            title: .adamantLocalized.alert.noInternetNotificationTitle,
-            description: .adamantLocalized.alert.noInternetNotificationBoby,
-            autoDismiss: false,
-            tapHandler: nil
-        )
+        DispatchQueue.onMainAsync { [weak popupManager] in
+            popupManager?.showNotification(
+                icon: #imageLiteral(resourceName: "error"),
+                title: .adamantLocalized.alert.noInternetNotificationTitle,
+                description: .adamantLocalized.alert.noInternetNotificationBoby,
+                autoDismiss: false,
+                tapHandler: nil
+            )
+        }
     }
     
     func dissmisNoConnectionNotification() {
-        popupManager.dismissNotification()
+        DispatchQueue.onMainAsync { [weak popupManager] in
+            popupManager?.dismissNotification()
+        }
     }
 }
 
 // MARK: - Notifications
 extension AdamantDialogService {
     func showNotification(title: String?, message: String?, image: UIImage?, tapHandler: (() -> Void)?) {
-        popupManager.showNotification(
-            icon: image,
-            title: title,
-            description: message,
-            autoDismiss: true,
-            tapHandler: tapHandler
-        )
+        DispatchQueue.onMainAsync { [weak popupManager] in
+            popupManager?.showNotification(
+                icon: image,
+                title: title,
+                description: message,
+                autoDismiss: true,
+                tapHandler: tapHandler
+            )
+        }
     }
     
     func dismissNotification() {
-        popupManager.dismissNotification()
+        DispatchQueue.onMainAsync { [weak popupManager] in
+            popupManager?.dismissNotification()
+        }
     }
 }
 

--- a/Adamant/Services/AdamantDialogService.swift
+++ b/Adamant/Services/AdamantDialogService.swift
@@ -7,23 +7,23 @@
 //
 
 import UIKit
-import FTIndicator
 import PMAlertController
 import MessageUI
+import PopupKit
 
 class AdamantDialogService: DialogService {
     // MARK: Dependencies
-    var router: Router!
-    
-    fileprivate var mailDelegate: MailDelegate = {
-        MailDelegate()
-    }()
+    private let router: Router
+    private let popupManager = PopupManager()
+    private let mailDelegate = MailDelegate()
     
     // Configure notifications
-    init() {
-        FTIndicator.setIndicatorStyle(.extraLight)
-        
-        FTNotificationIndicator.setDefaultDismissTime(4)
+    init(router: Router) {
+        self.router = router
+    }
+    
+    func setup() {
+        popupManager.setup()
     }
 }
 
@@ -65,32 +65,32 @@ extension AdamantDialogService {
 // MARK: - Toast
 extension AdamantDialogService {
     func showToastMessage(_ message: String) {
-        FTIndicator.showToastMessage(message)
+        popupManager.showToastMessage(message)
     }
     
     func dismissToast() {
-        FTIndicator.dismissToast()
+        popupManager.dismissToast()
     }
 }
 
 // MARK: - Indicators
 extension AdamantDialogService {
     func showProgress(withMessage message: String?, userInteractionEnable enabled: Bool) {
-        FTIndicator.showProgress(withMessage: message, userInteractionEnable: enabled)
+        popupManager.showProgressAlert(message: message, userInteractionEnabled: enabled)
     }
     
     func dismissProgress() {
-        DispatchQueue.onMainAsync {
-            FTIndicator.dismissProgress()
+        DispatchQueue.onMainAsync { [popupManager] in
+            popupManager.dismissAlert()
         }
     }
     
     func showSuccess(withMessage message: String) {
-        FTIndicator.showSuccess(withMessage: message)
+        popupManager.showSuccessAlert(message: message)
     }
     
     func showWarning(withMessage message: String) {
-        FTIndicator.showError(withMessage: message)
+        popupManager.showWarningAlert(message: message)
     }
     
     func showError(withMessage message: String, error: Error? = nil) {
@@ -100,7 +100,7 @@ extension AdamantDialogService {
     }
     
     private func internalShowError(withMessage message: String, error: Error? = nil) {
-        FTIndicator.dismissProgress()
+        popupManager.dismissAlert()
         
         let alertVC = PMAlertController(title: String.adamantLocalized.alert.error, description: message, image: #imageLiteral(resourceName: "error"), style: .alert)
         
@@ -179,26 +179,34 @@ extension AdamantDialogService {
     }
     
     func showNoConnectionNotification() {
-        FTIndicator.showNotification(with: #imageLiteral(resourceName: "error"), title: String.adamantLocalized.alert.noInternetNotificationTitle, message: String.adamantLocalized.alert.noInternetNotificationBoby, autoDismiss: false, tapHandler: nil, completion: nil)
+        popupManager.showNotification(
+            icon: #imageLiteral(resourceName: "error"),
+            title: .adamantLocalized.alert.noInternetNotificationTitle,
+            description: .adamantLocalized.alert.noInternetNotificationBoby,
+            autoDismiss: false,
+            tapHandler: nil
+        )
     }
     
     func dissmisNoConnectionNotification() {
-        FTIndicator.dismissNotification()
+        popupManager.dismissNotification()
     }
 }
 
 // MARK: - Notifications
 extension AdamantDialogService {
     func showNotification(title: String?, message: String?, image: UIImage?, tapHandler: (() -> Void)?) {
-        if let image = image {
-            FTIndicator.showNotification(with: image, title: title, message: message, tapHandler: tapHandler)
-        } else {
-            FTIndicator.showNotification(withTitle: title, message: message, tapHandler: tapHandler)
-        }
+        popupManager.showNotification(
+            icon: image,
+            title: title,
+            description: message,
+            autoDismiss: true,
+            tapHandler: tapHandler
+        )
     }
     
     func dismissNotification() {
-        FTIndicator.dismissNotification()
+        popupManager.dismissNotification()
     }
 }
 

--- a/Adamant/Services/AdamantPushNotificationsTokenService.swift
+++ b/Adamant/Services/AdamantPushNotificationsTokenService.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import os
 
 final class AdamantPushNotificationsTokenService: PushNotificationsTokenService {
     private let securedStore: SecuredStore
@@ -80,7 +79,7 @@ private extension AdamantPushNotificationsTokenService {
         }
         
         let token = mapToken(token)
-        os_log("APNS token: %{public}@", token)
+        AdamantUtilities.consoleLog("APNS token:", token)
         
         guard token != getToken() else {
             tokenProcessingSemaphore.signal()

--- a/Adamant/SwinjectDependencies.swift
+++ b/Adamant/SwinjectDependencies.swift
@@ -40,9 +40,7 @@ extension Container {
         // MARK: - Services with dependencies
         // MARK: DialogService
         self.register(DialogService.self) { r in
-            let service = AdamantDialogService()
-            service.router = r.resolve(Router.self)
-            return service
+            AdamantDialogService(router: r.resolve(Router.self)!)
         }.inObjectScope(.container)
         
         // MARK: Notifications

--- a/AdamantShared/Helpers/AdamantUtilities.swift
+++ b/AdamantShared/Helpers/AdamantUtilities.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import os
 
 class AdamantUtilities {
     
@@ -53,5 +54,10 @@ class AdamantUtilities {
         let data = Data(publicKeyHashBytes)
         let number = data.withUnsafeBytes { $0.load(as: UInt64.self) }
         return "U\(number)"
+    }
+    
+    static func consoleLog(_ args: String..., separator: String = " ") {
+        let message = args.joined(separator: separator)
+        os_log("adamant-console-log %{public}@", message)
     }
 }

--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -8,7 +8,6 @@
 
 import UserNotifications
 import MarkdownKit
-import os
 
 class NotificationService: UNNotificationServiceExtension {
     private let passphraseStoreKey = "accountService.passphrase"
@@ -41,7 +40,11 @@ class NotificationService: UNNotificationServiceExtension {
     var bestAttemptContent: UNMutableNotificationContent?
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-        os_log("Push notification received:\n\n%{public}@", request.content.userInfo.debugDescription)
+        AdamantUtilities.consoleLog(
+            "Push notification received",
+            request.content.userInfo.debugDescription,
+            separator: "\n"
+        )
         
         self.contentHandler = contentHandler
         bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
@@ -94,8 +97,8 @@ class NotificationService: UNNotificationServiceExtension {
             partnerPublicKey = transaction.senderPublicKey
         }
         
-        let contactsBlackList: [String] = securedStore.get(StoreKey.accountService.blackList) ?? []
-        guard !contactsBlackList.contains(partnerAddress) else { return }
+        let contactsBlockList: [String] = securedStore.get(StoreKey.accountService.blackList) ?? []
+        guard !contactsBlockList.contains(partnerAddress) else { return }
         
         // MARK: 4. Address book
         if let addressBook = api.getAddressBook(for: pushRecipient, core: core, keypair: keypair),

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,6 @@ target 'Adamant' do
   
   # UI
   pod 'FreakingSimpleRoundImageView' # Round avatars
-  pod 'FTIndicator' # Notifications and activity indicator
   pod 'MessageKit', '2.0.0' # Chat UI
   pod 'MyLittlePinpad' # Pinpad
   pod 'PMAlertController' # Custom alert controller

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,5 @@
 PODS:
   - FreakingSimpleRoundImageView (1.3)
-  - FTIndicator (1.2.9):
-    - FTIndicator/FTNotificationIndicator (= 1.2.9)
-    - FTIndicator/FTProgressIndicator (= 1.2.9)
-    - FTIndicator/FTToastIndicator (= 1.2.9)
-  - FTIndicator/FTNotificationIndicator (1.2.9)
-  - FTIndicator/FTProgressIndicator (1.2.9)
-  - FTIndicator/FTToastIndicator (1.2.9)
   - MessageInputBar/Core (0.4.1)
   - MessageKit (2.0.0):
     - MessageInputBar/Core
@@ -16,7 +9,6 @@ PODS:
 
 DEPENDENCIES:
   - FreakingSimpleRoundImageView
-  - FTIndicator
   - MessageKit (= 2.0.0)
   - MyLittlePinpad
   - PMAlertController
@@ -25,7 +17,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - FreakingSimpleRoundImageView
-    - FTIndicator
     - MessageInputBar
     - MessageKit
     - MyLittlePinpad
@@ -34,13 +25,12 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   FreakingSimpleRoundImageView: 0d687cb05da8684e85c4c2ae9945bafcbe89d2a2
-  FTIndicator: f7f071fd159e5befa1d040a9ef2e3ab53fa9322c
   MessageInputBar: e81c7535347f1f7b923de7080409a535a004b6e4
   MessageKit: 29c1c87e5a396d2ca7a3f712e5171dc9aba42a1e
   MyLittlePinpad: d75682f2d817b490c49acc70a9ebd37da752281b
   PMAlertController: ab5fcf4d085b7878c9451466d701449c4bf6efb8
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
 
-PODFILE CHECKSUM: 1f922c15b0493d5364bfac4f081f68c4170351b9
+PODFILE CHECKSUM: 6e7b116bac3a8dd20ab1012944d9f54838725597
 
 COCOAPODS: 1.11.3

--- a/PopupKit/.gitignore
+++ b/PopupKit/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/PopupKit/Package.swift
+++ b/PopupKit/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PopupKit",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(
+            name: "PopupKit",
+            targets: ["PopupKit"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "PopupKit",
+            dependencies: []
+        )
+    ]
+)

--- a/PopupKit/README.md
+++ b/PopupKit/README.md
@@ -1,0 +1,33 @@
+# PopupKit
+
+A library for presenting popups:
+- notifications (on the top)
+- alerts (in the middle)
+- toasts (on the bottom)
+
+This library uses its own UIWindow above main UIWindow to present popups.
+
+## Usage
+
+### Import Framework
+
+```swift
+import PopupKit
+```
+
+### Setup
+
+You need to setup popup manager after your main window setup (window.makeKeyAndVisible()). Not before.
+
+```swift
+let popupManager = PopupManager()
+popupManager.setup()
+```
+
+### Show popups
+
+```swift
+popupManager.showToastMessage("Some message")
+```
+
+etc.

--- a/PopupKit/Sources/PopupKit/Implementation/Common/BlockingView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/BlockingView.swift
@@ -7,15 +7,8 @@
 
 import SwiftUI
 
-extension View {
-    func interactionWithBackground(enabled: Bool) -> some View {
-        enabled
-            ? self.asAnyView()
-            : background(BlockingView()).asAnyView()
-    }
-}
-
-private struct BlockingView: UIViewRepresentable {
+/// Blocks interaction with background
+struct BlockingView: UIViewRepresentable {
     func makeUIView(context _: Context) -> some UIView {
         UIBlockingView()
     }

--- a/PopupKit/Sources/PopupKit/Implementation/Common/Blur.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/Blur.swift
@@ -1,0 +1,20 @@
+//
+//  Blur.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import SwiftUI
+
+struct Blur: UIViewRepresentable {
+    let style: UIBlurEffect.Style
+    
+    func makeUIView(context: Context) -> UIVisualEffectView {
+        .init(effect: UIBlurEffect(style: style))
+    }
+    
+    func updateUIView(_ uiView: UIVisualEffectView, context _: Context) {
+        uiView.effect = UIBlurEffect(style: style)
+    }
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Common/Constants.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/Constants.swift
@@ -1,0 +1,14 @@
+//
+//  Constants.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import UIKit
+
+enum Constants {
+    static let borderPadding: CGFloat = 35
+    static let cornerRadius: CGFloat = 8
+    static let blurStyle: UIBlurEffect.Style = .regular
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Common/Extensions.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/Extensions.swift
@@ -44,4 +44,3 @@ extension DragGesture.Value {
         .init(width: predictedEndLocation.x - location.x, height: predictedEndLocation.y - location.y)
     }
 }
-

--- a/PopupKit/Sources/PopupKit/Implementation/Common/Extensions.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/Extensions.swift
@@ -1,0 +1,47 @@
+//
+//  Extensions.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import SwiftUI
+
+extension Axis.Set {
+    static var all = Axis.Set([.vertical, .horizontal])
+}
+
+extension View {
+    func asAnyView() -> AnyView {
+        AnyView(self)
+    }
+    
+    func expanded(
+        _ axes: Axis.Set = .all,
+        alignment: Alignment = .center
+    ) -> some View {
+        var resultView = self.asAnyView()
+        if axes.contains(.vertical) {
+            resultView = resultView
+                .frame(maxHeight: .infinity, alignment: alignment)
+                .asAnyView()
+        }
+        if axes.contains(.horizontal) {
+            resultView = resultView
+                .frame(maxWidth: .infinity, alignment: alignment)
+                .asAnyView()
+        }
+        return resultView
+    }
+    
+    func frame(squareSize: CGFloat, alignment: Alignment = .center) -> some View {
+        frame(width: squareSize, height: squareSize, alignment: alignment)
+    }
+}
+
+extension DragGesture.Value {
+    var velocity: CGSize {
+        .init(width: predictedEndLocation.x - location.x, height: predictedEndLocation.y - location.y)
+    }
+}
+

--- a/PopupKit/Sources/PopupKit/Implementation/Common/HashableAction.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/HashableAction.swift
@@ -1,0 +1,24 @@
+//
+//  HashableAction.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import Foundation
+
+struct HashableAction {
+    let action: () -> Void
+}
+
+extension HashableAction: Equatable {
+    static func == (lhs: HashableAction, rhs: HashableAction) -> Bool {
+        true
+    }
+}
+
+extension HashableAction: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(String(describing: Self.self))
+    }
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Common/HashableAction.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/HashableAction.swift
@@ -8,17 +8,18 @@
 import Foundation
 
 struct HashableAction {
+    let id: Int
     let action: () -> Void
 }
 
 extension HashableAction: Equatable {
     static func == (lhs: HashableAction, rhs: HashableAction) -> Bool {
-        true
+        lhs.id == rhs.id
     }
 }
 
 extension HashableAction: Hashable {
     func hash(into hasher: inout Hasher) {
-        hasher.combine(String(describing: Self.self))
+        hasher.combine(id)
     }
 }

--- a/PopupKit/Sources/PopupKit/Implementation/Common/TransparentWindow.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/TransparentWindow.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Combine
 
 final class TransparentWindow: UIWindow {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {

--- a/PopupKit/Sources/PopupKit/Implementation/Common/TransparentWindow.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/TransparentWindow.swift
@@ -1,0 +1,16 @@
+//
+//  TransparentWindow.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import UIKit
+import Combine
+
+final class TransparentWindow: UIWindow {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let hitView = super.hitTest(point, with: event) else { return nil }
+        return rootViewController?.view == hitView ? nil : hitView
+    }
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Common/View+BackgroundInteraction.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Common/View+BackgroundInteraction.swift
@@ -1,0 +1,30 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import SwiftUI
+
+extension View {
+    func interactionWithBackground(enabled: Bool) -> some View {
+        enabled
+            ? self.asAnyView()
+            : background(BlockingView()).asAnyView()
+    }
+}
+
+private struct BlockingView: UIViewRepresentable {
+    func makeUIView(context _: Context) -> some UIView {
+        UIBlockingView()
+    }
+    
+    func updateUIView(_: UIViewType, context _: Context) {}
+}
+
+private final class UIBlockingView: UIView {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        super.hitTest(point, with: event) ?? UIView()
+    }
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Models/AlertModel.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Models/AlertModel.swift
@@ -1,0 +1,21 @@
+//
+//  AlertModel.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import UIKit
+
+struct AlertModel: Equatable, Hashable {
+    let icon: Icon
+    let message: String?
+    let userInteractionEnabled: Bool
+}
+
+extension AlertModel {
+    enum Icon: Equatable, Hashable {
+        case loading
+        case image(UIImage)
+    }
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Models/NotificationModel.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Models/NotificationModel.swift
@@ -1,0 +1,15 @@
+//
+//  NotificationModel.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import UIKit
+
+struct NotificationModel: Equatable, Hashable {
+    let icon: UIImage?
+    let title: String?
+    let description: String?
+    let tapHandler: HashableAction?
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Models/PopupCoordinatorModel.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Models/PopupCoordinatorModel.swift
@@ -1,0 +1,14 @@
+//
+//  PopupCoordinatorModel.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import UIKit
+
+final class PopupCoordinatorModel: ObservableObject {
+    @Published var notification: NotificationModel?
+    @Published var alert: AlertModel?
+    @Published var toastMessage: String?
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Services/AutoDismissManager.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Services/AutoDismissManager.swift
@@ -1,0 +1,66 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Golubenko on 07.12.2022.
+//
+
+import Combine
+import Foundation
+
+final class AutoDismissManager {
+    private let popupCoordinatorModel: PopupCoordinatorModel
+    private let calendar: Calendar
+    
+    private(set) var notificationDismissTask: Cancellable?
+    private(set) var alertDismissTask: Cancellable?
+    private(set) var toastDismissTask: Cancellable?
+    
+    init(popupCoordinatorModel: PopupCoordinatorModel, calendar: Calendar) {
+        self.popupCoordinatorModel = popupCoordinatorModel
+        self.calendar = calendar
+    }
+    
+    func dismissNotification() {
+        notificationDismissTask?.cancel()
+        notificationDismissTask = OperationQueue.main.schedule(
+            after: .init(makeDismissDate()),
+            interval: .zero
+        ) { [weak popupCoordinatorModel] in
+            popupCoordinatorModel?.notification = nil
+        }
+    }
+    
+    func dismissAlert() {
+        alertDismissTask?.cancel()
+        alertDismissTask = OperationQueue.main.schedule(
+            after: .init(makeDismissDate()),
+            interval: .zero
+        ) { [weak popupCoordinatorModel] in
+            popupCoordinatorModel?.alert = nil
+        }
+    }
+    
+    func dismissToast() {
+        toastDismissTask?.cancel()
+        toastDismissTask = OperationQueue.main.schedule(
+            after: .init(makeDismissDate()),
+            interval: .zero
+        ) { [weak popupCoordinatorModel] in
+            popupCoordinatorModel?.toastMessage = nil
+        }
+    }
+}
+
+private extension AutoDismissManager {
+    func makeDismissDate() -> Date {
+        guard let date = calendar.date(byAdding: .second, value: autoDismissTimeInterval, to: Date()) else {
+            assertionFailure("Date is nil")
+            return Date()
+        }
+        
+        return date
+    }
+}
+
+private let autoDismissTimeInterval: Int = 4

--- a/PopupKit/Sources/PopupKit/Implementation/Views/AlertView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/AlertView.swift
@@ -15,6 +15,7 @@ struct AlertView: View {
             iconView
             if let message = model.message {
                 Text(message)
+                    .multilineTextAlignment(.center)
                     .font(.system(size: 15))
             }
         }

--- a/PopupKit/Sources/PopupKit/Implementation/Views/AlertView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/AlertView.swift
@@ -1,0 +1,43 @@
+//
+//  AlertView.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import SwiftUI
+
+struct AlertView: View {
+    let model: AlertModel
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            iconView
+            if let message = model.message {
+                Text(message)
+                    .font(.system(size: 15))
+            }
+        }
+        .padding(.vertical, 20)
+        .padding(.horizontal, 16.5)
+        .background(Blur(style: Constants.blurStyle))
+        .cornerRadius(Constants.cornerRadius)
+        .padding(Constants.borderPadding)
+    }
+}
+
+private extension AlertView {
+    var iconView: some View {
+        Group {
+            switch model.icon {
+            case .loading:
+                ProgressView()
+                    .scaleEffect(1.5)
+            case let .image(image):
+                Image(uiImage: image)
+                    .renderingMode(.template)
+                    .foregroundColor(.primary)
+            }
+        }.frame(squareSize: 37)
+    }
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Views/NotificationView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/NotificationView.swift
@@ -1,0 +1,85 @@
+//
+//  NotificationView.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import SwiftUI
+
+struct NotificationView: View {
+    @State private var dragTranslation: CGFloat = .zero
+    @State private var minTranslationForDismiss: CGFloat = .infinity
+    
+    let model: NotificationModel
+    let safeAreaInsets: EdgeInsets
+    let dismissAction: () -> Void
+    
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 7) {
+            if let icon = model.icon {
+                makeIcon(image: icon)
+            }
+            textStack
+            Spacer(minLength: .zero)
+        }
+        .padding(10)
+        .background(GeometryReader(content: processGeometry))
+        .padding(.top, safeAreaInsets.top)
+        .expanded(.horizontal)
+        .background(Blur(style: Constants.blurStyle))
+        .offset(y: dragTranslation < .zero ? dragTranslation : .zero)
+        .gesture(dragGesture)
+        .onTapGesture(perform: onTap)
+    }
+}
+
+private extension NotificationView {
+    func makeIcon(image: UIImage) -> some View {
+        Image(uiImage: image)
+            .resizable()
+            .renderingMode(.template)
+            .foregroundColor(.primary)
+            .scaledToFit()
+            .frame(squareSize: 30)
+    }
+    
+    var textStack: some View {
+        VStack(alignment: .leading, spacing: .zero) {
+            if let title = model.title {
+                Text(title)
+                    .font(.system(size: 15, weight: .bold))
+            }
+            if let description = model.description {
+                Text(description)
+                    .font(.system(size: 13))
+            }
+        }
+    }
+    
+    var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { dragTranslation = $0.translation.height }
+            .onEnded {
+                print(-$0.translation.height, minTranslationForDismiss)
+                if $0.velocity.height < -100 || -$0.translation.height > minTranslationForDismiss {
+                    dismissAction()
+                } else {
+                    withAnimation { dragTranslation = .zero }
+                }
+            }
+    }
+    
+    func processGeometry(_ geometry: GeometryProxy) -> some View {
+        DispatchQueue.main.async {
+            minTranslationForDismiss = geometry.size.height / 2
+        }
+
+        return Color.clear
+    }
+    
+    func onTap() {
+        model.tapHandler?.action()
+        dismissAction()
+    }
+}

--- a/PopupKit/Sources/PopupKit/Implementation/Views/PopupCoordinatorView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/PopupCoordinatorView.swift
@@ -13,12 +13,15 @@ struct PopupCoordinatorView: View {
     var body: some View {
         GeometryReader { geomerty in
             ZStack {
+                if !(model.alert?.userInteractionEnabled ?? true) {
+                    BlockingView()
+                }
+                
                 makeNotificationView(geometry: geomerty)
                 makeAlertView()
                 makeToastView(geometry: geomerty)
             }
             .expanded()
-            .interactionWithBackground(enabled: model.alert?.userInteractionEnabled ?? true)
             .ignoresSafeArea()
         }
     }

--- a/PopupKit/Sources/PopupKit/Implementation/Views/PopupCoordinatorView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/PopupCoordinatorView.swift
@@ -17,9 +17,9 @@ struct PopupCoordinatorView: View {
                     BlockingView()
                 }
                 
-                makeNotificationView(geometry: geomerty)
+                makeNotificationView(safeAreaInsets: geomerty.safeAreaInsets)
                 makeAlertView()
-                makeToastView(geometry: geomerty)
+                makeToastView(safeAreaInsets: geomerty.safeAreaInsets)
             }
             .expanded()
             .ignoresSafeArea()
@@ -28,12 +28,12 @@ struct PopupCoordinatorView: View {
 }
 
 private extension PopupCoordinatorView {
-    func makeNotificationView(geometry: GeometryProxy) -> some View {
+    func makeNotificationView(safeAreaInsets: EdgeInsets) -> some View {
         VStack {
             if let notificationModel = model.notification {
                 NotificationView(
                     model: notificationModel,
-                    safeAreaInsets: geometry.safeAreaInsets,
+                    safeAreaInsets: safeAreaInsets,
                     dismissAction: { [weak model] in
                         model?.notification = nil
                     }
@@ -57,12 +57,12 @@ private extension PopupCoordinatorView {
         .animation(.easeInOut(duration: animationDuration), value: model.alert?.hashValue)
     }
     
-    func makeToastView(geometry: GeometryProxy) -> some View {
+    func makeToastView(safeAreaInsets: EdgeInsets) -> some View {
         VStack {
             Spacer()
             if let message = model.toastMessage {
                 ToastView(message: message)
-                    .padding(.bottom, geometry.safeAreaInsets.bottom)
+                    .padding(.bottom, safeAreaInsets.bottom)
                     .id(model.toastMessage?.hashValue)
                     .transition(.move(edge: .bottom))
             }

--- a/PopupKit/Sources/PopupKit/Implementation/Views/PopupCoordinatorView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/PopupCoordinatorView.swift
@@ -1,0 +1,71 @@
+//
+//  PopupCoordinatorView.swift
+//  
+//
+//  Created by Andrey Golubenko on 06.12.2022.
+//
+
+import SwiftUI
+
+struct PopupCoordinatorView: View {
+    @ObservedObject var model: PopupCoordinatorModel
+    
+    var body: some View {
+        GeometryReader { geomerty in
+            ZStack {
+                makeNotificationView(geometry: geomerty)
+                makeAlertView()
+                makeToastView(geometry: geomerty)
+            }
+            .expanded()
+            .interactionWithBackground(enabled: model.alert?.userInteractionEnabled ?? true)
+            .ignoresSafeArea()
+        }
+    }
+}
+
+private extension PopupCoordinatorView {
+    func makeNotificationView(geometry: GeometryProxy) -> some View {
+        VStack {
+            if let notificationModel = model.notification {
+                NotificationView(
+                    model: notificationModel,
+                    safeAreaInsets: geometry.safeAreaInsets,
+                    dismissAction: { [weak model] in
+                        model?.notification = nil
+                    }
+                )
+                .id(model.notification?.hashValue)
+                .transition(.move(edge: .top))
+            }
+            Spacer()
+        }
+        .animation(.easeInOut(duration: animationDuration), value: model.notification?.hashValue)
+    }
+    
+    func makeAlertView() -> some View {
+        VStack {
+            if let alertModel = model.alert {
+                AlertView(model: alertModel)
+                    .id(model.alert?.hashValue)
+                    .transition(.scale)
+            }
+        }
+        .animation(.easeInOut(duration: animationDuration), value: model.alert?.hashValue)
+    }
+    
+    func makeToastView(geometry: GeometryProxy) -> some View {
+        VStack {
+            Spacer()
+            if let message = model.toastMessage {
+                ToastView(message: message)
+                    .padding(.bottom, geometry.safeAreaInsets.bottom)
+                    .id(model.toastMessage?.hashValue)
+                    .transition(.move(edge: .bottom))
+            }
+        }
+        .animation(.easeInOut(duration: animationDuration), value: model.toastMessage?.hashValue)
+    }
+}
+
+private let animationDuration: TimeInterval = 0.2

--- a/PopupKit/Sources/PopupKit/Implementation/Views/ToastView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/ToastView.swift
@@ -12,6 +12,7 @@ struct ToastView: View {
     
     var body: some View {
         Text(message)
+            .multilineTextAlignment(.center)
             .padding(.horizontal, 20)
             .padding(.vertical, 10)
             .background(Blur(style: Constants.blurStyle))

--- a/PopupKit/Sources/PopupKit/Implementation/Views/ToastView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/ToastView.swift
@@ -1,0 +1,21 @@
+//
+//  ToastView.swift
+//  
+//
+//  Created by Andrey Golubenko on 07.12.2022.
+//
+
+import SwiftUI
+
+struct ToastView: View {
+    let message: String
+    
+    var body: some View {
+        Text(message)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+            .background(Blur(style: Constants.blurStyle))
+            .cornerRadius(Constants.cornerRadius)
+            .padding(Constants.borderPadding)
+    }
+}

--- a/PopupKit/Sources/PopupKit/PopupManager.swift
+++ b/PopupKit/Sources/PopupKit/PopupManager.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+public final class PopupManager {
+    private let window = TransparentWindow(frame: UIScreen.main.bounds)
+    private let coordinatorModel = PopupCoordinatorModel()
+    
+    private lazy var autoDismissManager = AutoDismissManager(
+        popupCoordinatorModel: coordinatorModel,
+        calendar: Calendar.current
+    )
+    
+    public func setup() {
+        let rootView = PopupCoordinatorView(model: coordinatorModel)
+        let rootVC = UIHostingController(rootView: rootView)
+        rootVC.view.backgroundColor = .clear
+        window.rootViewController = rootVC
+        window.makeKeyAndVisible()
+    }
+    
+    public init() {}
+}
+
+// MARK: - Toast
+
+public extension PopupManager {
+    func showToastMessage(_ message: String) {
+        coordinatorModel.toastMessage = message
+        autoDismissManager.dismissToast()
+    }
+    
+    func dismissToast() {
+        coordinatorModel.toastMessage = nil
+    }
+}
+
+// MARK: - Alert
+
+public extension PopupManager {
+    func dismissAlert() {
+        coordinatorModel.alert = nil
+    }
+    
+    func showProgressAlert(message: String?, userInteractionEnabled: Bool) {
+        autoDismissManager.alertDismissTask?.cancel()
+        coordinatorModel.alert = .init(
+            icon: .loading,
+            message: message,
+            userInteractionEnabled: userInteractionEnabled
+        )
+    }
+    
+    func showSuccessAlert(message: String?) {
+        coordinatorModel.alert = .init(
+            icon: .image(successImage),
+            message: message,
+            userInteractionEnabled: true
+        )
+        autoDismissManager.dismissAlert()
+    }
+    
+    func showWarningAlert(message: String?) {
+        coordinatorModel.alert = .init(
+            icon: .image(warningImage),
+            message: message,
+            userInteractionEnabled: true
+        )
+        autoDismissManager.dismissAlert()
+    }
+}
+
+// MARK: - Notification
+
+public extension PopupManager {
+    func showNotification(
+        icon: UIImage?,
+        title: String?,
+        description: String?,
+        autoDismiss: Bool,
+        tapHandler: (() -> Void)?
+    ) {
+        coordinatorModel.notification = .init(
+            icon: icon,
+            title: title,
+            description: description,
+            tapHandler: tapHandler.map { .init(action: $0) }
+        )
+        
+        if autoDismiss {
+            autoDismissManager.dismissNotification()
+        } else {
+            autoDismissManager.notificationDismissTask?.cancel()
+        }
+    }
+    
+    func dismissNotification() {
+        coordinatorModel.notification = nil
+    }
+}
+
+private let warningImage = UIImage(
+    systemName: "multiply.circle",
+    withConfiguration: UIImage.SymbolConfiguration(pointSize: 25, weight: .light)
+)!
+
+private let successImage = UIImage(
+    systemName: "checkmark.circle",
+    withConfiguration: UIImage.SymbolConfiguration(pointSize: 25, weight: .light)
+)!

--- a/PopupKit/Sources/PopupKit/PopupManager.swift
+++ b/PopupKit/Sources/PopupKit/PopupManager.swift
@@ -82,7 +82,7 @@ public extension PopupManager {
             icon: icon,
             title: title,
             description: description,
-            tapHandler: tapHandler.map { .init(action: $0) }
+            tapHandler: tapHandler.map { .init(id: .zero, action: $0) }
         )
         
         if autoDismiss {


### PR DESCRIPTION
Убрал библиотеку `FTIndicator`. Вместо нее написал наш вариант, который работает с macos. `FTIndicator` криво работала с macos, так как не было учтено возможности изменения размеров экрана.

В `PopupKit` сделал отдельный `UIWindow`, и в рамках него уже показываю попапы, чтобы не зависеть от переключающихся окошек в приложении. Написал библу на SwiftUI, поэтому поднял версию приложения до iOS 15 