### PR TITLE
[trello.com/c/IsInyuZJ] Health chech lags fix

### DIFF
--- a/Adamant/Services/AdamantNodesSource.swift
+++ b/Adamant/Services/AdamantNodesSource.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class AdamantNodesSource: NodesSource {
+final class AdamantNodesSource: NodesSource {
     // MARK: - Dependencies
     
     private let apiService: ApiService
@@ -35,6 +35,7 @@ class AdamantNodesSource: NodesSource {
     
     private let defaultNodesGetter: () -> [Node]
     private var timer: Timer?
+    private var savedNodes: [Node] = []
     
     // MARK: - Ctor
     
@@ -116,10 +117,13 @@ class AdamantNodesSource: NodesSource {
     }
     
     private func saveNodes() {
+        guard nodes != savedNodes else { return }
         securedStore.set(nodes, for: StoreKey.NodesSource.nodes)
+        savedNodes = securedStore.get(StoreKey.NodesSource.nodes) ?? []
     }
     
     private func loadNodes() {
+        savedNodes = securedStore.get(StoreKey.NodesSource.nodes) ?? defaultNodesGetter()
         nodes = securedStore.get(StoreKey.NodesSource.nodes) ?? defaultNodesGetter()
     }
     

--- a/Adamant/Services/ApiService/AdamantApiService.swift
+++ b/Adamant/Services/ApiService/AdamantApiService.swift
@@ -150,6 +150,8 @@ final class AdamantApiService: ApiService {
             return
         }
         
+        var needNodesUpdate = false
+        
         sendSafeRequest(
             nodes: currentNodes,
             path: path,
@@ -157,11 +159,15 @@ final class AdamantApiService: ApiService {
             method: method,
             body: body,
             waitsForConnectivity: waitsForConnectivity,
-            onFailure: { [weak self] node in
+            onFailure: { node in
                 node.connectionStatus = .offline
-                self?.nodesSource?.nodesUpdate()
+                needNodesUpdate = true
             },
-            completion: completion
+            completion: { [weak self] in
+                completion($0)
+                guard needNodesUpdate else { return }
+                self?.nodesSource?.nodesUpdate()
+            }
         )
         
         updateCurrentNodes()

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -419,7 +419,7 @@ extension AdamantChatsProvider {
         )
         
         isChatLoaded[addressRecipient] = true
-        chatMaxMessages[addressRecipient] = chatroom?.count ?? 0
+        chatMaxMessages[addressRecipient] = chatroom?.count
         
         let loadedCount = chatLoadedMessages[addressRecipient] ?? 0
         chatLoadedMessages[addressRecipient] = loadedCount + (chatroom?.messages?.count ?? 0)
@@ -461,7 +461,12 @@ extension AdamantChatsProvider {
             }
             
             await Task.sleep(interval: requestRepeatDelay)
-            return try await apiGetChatrooms(address: address, offset: offset)
+            
+            return try await apiGetChatMessages(
+                address: address,
+                addressRecipient: addressRecipient,
+                offset: offset
+            )
         }
     }
     

--- a/AdamantShared/Models/Node.swift
+++ b/AdamantShared/Models/Node.swift
@@ -21,7 +21,7 @@ enum URLScheme: String, Codable {
     }
 }
 
-class Node: Equatable, Codable {
+final class Node: Equatable, Codable {
     struct Status: Equatable, Codable {
         let ping: TimeInterval
         let wsEnabled: Bool


### PR DESCRIPTION
Проблема была в слишком частом шифровании нод для сохранения в хранилище.

Решил так:
1. При неудачном запросе делаю `health check` не при каждом неудачном запросе на ноду, а только в конце.
2. Сделал проверку перед сохранением нод в хранилище.

Также исправил отправку повторного запроса на получение сообщений.