### PR TITLE
Fixed pushes working without account

### DIFF
--- a/Adamant/Assets/l18n/de.lproj/Localizable.strings
+++ b/Adamant/Assets/l18n/de.lproj/Localizable.strings
@@ -685,6 +685,9 @@
 /* Notifications: User has disabled notifications. Head him into settings */
 "NotificationsService.NotificationsDisabled" = "Benachrichtigungen deaktiviert. Sie können Benachrichtigungen in den Einstellungen aktivieren";
 
+/* Notifications: Not stayed logged in */
+"NotificationsService.NotStayedLoggedIn" = "Can't turn on notifications without staying logged in";
+
 /* Pinpad: Ask user to create new pin */
 "Pinpad.EnterNewPin" = "Neue PIN eingeben";
 

--- a/Adamant/Assets/l18n/en.lproj/Localizable.strings
+++ b/Adamant/Assets/l18n/en.lproj/Localizable.strings
@@ -676,6 +676,9 @@
 /* Notifications: User has disabled notifications. Head him into settings */
 "NotificationsService.NotificationsDisabled" = "Notifications disabled. You can enable notifications in Settings";
 
+/* Notifications: Not stayed logged in */
+"NotificationsService.NotStayedLoggedIn" = "Can't turn on notifications without staying logged in";
+
 /* Pinpad: Ask user to create new pin */
 "Pinpad.EnterNewPin" = "Enter new PIN code";
 

--- a/Adamant/Assets/l18n/ru.lproj/Localizable.strings
+++ b/Adamant/Assets/l18n/ru.lproj/Localizable.strings
@@ -673,6 +673,9 @@
 /* Notifications: User has disabled notifications. Head him into settings */
 "NotificationsService.NotificationsDisabled" = "Уведомления отключены. Вы можете включить их в Настройках";
 
+/* Notifications: Not stayed logged in */
+"NotificationsService.NotStayedLoggedIn" = "Нельзя включить уведомления, не оставаясь в системе";
+
 /* Pinpad: Ask user to create new pin */
 "Pinpad.EnterNewPin" = "Введите новый PIN-код";
 

--- a/Adamant/ServiceProtocols/NotificationsService.swift
+++ b/Adamant/ServiceProtocols/NotificationsService.swift
@@ -10,6 +10,7 @@ import Foundation
 
 extension String.adamantLocalized.notifications {
     static let notificationsDisabled = NSLocalizedString("NotificationsService.NotificationsDisabled", comment: "Notifications: User has disabled notifications. Head him into settings")
+    static let notStayedLoggedIn = NSLocalizedString("NotificationsService.NotStayedLoggedIn", comment: "Notifications: Not stayed logged in")
     
     static let newMessageTitle = NSLocalizedString("NotificationsService.NewMessage.Title", comment: "Notifications: New message notification title")
     static let newMessageBody = NSLocalizedString("NotificationsService.NewMessage.BodyFormat", comment: "Notifications: new messages notification body. Using %d for amount")
@@ -159,6 +160,7 @@ enum NotificationsServiceResult {
 enum NotificationsServiceError: Error {
     case notEnoughMoney
     case denied(error: Error?)
+    case notStayedLoggedIn
 }
 
 extension NotificationsServiceError: RichError {
@@ -166,19 +168,20 @@ extension NotificationsServiceError: RichError {
         switch self {
         case .notEnoughMoney: return String.adamantLocalized.sharedErrors.notEnoughMoney
         case .denied: return String.adamantLocalized.notifications.notificationsDisabled
+        case .notStayedLoggedIn: return String.adamantLocalized.notifications.notStayedLoggedIn
         }
     }
     
     var internalError: Error? {
         switch self {
-        case .notEnoughMoney: return nil
+        case .notEnoughMoney, .notStayedLoggedIn: return nil
         case .denied(let error): return error
         }
     }
     
     var level: ErrorLevel {
         switch self {
-        case .notEnoughMoney: return .warning
+        case .notEnoughMoney, .notStayedLoggedIn: return .warning
         case .denied: return .error
         }
     }

--- a/Adamant/Services/AdamantNotificationService.swift
+++ b/Adamant/Services/AdamantNotificationService.swift
@@ -125,6 +125,11 @@ extension AdamantNotificationsService {
             fallthrough
             
         case .backgroundFetch:
+            guard accountService?.hasStayInAccount ?? false else {
+                completion?(.failure(error: .notStayedLoggedIn))
+                return
+            }
+            
             authorizeNotifications { [weak self] (success, error) in
                 guard success else {
                     completion?(.failure(error: .denied(error: error)))

--- a/Adamant/Services/AdamantPushNotificationsTokenService.swift
+++ b/Adamant/Services/AdamantPushNotificationsTokenService.swift
@@ -190,6 +190,9 @@ private extension AdamantPushNotificationsTokenService {
 
 private extension AdamantPushNotificationsTokenService {
     func setTokenToStorage(_ token: String?) {
+        securedStoreSemaphore.wait()
+        defer { securedStoreSemaphore.signal() }
+        
         if let token = token {
             securedStore.set(token, for: StoreKey.PushNotificationsTokenService.token)
         } else {

--- a/Adamant/Stories/Settings/NotificationsViewController.swift
+++ b/Adamant/Stories/Settings/NotificationsViewController.swift
@@ -254,7 +254,7 @@ class NotificationsViewController: FormViewController {
                     return
                 case .failure(let error):
                     switch error {
-                    case .notEnoughMoney:
+                    case .notEnoughMoney, .notStayedLoggedIn:
                         self?.dialogService.showRichError(error: error)
                     case .denied:
                         self?.presentNotificationsDeniedError()

--- a/Adamant/Stories/Settings/SecurityViewController+notifications.swift
+++ b/Adamant/Stories/Settings/SecurityViewController+notifications.swift
@@ -27,7 +27,7 @@ extension SecurityViewController {
                 }
                 
                 switch error {
-                case .notEnoughMoney:
+                case .notEnoughMoney, .notStayedLoggedIn:
                     self?.dialogService.showRichError(error: error)
                     
                 case .denied:


### PR DESCRIPTION
1. Пуши могли работать и без входа в аккаунт. Для этого на маке надо отключить сохранение акка, находясь на экране настройки уведомлений, а потом включить уведомления заново. Затем просто закрыть приложение. Пофиксил это.

2. Пофиксил сброс экранов на маке при выходе из акка.

3. Если зайти в приложение через пуш и попасть в чат, а затем выйти и зайти обратно в акк, при входе будет переброс в чат из пуша, по которому был запуск приложения. Исправил это.