### PR TITLE
Fixed sending btc transactions by pay-to-script-hash method

### DIFF
--- a/Adamant/Wallets/Bitcoin/BtcWalletService+Send.swift
+++ b/Adamant/Wallets/Bitcoin/BtcWalletService+Send.swift
@@ -139,7 +139,7 @@ extension BtcWalletService: WalletServiceTwoStepSend {
                         
                     let value = NSDecimalNumber(decimal: item.value).uint64Value
                     
-                    let lockScript = Script.buildPublicKeyHashOut(pubKeyHash: wallet.publicKey.toCashaddr().data)
+                    let lockScript = wallet.publicKey.toCashaddr().lockingScript
                     let txHash = Data(hex: item.txId).map { Data($0.reversed()) } ?? Data()
                     let txIndex = item.vout
                     

--- a/BitcoinKit/Sources/BitcoinKit/Core/Keys/Address.swift
+++ b/BitcoinKit/Sources/BitcoinKit/Core/Keys/Address.swift
@@ -252,3 +252,17 @@ extension Cashaddr: CustomStringConvertible {
         return cashaddr
     }
 }
+
+extension AddressProtocol {
+    public var lockingScript: Data {
+        switch type {
+        case .pubkeyHash:
+            return Script.buildPublicKeyHashOut(pubKeyHash: data)
+        case .scriptHash:
+            return Script.buildScriptHashOut(scriptHash: data)
+        default:
+            assertionFailure("Unknown type")
+            return .init()
+        }
+    }
+}

--- a/BitcoinKit/Sources/BitcoinKit/Messages/Transaction.swift
+++ b/BitcoinKit/Sources/BitcoinKit/Messages/Transaction.swift
@@ -145,11 +145,8 @@ public struct Transaction {
         let totalAmount: UInt64 = UInt64(utxos.reduce(0) { $0 + $1.output.value })
         let change: UInt64 = totalAmount - amount - fee
         
-        let toPubKeyHash: Data = toAddress.data
-        let changePubkeyHash: Data = changeAddress.data
-        
-        let lockingScriptTo = Script.buildPublicKeyHashOut(pubKeyHash: toPubKeyHash)
-        let lockingScriptChange = Script.buildPublicKeyHashOut(pubKeyHash: changePubkeyHash)
+        let lockingScriptTo = toAddress.lockingScript
+        let lockingScriptChange = changeAddress.lockingScript
         
         var outputs = [TransactionOutput]()
         outputs.append(TransactionOutput(value: amount, lockingScript: lockingScriptTo))

--- a/BitcoinKit/Sources/BitcoinKit/Scripts/Script.swift
+++ b/BitcoinKit/Sources/BitcoinKit/Scripts/Script.swift
@@ -468,6 +468,16 @@ extension Script {
         tmp += OpCode.OP_CHECKSIG
         return tmp
     }
+    
+    // Transaction to Bitcoin address (pay-to-script-hash)
+    public static func buildScriptHashOut(scriptHash: Data) -> Data {
+        var tmp = Data()
+        tmp += OpCode.OP_HASH160
+        tmp += UInt8(scriptHash.count)
+        tmp += scriptHash
+        tmp += OpCode.OP_EQUAL
+        return tmp
+    }
 
     public static func buildPublicKeyUnlockingScript(signature: Data, pubkey: PublicKey, hashType: SighashType) -> Data {
         var data: Data = Data([UInt8(signature.count + 1)]) + signature + UInt8(hashType)


### PR DESCRIPTION
Добавил возможность создания `pay-to-script-hash`. Раньше для всех типов адресов создавались `pay-to-pubkey-hash` транзакции.