### PR TITLE
[https://trello.com/c/7Yjrwi9r] Fixed chats collection layout

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		934B9BE5296C58210027A8D0 /* CollectionCellWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934B9BE4296C58210027A8D0 /* CollectionCellWrapper.swift */; };
 		934B9BE7296C620B0027A8D0 /* UILabel+adamant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934B9BE6296C620B0027A8D0 /* UILabel+adamant.swift */; };
 		934B9BE9296C680D0027A8D0 /* ChatTransactionCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934B9BE8296C680D0027A8D0 /* ChatTransactionCellSizeCalculator.swift */; };
+		9371130F2996EDA900F64CF9 /* ChatRefreshMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371130E2996EDA900F64CF9 /* ChatRefreshMock.swift */; };
 		9371E561295CD53100438F2C /* ChatLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371E560295CD53100438F2C /* ChatLocalization.swift */; };
 		9377FBDF296C2A2F00C9211B /* ChatTransactionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9377FBDE296C2A2F00C9211B /* ChatTransactionContentView.swift */; };
 		9377FBE2296C2ACA00C9211B /* ChatTransactionContentView+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9377FBE1296C2ACA00C9211B /* ChatTransactionContentView+Model.swift */; };
@@ -901,6 +902,7 @@
 		934B9BE4296C58210027A8D0 /* CollectionCellWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionCellWrapper.swift; sourceTree = "<group>"; };
 		934B9BE6296C620B0027A8D0 /* UILabel+adamant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+adamant.swift"; sourceTree = "<group>"; };
 		934B9BE8296C680D0027A8D0 /* ChatTransactionCellSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTransactionCellSizeCalculator.swift; sourceTree = "<group>"; };
+		9371130E2996EDA900F64CF9 /* ChatRefreshMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRefreshMock.swift; sourceTree = "<group>"; };
 		9371E560295CD53100438F2C /* ChatLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLocalization.swift; sourceTree = "<group>"; };
 		9377FBDE296C2A2F00C9211B /* ChatTransactionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTransactionContentView.swift; sourceTree = "<group>"; };
 		9377FBE1296C2ACA00C9211B /* ChatTransactionContentView+Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatTransactionContentView+Model.swift"; sourceTree = "<group>"; };
@@ -1539,6 +1541,7 @@
 				9377FBE0296C2AB700C9211B /* ChatTransaction */,
 				938F7D652955C966001915CA /* ChatInputBar.swift */,
 				93A91FD0297972B7001DB1F8 /* ChatScrollDownButton.swift */,
+				9371130E2996EDA900F64CF9 /* ChatRefreshMock.swift */,
 				93996A962968209C008D080B /* ChatMessagesCollection.swift */,
 				93B9DBD129803179004F8BFF /* MessageCollectionViewCell+Extension.swift */,
 			);
@@ -2985,6 +2988,7 @@
 				6449BA69235CA0930033B936 /* ERC20TransferViewController.swift in Sources */,
 				E9E7CD8B20026B0600DFC4DB /* AccountService.swift in Sources */,
 				640EFAA42558613A00E9724B /* EthProvider.swift in Sources */,
+				9371130F2996EDA900F64CF9 /* ChatRefreshMock.swift in Sources */,
 				41047B74294C61D10039E956 /* VisibleWalletsService.swift in Sources */,
 				553B1284281C6EE100FFF24C /* GCDUtilites.swift in Sources */,
 				648CE3AC229AD2190070A2CC /* DashTransferViewController.swift in Sources */,

--- a/Adamant/Stories/Chat/View/ChatViewController.swift
+++ b/Adamant/Stories/Chat/View/ChatViewController.swift
@@ -325,6 +325,7 @@ private extension ChatViewController {
     
     func makeChatMessagesCollectionView() -> ChatMessagesCollectionView {
         let collection = ChatMessagesCollectionView()
+        collection.refreshControl = ChatRefreshMock()
         collection.register(TransactionCell.self)
         collection.register(
             SpinnerCell.self,

--- a/Adamant/Stories/Chat/View/Subviews/ChatMessagesCollection.swift
+++ b/Adamant/Stories/Chat/View/Subviews/ChatMessagesCollection.swift
@@ -24,18 +24,6 @@ final class ChatMessagesCollectionView: MessagesCollectionView {
         safeAreaInsets + contentInset
     }
     
-    /// To avoid insets changing by MessageKit
-    override var contentInset: UIEdgeInsets {
-        get { super.contentInset }
-        set {}
-    }
-    
-    /// To avoid insets changing by MessageKit
-    override var verticalScrollIndicatorInsets: UIEdgeInsets {
-        get { super.verticalScrollIndicatorInsets }
-        set {}
-    }
-    
     override func layoutSubviews() {
         super.layoutSubviews()
         
@@ -61,10 +49,10 @@ final class ChatMessagesCollectionView: MessagesCollectionView {
     func setFullBottomInset(_ inset: CGFloat) {
         let inset = inset - safeAreaInsets.bottom
         let bottomOffset = self.bottomOffset
-        super.contentInset.bottom = inset
-        super.verticalScrollIndicatorInsets.bottom = inset
+        contentInset.bottom = inset
+        verticalScrollIndicatorInsets.bottom = inset
 
-        guard !isDragging || isDecelerating else { return }
+        guard !hasActiveScrollGestures else { return }
         setBottomOffset(bottomOffset, safely: false)
     }
     
@@ -87,6 +75,23 @@ private extension ChatMessagesCollectionView {
     
     var contentHeightWithBottomInsets: CGFloat {
         contentSize.height + fullInsets.bottom
+    }
+    
+    var scrollGestureRecognizers: [UIGestureRecognizer] {
+        [panGestureRecognizer, pinchGestureRecognizer].compactMap { $0 }
+    }
+    
+    var hasActiveScrollGestures: Bool {
+        scrollGestureRecognizers.contains {
+            switch $0.state {
+            case .began, .changed:
+                return true
+            case .ended, .cancelled, .possible, .failed:
+                return false
+            @unknown default:
+                return false
+            }
+        }
     }
     
     func applyNewModels(_ newModels: [ChatMessage]) {

--- a/Adamant/Stories/Chat/View/Subviews/ChatRefreshMock.swift
+++ b/Adamant/Stories/Chat/View/Subviews/ChatRefreshMock.swift
@@ -1,0 +1,28 @@
+//
+//  ChatRefreshMock.swift
+//  Adamant
+//
+//  Created by Andrey Golubenko on 11.02.2023.
+//  Copyright © 2023 Adamant. All rights reserved.
+//
+
+import UIKit
+
+final class ChatRefreshMock: UIRefreshControl {
+    override init() {
+        super.init()
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+}
+
+private extension ChatRefreshMock {
+    func configure() {
+        tintColor = .clear
+        addTarget(self, action: #selector(endRefreshing), for: .valueChanged)
+    }
+}


### PR DESCRIPTION
1. Если во время докрутки ленты после скролла начать скрывать клавиатуру, лента будет крутиться в 2 раза быстрее чем нужно. Пофиксил это.
2. Если начать скрывать клавиатуру при нахождении позиции скролла в самом верху, она отпружинит без анимации. Пофиксил это. Проблема была из-за MessageKit. Все работает нормально только при добавлении `UIRefreshControl`,  поэтому добавил мок для `UIRefreshControl` (`ChatRefreshMock`)