### PR TITLE
Fixed background fetch crash

### DIFF
--- a/Adamant/AppDelegate.swift
+++ b/Adamant/AppDelegate.swift
@@ -359,7 +359,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 extension AppDelegate {
     func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         let container = Container()
-        container.registerAdamantBackgroundFetchServices()
+        container.registerAdamantServices()
         
         guard let notificationsService = container.resolve(NotificationsService.self) else {
                 UIApplication.shared.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalNever)

--- a/Adamant/ServiceProtocols/DataProviders/ChatsProvider.swift
+++ b/Adamant/ServiceProtocols/DataProviders/ChatsProvider.swift
@@ -175,7 +175,7 @@ protocol ChatsProvider: DataProvider {
     var isInitiallySynced: Bool { get }
     
     var chatPositon: [String: Double] { get set }
-    var blackList: [String] { get }
+    var blockList: [String] { get }
     
     var roomsMaxCount: Int? { get }
     var roomsLoadedCount: Int? { get }

--- a/Adamant/ServiceProtocols/DataProviders/TransfersProvider.swift
+++ b/Adamant/ServiceProtocols/DataProviders/TransfersProvider.swift
@@ -129,13 +129,13 @@ extension StoreKey {
 }
 
 protocol TransfersProvider: DataProvider {
+    // MARK: - Constants
+    static var transferFee: Decimal { get }
+    
     // MARK: - Properties
     var receivedLastHeight: Int64? { get }
     var readedLastHeight: Int64? { get }
     var isInitiallySynced: Bool { get }
-    
-    var transferFee: Decimal { get }
-    
     var hasTransactions: Bool { get }
     
     // MARK: Controller

--- a/Adamant/Services/AdamantAccountService.swift
+++ b/Adamant/Services/AdamantAccountService.swift
@@ -146,6 +146,8 @@ class AdamantAccountService: AccountService {
         NotificationCenter.default.addObserver(forName: .AdamantAccountService.forceUpdateBalance, object: nil, queue: OperationQueue.main) { [weak self] _ in
             self?.update()
         }
+        
+        setupSecuredStore()
     }
 }
 
@@ -216,7 +218,7 @@ extension AdamantAccountService {
         notificationsService?.setNotificationsMode(.disabled, completion: nil)
     }
     
-    func setupSecuredStore() {
+    private func setupSecuredStore() {
         securedStoreSemaphore.wait()
         defer { securedStoreSemaphore.signal() }
         
@@ -503,7 +505,7 @@ private enum Key: CaseIterable {
     case useBiometry
     case passphrase
     case showedV12
-    case blackListKey
+    case blockListKey
     case removedMessages
     
     var stringValue: String {
@@ -514,7 +516,7 @@ private enum Key: CaseIterable {
         case .useBiometry: return StoreKey.accountService.useBiometry
         case .passphrase: return StoreKey.accountService.passphrase
         case .showedV12: return StoreKey.accountService.showedV12
-        case .blackListKey: return StoreKey.accountService.blackList
+        case .blockListKey: return StoreKey.accountService.blockList
         case .removedMessages: return StoreKey.accountService.removedMessages
         }
     }

--- a/Adamant/Services/AdamantAddressBookService.swift
+++ b/Adamant/Services/AdamantAddressBookService.swift
@@ -15,10 +15,10 @@ class AdamantAddressBookService: AddressBookService {
     
     // MARK: - Dependencies
     
-    var apiService: ApiService!
-    var adamantCore: AdamantCore!
-    var accountService: AccountService!
-    var dialogService: DialogService!
+    private let apiService: ApiService
+    private let adamantCore: AdamantCore
+    private let accountService: AccountService
+    private let dialogService: DialogService
     
     // MARK: - Properties
     
@@ -36,7 +36,17 @@ class AdamantAddressBookService: AddressBookService {
     private var savingBookOnLogoutTaskId = UIBackgroundTaskIdentifier.invalid
     
     // MARK: - Lifecycle
-    init() {
+    init(
+        apiService: ApiService,
+        adamantCore: AdamantCore,
+        accountService: AccountService,
+        dialogService: DialogService
+    ) {
+        self.apiService = apiService
+        self.adamantCore = adamantCore
+        self.accountService = accountService
+        self.dialogService = dialogService
+        
         // Update on login
         NotificationCenter.default.addObserver(forName: Notification.Name.AdamantAccountService.userLoggedIn, object: nil, queue: nil) { [weak self] _ in
             self?.update(nil)

--- a/Adamant/Services/AdamantCurrencyInfoService.swift
+++ b/Adamant/Services/AdamantCurrencyInfoService.swift
@@ -49,7 +49,7 @@ class AdamantCurrencyInfoService: CurrencyInfoService {
     
     public var currentCurrency: Currency = Currency.default {
         didSet {
-            securedStore?.set(currentCurrency.rawValue, for: StoreKey.CoinInfo.selectedCurrency)
+            securedStore.set(currentCurrency.rawValue, for: StoreKey.CoinInfo.selectedCurrency)
             NotificationCenter.default.post(name: Notification.Name.AdamantCurrencyInfoService.currencyRatesUpdated, object: nil)
         }
     }
@@ -57,7 +57,9 @@ class AdamantCurrencyInfoService: CurrencyInfoService {
     private var observerActive: NSObjectProtocol?
     
     // MARK: - Dependencies
-    var accountService: AccountService! {
+    private let securedStore: SecuredStore
+    
+    weak var accountService: AccountService? {
         didSet {
             if let accountService = accountService {
                 rateCoins = accountService.wallets.map { s -> String in s.tokenSymbol }
@@ -67,23 +69,11 @@ class AdamantCurrencyInfoService: CurrencyInfoService {
         }
     }
     
-    var securedStore: SecuredStore? {
-        didSet {
-            if
-                let securedStore = securedStore,
-                let id: String = securedStore.get(StoreKey.CoinInfo.selectedCurrency),
-                let currency = Currency(rawValue: id)
-            {
-                currentCurrency = currency
-            } else {
-                currentCurrency = Currency.default
-            }
-        }
-    }
-    
     // MARK: - Init
-    init() {
+    init(securedStore: SecuredStore) {
+        self.securedStore = securedStore
         addObservers()
+        setupSecuredStore()
     }
     
     deinit {
@@ -186,6 +176,17 @@ class AdamantCurrencyInfoService: CurrencyInfoService {
             case .failure(let error):
                 completion(.failure(.networkError(error: error)))
             }
+        }
+    }
+    
+    private func setupSecuredStore() {
+        if
+            let id: String = securedStore.get(StoreKey.CoinInfo.selectedCurrency),
+            let currency = Currency(rawValue: id)
+        {
+            currentCurrency = currency
+        } else {
+            currentCurrency = Currency.default
         }
     }
 }

--- a/Adamant/Services/AdamantHealthCheckService.swift
+++ b/Adamant/Services/AdamantHealthCheckService.swift
@@ -12,7 +12,7 @@ import Alamofire
 final class AdamantHealthCheckService: HealthCheckService {
     // MARK: - Dependencies
     
-    var apiService: ApiService!
+    private let apiService: ApiService
     
     // MARK: - Properties
     
@@ -21,6 +21,10 @@ final class AdamantHealthCheckService: HealthCheckService {
     private let semaphore = DispatchSemaphore(value: 1)
     
     weak var delegate: HealthCheckDelegate?
+    
+    init(apiService: ApiService) {
+        self.apiService = apiService
+    }
     
     var nodes: [Node] {
         get {
@@ -65,7 +69,7 @@ final class AdamantHealthCheckService: HealthCheckService {
             } ?? .synchronizing
         }
         
-        DispatchQueue.global().async { [weak delegate] in
+        DispatchQueue.main.async { [weak delegate] in
             delegate?.healthCheckUpdate()
         }
     }

--- a/Adamant/Services/AdamantNodesSource.swift
+++ b/Adamant/Services/AdamantNodesSource.swift
@@ -11,21 +11,9 @@ import Foundation
 class AdamantNodesSource: NodesSource {
     // MARK: - Dependencies
     
-    var apiService: ApiService!
-    
-    var healthCheckService: HealthCheckService! {
-        didSet {
-            healthCheckService.delegate = self
-            healthCheckService.nodes = nodes
-            setHealthCheckTimer()
-        }
-    }
-    
-    var securedStore: SecuredStore! {
-        didSet {
-            loadNodes()
-        }
-    }
+    private let apiService: ApiService
+    private let healthCheckService: HealthCheckService
+    private let securedStore: SecuredStore
     
     // MARK: - Properties
     
@@ -50,7 +38,15 @@ class AdamantNodesSource: NodesSource {
     
     // MARK: - Ctor
     
-    init(defaultNodesGetter: @escaping () -> [Node]) {
+    init(
+        apiService: ApiService,
+        healthCheckService: HealthCheckService,
+        securedStore: SecuredStore,
+        defaultNodesGetter: @escaping () -> [Node]
+    ) {
+        self.apiService = apiService
+        self.healthCheckService = healthCheckService
+        self.securedStore = securedStore
         self.defaultNodesGetter = defaultNodesGetter
         
         NotificationCenter.default.addObserver(
@@ -71,6 +67,10 @@ class AdamantNodesSource: NodesSource {
         }
         
         self.preferTheFastestNode = preferTheFastestNode
+        healthCheckService.delegate = self
+        healthCheckService.nodes = nodes
+        setHealthCheckTimer()
+        loadNodes()
     }
     
     deinit {

--- a/Adamant/Services/AdamantNotificationService.swift
+++ b/Adamant/Services/AdamantNotificationService.swift
@@ -26,7 +26,7 @@ extension NotificationsMode {
 
 class AdamantNotificationsService: NotificationsService {
     // MARK: Dependencies
-    var securedStore: SecuredStore!
+    private let securedStore: SecuredStore
     weak var accountService: AccountService?
     
     // MARK: Properties
@@ -39,7 +39,9 @@ class AdamantNotificationsService: NotificationsService {
     private var preservedBadgeNumber: Int?
     
     // MARK: Lifecycle
-    init() {
+    init(securedStore: SecuredStore) {
+        self.securedStore = securedStore
+        
         NotificationCenter.default.addObserver(forName: Notification.Name.AdamantAccountService.userLoggedIn, object: nil, queue: OperationQueue.main) { [weak self] _ in
             UNUserNotificationCenter.current().removeAllDeliveredNotifications()
             UIApplication.shared.applicationIconBadgeNumber = 0

--- a/Adamant/Services/ApiService/AdamantApiService.swift
+++ b/Adamant/Services/ApiService/AdamantApiService.swift
@@ -49,7 +49,7 @@ final class AdamantApiService: ApiService {
     
     // MARK: - Dependencies
     
-    var adamantCore: AdamantCore!
+    let adamantCore: AdamantCore
     
     weak var nodesSource: NodesSource? {
         didSet {
@@ -92,7 +92,9 @@ final class AdamantApiService: ApiService {
     
     // MARK: - Init
     
-    init() {
+    init(adamantCore: AdamantCore) {
+        self.adamantCore = adamantCore
+        
         NotificationCenter.default.addObserver(
             forName: Notification.Name.NodesSource.nodesUpdate,
             object: nil,

--- a/Adamant/Services/DataProviders/AdamantAccountsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantAccountsProvider.swift
@@ -38,15 +38,19 @@ class AdamantAccountsProvider: AccountsProvider {
     }
     
     // MARK: Dependencies
-    var stack: CoreDataStack!
-    var apiService: ApiService!
-    var addressBookService: AddressBookService!
+    private let stack: CoreDataStack
+    private let apiService: ApiService
+    private let addressBookService: AddressBookService
     
     // MARK: Properties
     private let knownContacts: [String:KnownContact]
     
     // MARK: Lifecycle
-    init() {
+    init(stack: CoreDataStack, apiService: ApiService, addressBookService: AddressBookService) {
+        self.stack = stack
+        self.apiService = apiService
+        self.addressBookService = addressBookService
+        
         let ico = KnownContact(contact: AdamantContacts.adamantIco)
         let bounty = KnownContact(contact: AdamantContacts.adamantBountyWallet)
         let welcome = KnownContact(contact: AdamantContacts.adamantWelcomeWallet)

--- a/Adamant/Services/DataProviders/AdamantChatTransactionService.swift
+++ b/Adamant/Services/DataProviders/AdamantChatTransactionService.swift
@@ -14,13 +14,24 @@ import MarkdownKit
 class AdamantChatTransactionService: ChatTransactionService {
     
     // MARK: Dependencies
-    var adamantCore: AdamantCore!
-    var richProviders: [String:RichMessageProviderWithStatusCheck]!
+    private let adamantCore: AdamantCore
+    private let richProviders: [String: RichMessageProviderWithStatusCheck]
     
     private let markdownParser = MarkdownParser(font: UIFont.systemFont(ofSize: UIFont.systemFontSize))
     private var transactionInProgress: [UInt64] = []
     private var onTransactionSaved: (() -> Void)?
     private let processSemaphore = DispatchSemaphore(value: 1)
+    
+    init(adamantCore: AdamantCore, accountService: AccountService) {
+        self.adamantCore = adamantCore
+        
+        var richProviders = [String: RichMessageProviderWithStatusCheck]()
+        for case let provider as RichMessageProviderWithStatusCheck in accountService.wallets {
+            richProviders[provider.dynamicRichMessageType] = provider
+        }
+        self.richProviders = richProviders
+    }
+    
     /// Search transaction in local storage
     ///
     /// - Parameter id: Transacton ID

--- a/Adamant/Services/DataProviders/AdamantChatsProvider+backgroundFetch.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider+backgroundFetch.swift
@@ -10,8 +10,7 @@ import Foundation
 
 extension AdamantChatsProvider: BackgroundFetchService {
     func fetchBackgroundData(notificationsService: NotificationsService, completion: @escaping (FetchResult) -> Void) {
-        guard let securedStore = self.securedStore,
-            let address: String = securedStore.get(StoreKey.chatProvider.address) else {
+        guard let address: String = securedStore.get(StoreKey.chatProvider.address) else {
             completion(.failed)
             return
         }
@@ -34,15 +33,15 @@ extension AdamantChatsProvider: BackgroundFetchService {
             }
         }
         
-        apiService.getMessageTransactions(address: address, height: lastHeight, offset: nil) { result in
+        apiService.getMessageTransactions(address: address, height: lastHeight, offset: nil) { [weak self] result in
             switch result {
             case .success(let transactions):
                 if transactions.count > 0 {
                     let total = transactions.count
-                    securedStore.set(String(total + notifiedCount), for: StoreKey.chatProvider.notifiedMessagesCount)
+                    self?.securedStore.set(String(total + notifiedCount), for: StoreKey.chatProvider.notifiedMessagesCount)
                     
                     if let newLastHeight = transactions.map({$0.height}).sorted().last {
-                        securedStore.set(String(newLastHeight), for: StoreKey.chatProvider.notifiedLastHeight)
+                        self?.securedStore.set(String(newLastHeight), for: StoreKey.chatProvider.notifiedLastHeight)
                     }
                     
                     notificationsService.showNotification(title: String.adamantLocalized.notifications.newMessageTitle, body: String.localizedStringWithFormat(String.adamantLocalized.notifications.newMessageBody, total + notifiedCount), type: .newMessages(count: total))

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -136,7 +136,7 @@ class AdamantChatsProvider: ChatsProvider {
             
             if state {
                 if let blackList = self?.blockList {
-                    self?.securedStore.set(blackList, for: StoreKey.accountService.blackList)
+                    self?.securedStore.set(blackList, for: StoreKey.accountService.blockList)
                 }
                 
                 if let removedMessages = self?.removedMessages {
@@ -210,7 +210,7 @@ class AdamantChatsProvider: ChatsProvider {
     }
     
     private func setupSecuredStore() {
-        blockList = securedStore.get(StoreKey.accountService.blackList) ?? []
+        blockList = securedStore.get(StoreKey.accountService.blockList) ?? []
         removedMessages = securedStore.get(StoreKey.accountService.removedMessages) ?? []
     }
 }
@@ -1458,7 +1458,7 @@ extension AdamantChatsProvider {
             self.blockList.append(address)
             
             if self.accountService.hasStayInAccount {
-                self.securedStore.set(blockList, for: StoreKey.accountService.blackList)
+                self.securedStore.set(blockList, for: StoreKey.accountService.blockList)
             }
         }
     }

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -12,21 +12,16 @@ import MarkdownKit
 
 class AdamantChatsProvider: ChatsProvider {
     // MARK: Dependencies
-    var accountService: AccountService!
-    var apiService: ApiService!
-    var socketService: SocketService!
-    var stack: CoreDataStack!
-    var adamantCore: AdamantCore!
-    var accountsProvider: AccountsProvider!
-    var transactionService: ChatTransactionService!
-    var securedStore: SecuredStore! {
-        didSet {
-            self.blackList = self.securedStore.get(StoreKey.accountService.blackList) ?? []
-            self.removedMessages = self.securedStore.get(StoreKey.accountService.removedMessages) ?? []
-        }
-    }
+    let accountService: AccountService
+    let apiService: ApiService
+    let socketService: SocketService
+    let stack: CoreDataStack
+    let adamantCore: AdamantCore
+    let accountsProvider: AccountsProvider
+    let transactionService: ChatTransactionService
+    let securedStore: SecuredStore
     
-    var richProviders: [String:RichMessageProviderWithStatusCheck]!
+    private let richProviders: [String: RichMessageProviderWithStatusCheck]
     
     // MARK: Properties
     private(set) var state: State = .empty
@@ -37,7 +32,7 @@ class AdamantChatsProvider: ChatsProvider {
     private var unconfirmedTransactionsBySignature: [String] = []
     
     public var chatPositon: [String : Double] = [:]
-    private(set) var blackList: [String] = []
+    private(set) var blockList: [String] = []
     private(set) var removedMessages: [String] = []
     
     public var isChatLoaded: [String : Bool] = [:]
@@ -68,7 +63,31 @@ class AdamantChatsProvider: ChatsProvider {
     private(set) var roomsLoadedCount: Int?
     
     // MARK: Lifecycle
-    init() {
+    init(
+        accountService: AccountService,
+        apiService: ApiService,
+        socketService: SocketService,
+        stack: CoreDataStack,
+        adamantCore: AdamantCore,
+        accountsProvider: AccountsProvider,
+        transactionService: ChatTransactionService,
+        securedStore: SecuredStore
+    ) {
+        self.accountService = accountService
+        self.apiService = apiService
+        self.socketService = socketService
+        self.stack = stack
+        self.adamantCore = adamantCore
+        self.accountsProvider = accountsProvider
+        self.transactionService = transactionService
+        self.securedStore = securedStore
+        
+        var richProviders = [String: RichMessageProviderWithStatusCheck]()
+        for case let provider as RichMessageProviderWithStatusCheck in accountService.wallets {
+            richProviders[provider.dynamicRichMessageType] = provider
+        }
+        self.richProviders = richProviders
+        
         NotificationCenter.default.addObserver(forName: Notification.Name.AdamantAccountService.userLoggedIn, object: nil, queue: nil) { [weak self] notification in
             guard let store = self?.securedStore else {
                 return
@@ -104,7 +123,7 @@ class AdamantChatsProvider: ChatsProvider {
             // BackgroundFetch
             self?.dropStateData()
             
-            self?.blackList = []
+            self?.blockList = []
             self?.removedMessages = []
             
             self?.disconnectFromSocket()
@@ -116,7 +135,7 @@ class AdamantChatsProvider: ChatsProvider {
             }
             
             if state {
-                if let blackList = self?.blackList {
+                if let blackList = self?.blockList {
                     self?.securedStore.set(blackList, for: StoreKey.accountService.blackList)
                 }
                 
@@ -188,6 +207,11 @@ class AdamantChatsProvider: ChatsProvider {
                 }
             }
         }
+    }
+    
+    private func setupSecuredStore() {
+        blockList = securedStore.get(StoreKey.accountService.blackList) ?? []
+        removedMessages = securedStore.get(StoreKey.accountService.removedMessages) ?? []
     }
 }
 
@@ -1290,7 +1314,7 @@ extension AdamantChatsProvider {
             }
             
             if let address = privateChatroom.partner?.address {
-                chatroom.isHidden = self.blackList.contains(address)
+                chatroom.isHidden = self.blockList.contains(address)
             }
         }
         
@@ -1303,7 +1327,7 @@ extension AdamantChatsProvider {
             let chatrooms = Dictionary(grouping: unreadTransactions, by: ({ (t: ChatTransaction) -> Chatroom in t.chatroom! }))
             for (chatroom, trs) in chatrooms {
                 if let address = chatroom.partner?.address {
-                    chatroom.isHidden = self.blackList.contains(address)
+                    chatroom.isHidden = self.blockList.contains(address)
                 }
                 chatroom.hasUnreadMessages = true
                 trs.forEach { $0.isUnread = true }
@@ -1430,11 +1454,11 @@ extension AdamantChatsProvider {
     }
     
     public func blockChat(with address: String) {
-        if !self.blackList.contains(address) {
-            self.blackList.append(address)
+        if !self.blockList.contains(address) {
+            self.blockList.append(address)
             
             if self.accountService.hasStayInAccount {
-                self.securedStore.set(blackList, for: StoreKey.accountService.blackList)
+                self.securedStore.set(blockList, for: StoreKey.accountService.blackList)
             }
         }
     }

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -88,6 +88,8 @@ class AdamantChatsProvider: ChatsProvider {
         }
         self.richProviders = richProviders
         
+        setupSecuredStore()
+        
         NotificationCenter.default.addObserver(forName: Notification.Name.AdamantAccountService.userLoggedIn, object: nil, queue: nil) { [weak self] notification in
             guard let store = self?.securedStore else {
                 return

--- a/Adamant/Services/DataProviders/AdamantTransfersProvider+backgroundFetch.swift
+++ b/Adamant/Services/DataProviders/AdamantTransfersProvider+backgroundFetch.swift
@@ -10,8 +10,7 @@ import Foundation
 
 extension AdamantTransfersProvider: BackgroundFetchService {
     func fetchBackgroundData(notificationsService: NotificationsService, completion: @escaping (FetchResult) -> Void) {
-        guard let securedStore = self.securedStore,
-            let address: String = securedStore.get(StoreKey.transfersProvider.address) else {
+        guard let address: String = securedStore.get(StoreKey.transfersProvider.address) else {
             completion(.failed)
             return
         }
@@ -34,17 +33,23 @@ extension AdamantTransfersProvider: BackgroundFetchService {
             }
         }
         
-        apiService.getTransactions(forAccount: address, type: .send, fromHeight: lastHeight, offset: 0, limit: 100) { result in
+        apiService.getTransactions(
+            forAccount: address,
+            type: .send,
+            fromHeight: lastHeight,
+            offset: 0,
+            limit: 100
+        ) { [weak self] result in
             switch result {
             case .success(let transactions):
                 let total = transactions.filter({$0.recipientId == address}).count
                 
                 if total > 0 {
-                    securedStore.set(String(total + notifiedCount), for: StoreKey.transfersProvider.notifiedTransfersCount)
+                    self?.securedStore.set(String(total + notifiedCount), for: StoreKey.transfersProvider.notifiedTransfersCount)
                     
                     if var newLastHeight = transactions.map({$0.height}).sorted().last {
                         newLastHeight += 1 // Server will return new transactions including this one
-                        securedStore.set(String(newLastHeight), for: StoreKey.transfersProvider.notifiedLastHeight)
+                        self?.securedStore.set(String(newLastHeight), for: StoreKey.transfersProvider.notifiedLastHeight)
                     }
                     
                     notificationsService.showNotification(title: String.adamantLocalized.notifications.newTransferTitle, body: String.localizedStringWithFormat(String.adamantLocalized.notifications.newTransferBody, total + notifiedCount), type: .newTransactions(count: total))

--- a/Adamant/Services/DataProviders/AdamantTransfersProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantTransfersProvider.swift
@@ -10,18 +10,18 @@ import Foundation
 import CoreData
 
 class AdamantTransfersProvider: TransfersProvider {
-    // MARK: Dependencies
-    var apiService: ApiService!
-    var stack: CoreDataStack!
-    var adamantCore: AdamantCore!
-    var accountService: AccountService!
-    var accountsProvider: AccountsProvider!
-    var securedStore: SecuredStore!
-    var transactionService: ChatTransactionService!
-    weak var chatsProvider: ChatsProvider?
+    // MARK: Constants
+    static let transferFee: Decimal = Decimal(sign: .plus, exponent: -1, significand: 5)
     
-    // MARK: Properties
-    let transferFee: Decimal = Decimal(sign: .plus, exponent: -1, significand: 5)
+    // MARK: Dependencies
+    let apiService: ApiService
+    private let stack: CoreDataStack
+    private let adamantCore: AdamantCore
+    private let accountService: AccountService
+    private let accountsProvider: AccountsProvider
+    let securedStore: SecuredStore
+    private let transactionService: ChatTransactionService
+    weak var chatsProvider: ChatsProvider?
     
     private(set) var state: State = .empty
     private(set) var isInitiallySynced: Bool = false
@@ -63,7 +63,23 @@ class AdamantTransfersProvider: TransfersProvider {
     }
     
     // MARK: Lifecycle
-    init() {
+    init(
+        apiService: ApiService,
+        stack: CoreDataStack,
+        adamantCore: AdamantCore,
+        accountService: AccountService,
+        accountsProvider: AccountsProvider,
+        securedStore: SecuredStore,
+        transactionService: ChatTransactionService
+    ) {
+        self.apiService = apiService
+        self.stack = stack
+        self.adamantCore = adamantCore
+        self.accountService = accountService
+        self.accountsProvider = accountsProvider
+        self.securedStore = securedStore
+        self.transactionService = transactionService
+        
         NotificationCenter.default.addObserver(forName: Notification.Name.AdamantAccountService.userLoggedIn, object: nil, queue: nil) { [weak self] notification in
             guard let store = self?.securedStore else {
                 return
@@ -329,7 +345,7 @@ extension AdamantTransfersProvider {
             return
         }
         
-        guard loggedAccount.balance > amount + transferFee else {
+        guard loggedAccount.balance > amount + Self.transferFee else {
             completion(.failure(.notEnoughMoney))
             return
         }
@@ -392,7 +408,7 @@ extension AdamantTransfersProvider {
         transaction.chatMessageId = UUID().uuidString
         transaction.statusEnum = MessageStatus.pending
         transaction.comment = comment
-        transaction.fee = transferFee as NSDecimalNumber
+        transaction.fee = Self.transferFee as NSDecimalNumber
         transaction.partner = partner
         
         chatroom.addToTransactions(transaction)
@@ -460,7 +476,7 @@ extension AdamantTransfersProvider {
             return
         }
         
-        guard loggedAccount.balance > amount + transferFee else {
+        guard loggedAccount.balance > amount + Self.transferFee else {
             completion(.failure(.notEnoughMoney))
             return
         }
@@ -544,7 +560,7 @@ extension AdamantTransfersProvider {
         transaction.type = Int16(TransactionType.send.rawValue)
         transaction.isOutgoing = true
         transaction.showsChatroom = false
-        transaction.fee = transferFee as NSDecimalNumber
+        transaction.fee = Self.transferFee as NSDecimalNumber
         
         transaction.transactionId = nil
         transaction.blockId = nil

--- a/Adamant/Services/SocketService/AdamantSocketService.swift
+++ b/Adamant/Services/SocketService/AdamantSocketService.swift
@@ -13,7 +13,7 @@ class AdamantSocketService: SocketService {
 
     // MARK: - Dependencies
     
-    weak var nodesSource: NodesSource! {
+    weak var nodesSource: NodesSource? {
         didSet {
             refreshNode()
         }
@@ -107,7 +107,7 @@ class AdamantSocketService: SocketService {
     }
     
     private func refreshNode() {
-        currentNode = nodesSource.getAllowedNodes(needWS: true).first
+        currentNode = nodesSource?.getAllowedNodes(needWS: true).first
     }
     
     private func handleTransaction(data: [Any]) {

--- a/Adamant/SwinjectDependencies.swift
+++ b/Adamant/SwinjectDependencies.swift
@@ -45,11 +45,9 @@ extension Container {
         
         // MARK: Notifications
         self.register(NotificationsService.self) { r in
-            let service = AdamantNotificationsService()
-            service.securedStore = r.resolve(SecuredStore.self)
-            return service
+            AdamantNotificationsService(securedStore: r.resolve(SecuredStore.self)!)
         }.initCompleted { (r, c) in    // Weak reference
-            let service = c as! AdamantNotificationsService
+            guard let service = c as? AdamantNotificationsService else { return }
             service.accountService = r.resolve(AccountService.self)
         }.inObjectScope(.container)
         
@@ -65,53 +63,48 @@ extension Container {
         
         // MARK: NodesSource
         self.register(NodesSource.self) { r in
-            let service = AdamantNodesSource(defaultNodesGetter: { AdamantResources.nodes })
-            service.apiService = r.resolve(ApiService.self)!
-            service.healthCheckService = r.resolve(HealthCheckService.self)!
-            service.securedStore = r.resolve(SecuredStore.self)
-            return service
+            AdamantNodesSource(
+                apiService: r.resolve(ApiService.self)!,
+                healthCheckService: r.resolve(HealthCheckService.self)!,
+                securedStore: r.resolve(SecuredStore.self)!,
+                defaultNodesGetter: { AdamantResources.nodes }
+            )
         }.inObjectScope(.container)
         
         // MARK: ApiService
         self.register(ApiService.self) { r in
-            let service = AdamantApiService()
-            service.adamantCore = r.resolve(AdamantCore.self)
-            return service
+            AdamantApiService(adamantCore: r.resolve(AdamantCore.self)!)
         }.initCompleted { (r, c) in    // Weak reference
-            let service = c as! AdamantApiService
+            guard let service = c as? AdamantApiService else { return }
             service.nodesSource = r.resolve(NodesSource.self)
         }.inObjectScope(.container)
         
         // MARK: HealthCheckService
         self.register(HealthCheckService.self) { r in
-            let service = AdamantHealthCheckService()
-            service.apiService = r.resolve(ApiService.self)!
-            return service
+            AdamantHealthCheckService(apiService: r.resolve(ApiService.self)!)
         }.inObjectScope(.container)
         
         // MARK: SocketService
         self.register(SocketService.self) { _ in
-            let service = AdamantSocketService()
-            return service
+            AdamantSocketService()
         }.initCompleted { (r, c) in    // Weak reference
-            let service = c as! AdamantSocketService
+            guard let service = c as? AdamantSocketService else { return }
             service.nodesSource = r.resolve(NodesSource.self)
         }.inObjectScope(.container)
         
         // MARK: AccountService
         self.register(AccountService.self) { r in
-            let service = AdamantAccountService()
-            service.apiService = r.resolve(ApiService.self)!
-            service.adamantCore = r.resolve(AdamantCore.self)!
-            service.securedStore = r.resolve(SecuredStore.self)!
-            service.dialogService = r.resolve(DialogService.self)!
-            service.currencyInfoService = r.resolve(CurrencyInfoService.self)!
-            
-            return service
+            AdamantAccountService(
+                apiService: r.resolve(ApiService.self)!,
+                adamantCore: r.resolve(AdamantCore.self)!,
+                dialogService: r.resolve(DialogService.self)!,
+                securedStore: r.resolve(SecuredStore.self)!
+            )
         }.inObjectScope(.container).initCompleted { (r, c) in
-            let service = c as! AdamantAccountService
+            guard let service = c as? AdamantAccountService else { return }
             service.notificationsService = r.resolve(NotificationsService.self)!
             service.pushNotificationsTokenService = r.resolve(PushNotificationsTokenService.self)!
+            service.currencyInfoService = r.resolve(CurrencyInfoService.self)!
             
             for case let wallet as SwinjectDependentService in service.wallets {
                 wallet.injectDependencies(from: self)
@@ -120,25 +113,22 @@ extension Container {
         
         // MARK: AddressBookServeice
         self.register(AddressBookService.self) { r in
-            let service = AdamantAddressBookService()
-            service.apiService = r.resolve(ApiService.self)!
-            service.adamantCore = r.resolve(AdamantCore.self)!
-            service.accountService = r.resolve(AccountService.self)!
-            service.dialogService = r.resolve(DialogService.self)!
-            return service
+            AdamantAddressBookService(
+                apiService: r.resolve(ApiService.self)!,
+                adamantCore: r.resolve(AdamantCore.self)!,
+                accountService: r.resolve(AccountService.self)!,
+                dialogService: r.resolve(DialogService.self)!
+            )
         }.inObjectScope(.container)
         
         // MARK: CurrencyInfoService
         self.register(CurrencyInfoService.self) { r in
-            let service = AdamantCurrencyInfoService()
-            service.securedStore = r.resolve(SecuredStore.self)
-            return service
+            AdamantCurrencyInfoService(securedStore: r.resolve(SecuredStore.self)!)
         }.inObjectScope(.container).initCompleted { (r, c) in
-            if let service = c as? AdamantCurrencyInfoService {
-                service.accountService = r.resolve(AccountService.self)
-            }
+            guard let service = c as? AdamantCurrencyInfoService else { return }
+            service.accountService = r.resolve(AccountService.self)
         }
-
+        
         // MARK: - Data Providers
         // MARK: CoreData Stack
         self.register(CoreDataStack.self) { _ in
@@ -147,113 +137,49 @@ extension Container {
         
         // MARK: Accounts
         self.register(AccountsProvider.self) { r in
-            let provider = AdamantAccountsProvider()
-            provider.stack = r.resolve(CoreDataStack.self)
-            provider.apiService = r.resolve(ApiService.self)
-            provider.addressBookService = r.resolve(AddressBookService.self)
-            return provider
+            AdamantAccountsProvider(
+                stack: r.resolve(CoreDataStack.self)!,
+                apiService: r.resolve(ApiService.self)!,
+                addressBookService: r.resolve(AddressBookService.self)!
+            )
         }.inObjectScope(.container)
         
         // MARK: Transfers
         self.register(TransfersProvider.self) { r in
-            let provider = AdamantTransfersProvider()
-            provider.apiService = r.resolve(ApiService.self)
-            provider.stack = r.resolve(CoreDataStack.self)
-            provider.accountService = r.resolve(AccountService.self)
-            provider.accountsProvider = r.resolve(AccountsProvider.self)
-            provider.securedStore = r.resolve(SecuredStore.self)
-            provider.adamantCore = r.resolve(AdamantCore.self)
-            provider.transactionService = r.resolve(ChatTransactionService.self)
-            return provider
+            AdamantTransfersProvider(
+                apiService: r.resolve(ApiService.self)!,
+                stack: r.resolve(CoreDataStack.self)!,
+                adamantCore: r.resolve(AdamantCore.self)!,
+                accountService: r.resolve(AccountService.self)!,
+                accountsProvider: r.resolve(AccountsProvider.self)!,
+                securedStore: r.resolve(SecuredStore.self)!,
+                transactionService: r.resolve(ChatTransactionService.self)!
+            )
         }.inObjectScope(.container).initCompleted { (r, c) in
-            let provider = c as! AdamantTransfersProvider
-            provider.chatsProvider = r.resolve(ChatsProvider.self)
+            guard let service = c as? AdamantTransfersProvider else { return }
+            service.chatsProvider = r.resolve(ChatsProvider.self)
         }
         
         // MARK: Chats
         self.register(ChatsProvider.self) { r in
-            let provider = AdamantChatsProvider()
-            provider.apiService = r.resolve(ApiService.self)
-            provider.socketService = r.resolve(SocketService.self)
-            provider.stack = r.resolve(CoreDataStack.self)
-            provider.adamantCore = r.resolve(AdamantCore.self)
-            provider.securedStore = r.resolve(SecuredStore.self)
-            provider.accountsProvider = r.resolve(AccountsProvider.self)
-            provider.transactionService = r.resolve(ChatTransactionService.self)
-            
-            let accountService = r.resolve(AccountService.self)!
-            provider.accountService = accountService
-            var richProviders = [String: RichMessageProviderWithStatusCheck]()
-            for case let provider as RichMessageProviderWithStatusCheck in accountService.wallets {
-                richProviders[provider.dynamicRichMessageType] = provider
-            }
-            provider.richProviders = richProviders
-            return provider
+            AdamantChatsProvider(
+                accountService: r.resolve(AccountService.self)!,
+                apiService: r.resolve(ApiService.self)!,
+                socketService: r.resolve(SocketService.self)!,
+                stack: r.resolve(CoreDataStack.self)!,
+                adamantCore: r.resolve(AdamantCore.self)!,
+                accountsProvider: r.resolve(AccountsProvider.self)!,
+                transactionService: r.resolve(ChatTransactionService.self)!,
+                securedStore: r.resolve(SecuredStore.self)!
+            )
         }.inObjectScope(.container)
         
         // MARK: Chat Transaction Service
         self.register(ChatTransactionService.self) { r in
-            let provider = AdamantChatTransactionService()
-            provider.adamantCore = r.resolve(AdamantCore.self)
-            
-            let accountService = r.resolve(AccountService.self)!
-            var richProviders = [String: RichMessageProviderWithStatusCheck]()
-            for case let provider as RichMessageProviderWithStatusCheck in accountService.wallets {
-                richProviders[provider.dynamicRichMessageType] = provider
-            }
-            provider.richProviders = richProviders
-            return provider
-        }.inObjectScope(.container)
-    }
-    
-    func registerAdamantBackgroundFetchServices() {
-        // MARK: Secured store
-        self.register(SecuredStore.self) { _ in KeychainStore() }.inObjectScope(.container)
-        
-        // MARK: NodesSource
-        self.register(NodesSource.self) { r in
-            let service = AdamantNodesSource(defaultNodesGetter: { AdamantResources.nodes })
-            service.securedStore = r.resolve(SecuredStore.self)
-            return service
-        }.inObjectScope(.container)
-        
-        // MARK: ApiService
-        // No need to init AdamantCore
-        self.register(ApiService.self) { r in
-            let service = AdamantApiService()
-            service.nodesSource = r.resolve(NodesSource.self)
-            return service
-        }.inObjectScope(.container)
-        
-        // MARK: SocketService
-        // No need to init AdamantCore
-        self.register(SocketService.self) { r in
-            let service = AdamantSocketService()
-            service.nodesSource = r.resolve(NodesSource.self)
-            return service
-        }.inObjectScope(.container)
-        
-        // MARK: Notifications
-        self.register(NotificationsService.self) { r in
-            let service = AdamantNotificationsService()
-            service.securedStore = r.resolve(SecuredStore.self)
-            return service
-        }.inObjectScope(.container)
-        
-        // MARK: Fetch Services
-        self.register(ChatsProvider.self) { r in
-            let provider = AdamantChatsProvider()
-            provider.apiService = r.resolve(ApiService.self)
-            provider.socketService = r.resolve(SocketService.self)
-            provider.securedStore = r.resolve(SecuredStore.self)
-            return provider
-        }.inObjectScope(.container)
-        
-        self.register(TransfersProvider.self) { r in
-            let provider = AdamantTransfersProvider()
-            provider.apiService = r.resolve(ApiService.self)
-            provider.securedStore = r.resolve(SecuredStore.self)
-            return provider
+            AdamantChatTransactionService(
+                adamantCore: r.resolve(AdamantCore.self)!,
+                accountService: r.resolve(AccountService.self)!
+            )
         }.inObjectScope(.container)
     }
 }

--- a/Adamant/Wallets/Adamant/AdmWalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/Adamant/AdmWalletService+RichMessageProvider.swift
@@ -30,7 +30,7 @@ extension AdmWalletService: RichMessageProvider {
         controller.transaction = transaction
         controller.comment = transaction.comment
         
-        if let address = accountService.account?.address {
+        if let address = accountService?.account?.address {
             if address == transaction.senderId {
                 controller.senderName = String.adamantLocalized.transactionDetails.yourAddress
             } else {

--- a/Adamant/Wallets/Adamant/AdmWalletService.swift
+++ b/Adamant/Wallets/Adamant/AdmWalletService.swift
@@ -42,7 +42,7 @@ class AdmWalletService: NSObject, WalletService {
     }
     
 	// MARK: - Dependencies
-	weak var accountService: AccountService!
+	weak var accountService: AccountService?
 	var apiService: ApiService!
 	var transfersProvider: TransfersProvider!
     var router: Router!

--- a/Adamant/Wallets/ERC20/ERC20WalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/ERC20/ERC20WalletService+RichMessageProvider.swift
@@ -35,7 +35,7 @@ extension ERC20WalletService: RichMessageProvider {
         let senderName: String?
         let recipientName: String?
         
-        if let address = accountService.account?.address {
+        if let address = accountService?.account?.address {
             if let senderId = transaction.senderId, senderId.caseInsensitiveCompare(address) == .orderedSame {
                 senderName = String.adamantLocalized.transactionDetails.yourAddress
             } else {

--- a/Adamant/Wallets/ERC20/ERC20WalletService.swift
+++ b/Adamant/Wallets/ERC20/ERC20WalletService.swift
@@ -55,7 +55,7 @@ class ERC20WalletService: WalletService {
     static let walletPassword = ""
     
     // MARK: - Dependencies
-    weak var accountService: AccountService!
+    weak var accountService: AccountService?
     var apiService: ApiService!
     var dialogService: DialogService!
     var router: Router!

--- a/Adamant/Wallets/Ethereum/EthWalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/Ethereum/EthWalletService+RichMessageProvider.swift
@@ -39,7 +39,7 @@ extension EthWalletService: RichMessageProvider {
         let senderName: String?
         let recipientName: String?
         
-        if let address = accountService.account?.address {
+        if let address = accountService?.account?.address {
             if let senderId = transaction.senderId, senderId.caseInsensitiveCompare(address) == .orderedSame {
                 senderName = String.adamantLocalized.transactionDetails.yourAddress
             } else {

--- a/Adamant/Wallets/Ethereum/EthWalletService.swift
+++ b/Adamant/Wallets/Ethereum/EthWalletService.swift
@@ -92,7 +92,7 @@ class EthWalletService: WalletService {
     static let walletPassword = ""
     
     // MARK: - Dependencies
-    weak var accountService: AccountService!
+    weak var accountService: AccountService?
     var apiService: ApiService!
     var dialogService: DialogService!
     var router: Router!
@@ -334,7 +334,7 @@ class EthWalletService: WalletService {
 // MARK: - WalletInitiatedWithPassphrase
 extension EthWalletService: InitiatedWithPassphraseService {
     func initWallet(withPassphrase passphrase: String, completion: @escaping (WalletServiceResult<WalletAccount>) -> Void) {
-        guard let adamant = accountService.account else {
+        guard let adamant = accountService?.account else {
             completion(.failure(error: .notLogged))
             return
         }
@@ -445,7 +445,7 @@ extension EthWalletService: InitiatedWithPassphraseService {
             case .notEnoughMoney:  // Possibly new account, we need to wait for dropship
                 // Register observer
                 let observer = NotificationCenter.default.addObserver(forName: NSNotification.Name.AdamantAccountService.accountDataUpdated, object: nil, queue: nil) { [weak self] _ in
-                    guard let balance = self?.accountService.account?.balance, balance > AdamantApiService.KvsFee else {
+                    guard let balance = self?.accountService?.account?.balance, balance > AdamantApiService.KvsFee else {
                         return
                     }
                     
@@ -515,7 +515,7 @@ extension EthWalletService {
     ///   - adamantAddress: Owner of Ethereum address
     ///   - completion: success
     private func save(ethAddress: String, completion: @escaping (WalletServiceSimpleResult) -> Void) {
-        guard let adamant = accountService.account, let keypair = accountService.keypair else {
+        guard let adamant = accountService?.account, let keypair = accountService?.keypair else {
             completion(.failure(error: .notLogged))
             return
         }

--- a/AdamantShared/Models/AccountServiceStoreKey.swift
+++ b/AdamantShared/Models/AccountServiceStoreKey.swift
@@ -15,7 +15,7 @@ extension StoreKey {
         static let passphrase = "accountService.passphrase"
         static let showedV12 = "accountService.showedV12"
         static let pushTokenHash = "accountService.deviceTokenHash"
-        static let blackList = "blackList"
+        static let blockList = "blackList"
         static let removedMessages = "removedMessages"
     }
 }

--- a/AdamantTests/AdamantHealthCheckServiceTests.swift
+++ b/AdamantTests/AdamantHealthCheckServiceTests.swift
@@ -14,8 +14,7 @@ class AdamantHealthCheckServiceTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        service = .init()
-        service.apiService = ApiServiceStub()
+        service = .init(apiService: ApiServiceStub())
     }
     
     override func tearDown() {

--- a/AdamantTests/FeeTests.swift
+++ b/AdamantTests/FeeTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class FeeTests: XCTestCase {
     func testTransferFee() {
         let estimatedFee = Decimal(0.5)
-        XCTAssertEqual(estimatedFee, AdamantTransfersProvider().transferFee)
+        XCTAssertEqual(estimatedFee, AdamantTransfersProvider.transferFee)
     }
     
     func testShortMessageFee() {

--- a/AdamantTests/Stubs/ApiServiceStub.swift
+++ b/AdamantTests/Stubs/ApiServiceStub.swift
@@ -43,7 +43,9 @@ final class ApiServiceStub: ApiService {
     
     func getMessageTransactions(address: String, height: Int64?, offset: Int?, completion: @escaping (ApiServiceResult<[Transaction]>) -> Void) {}
     
-    func sendMessage(senderId: String, recipientId: String, keypair: Keypair, message: String, type: ChatType, nonce: String, amount: Decimal?, completion: @escaping (ApiServiceResult<UInt64>) -> Void) {}
+    func sendMessage(senderId: String, recipientId: String, keypair: Keypair, message: String, type: ChatType, nonce: String, amount: Decimal?, completion: @escaping (ApiServiceResult<UInt64>) -> Void) -> UnregisteredTransaction? { nil }
+    
+    func sendTransaction(path: String, transaction: UnregisteredTransaction, completion: @escaping (ApiServiceResult<TransactionIdResponse>) -> Void) {}
     
     func getDelegates(limit: Int, completion: @escaping (ApiServiceResult<[Delegate]>) -> Void) {}
     

--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -97,7 +97,7 @@ class NotificationService: UNNotificationServiceExtension {
             partnerPublicKey = transaction.senderPublicKey
         }
         
-        let contactsBlockList: [String] = securedStore.get(StoreKey.accountService.blackList) ?? []
+        let contactsBlockList: [String] = securedStore.get(StoreKey.accountService.blockList) ?? []
         guard !contactsBlockList.contains(partnerAddress) else { return }
         
         // MARK: 4. Address book


### PR DESCRIPTION
Пофиксил креш при background fetch.

Проблема была в том, что в `AdamantNodesSource` не добавлялась нужная зависимость.

Чтобы исключить такие проблемы в будущем, сделал рефакторинг:
1. Убрал force unwrap зависимостей в сервисах из DI (везде пока решил не убирать, много переписывать нужно)
2. Убрал отдельную регистрацию сервисов для бэкграунда. Swinject устроен так, что сервисы создаются при первой попытке получить доступ к ним. Поэтому ничего лишнего создаваться в бэкграунде не будет.