### PR TITLE
[trello.com/c/wEE12i1g] txFetch fix

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		9371E561295CD53100438F2C /* ChatLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371E560295CD53100438F2C /* ChatLocalization.swift */; };
 		9377FBDF296C2A2F00C9211B /* ChatTransactionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9377FBDE296C2A2F00C9211B /* ChatTransactionContentView.swift */; };
 		9377FBE2296C2ACA00C9211B /* ChatTransactionContentView+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9377FBE1296C2ACA00C9211B /* ChatTransactionContentView+Model.swift */; };
+		9382F61329DEC0A3005E6216 /* ChatModelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9382F61229DEC0A3005E6216 /* ChatModelView.swift */; };
 		938F7D582955C1DA001915CA /* MessageKit in Frameworks */ = {isa = PBXBuildFile; productRef = 938F7D572955C1DA001915CA /* MessageKit */; };
 		938F7D5B2955C8DA001915CA /* ChatDisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938F7D5A2955C8DA001915CA /* ChatDisplayManager.swift */; };
 		938F7D5D2955C8F9001915CA /* ChatLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938F7D5C2955C8F9001915CA /* ChatLayoutManager.swift */; };
@@ -926,6 +927,7 @@
 		9371E560295CD53100438F2C /* ChatLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLocalization.swift; sourceTree = "<group>"; };
 		9377FBDE296C2A2F00C9211B /* ChatTransactionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTransactionContentView.swift; sourceTree = "<group>"; };
 		9377FBE1296C2ACA00C9211B /* ChatTransactionContentView+Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatTransactionContentView+Model.swift"; sourceTree = "<group>"; };
+		9382F61229DEC0A3005E6216 /* ChatModelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelView.swift; sourceTree = "<group>"; };
 		938F7D5A2955C8DA001915CA /* ChatDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDisplayManager.swift; sourceTree = "<group>"; };
 		938F7D5C2955C8F9001915CA /* ChatLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLayoutManager.swift; sourceTree = "<group>"; };
 		938F7D5E2955C90D001915CA /* ChatInputBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInputBarManager.swift; sourceTree = "<group>"; };
@@ -1586,6 +1588,7 @@
 				93A91FD0297972B7001DB1F8 /* ChatScrollDownButton.swift */,
 				9371130E2996EDA900F64CF9 /* ChatRefreshMock.swift */,
 				93996A962968209C008D080B /* ChatMessagesCollection.swift */,
+				9382F61229DEC0A3005E6216 /* ChatModelView.swift */,
 				93B9DBD129803179004F8BFF /* MessageCollectionViewCell+Extension.swift */,
 			);
 			path = Subviews;
@@ -3349,6 +3352,7 @@
 				E9AA8BF82129F13000F9249F /* ComplexTransferViewController.swift in Sources */,
 				640EFAA72558614300E9724B /* TransferBaseProvider.swift in Sources */,
 				E9A174B52057EDCE003667CD /* AdamantTransfersProvider+backgroundFetch.swift in Sources */,
+				9382F61329DEC0A3005E6216 /* ChatModelView.swift in Sources */,
 				E9147B5F20500E9300145913 /* MyLittlePinpad+adamant.swift in Sources */,
 				E9981896212095CA0018C84C /* EthWalletViewController.swift in Sources */,
 				648DD7A22237D9A000B811FD /* DogeTransaction.swift in Sources */,

--- a/Adamant/Models/TransactionStatus.swift
+++ b/Adamant/Models/TransactionStatus.swift
@@ -15,6 +15,7 @@ enum TransactionStatus: Int16 {
     case failed
     case registered
     case inconsistent
+    case noNetwork
     
     var localized: String {
         switch self {
@@ -28,6 +29,8 @@ enum TransactionStatus: Int16 {
             return NSLocalizedString("TransactionStatus.Failed", comment: "Transaction status: transaction failed")
         case .inconsistent:
             return NSLocalizedString("TransactionStatus.Inconsistent", comment: "Transaction status: transaction warning")
+        case .noNetwork:
+            return NSLocalizedString("Error.NoNetwork", comment: "Shared error: Network problems. In most cases - no connection")
         }
     }
 }

--- a/Adamant/Models/TransactionStatus.swift
+++ b/Adamant/Models/TransactionStatus.swift
@@ -16,6 +16,7 @@ enum TransactionStatus: Int16 {
     case registered
     case inconsistent
     case noNetwork
+    case noNetworkFinal
     
     var localized: String {
         switch self {
@@ -29,7 +30,7 @@ enum TransactionStatus: Int16 {
             return NSLocalizedString("TransactionStatus.Failed", comment: "Transaction status: transaction failed")
         case .inconsistent:
             return NSLocalizedString("TransactionStatus.Inconsistent", comment: "Transaction status: transaction warning")
-        case .noNetwork:
+        case .noNetwork, .noNetworkFinal:
             return NSLocalizedString("Error.NoNetwork", comment: "Shared error: Network problems. In most cases - no connection")
         }
     }

--- a/Adamant/ServiceProtocols/RichMessageProviderWithStatusCheck/RichMessageProviderWithStatusCheck+Extension.swift
+++ b/Adamant/ServiceProtocols/RichMessageProviderWithStatusCheck/RichMessageProviderWithStatusCheck+Extension.swift
@@ -9,7 +9,10 @@
 import Foundation
 
 extension RichMessageProviderWithStatusCheck {
-    func statusWithFilters(transaction: RichMessageTransaction) async -> TransactionStatus {
+    func statusWithFilters(
+        transaction: RichMessageTransaction,
+        oldPendingAttempts: Int
+    ) async -> TransactionStatus {
         let info = await statusInfoFor(transaction: transaction)
         
         switch info.status {
@@ -17,22 +20,23 @@ extension RichMessageProviderWithStatusCheck {
             return consistencyFilter(transaction: transaction, statusInfo: info)
                 ? info.status
                 : .inconsistent
-        case .notInitiated, .pending:
-            return timeFilter(transaction: transaction, statusInfo: info)
+        case .pending:
+            return pendingAttemptsCountFilter(oldPendingAttempts: oldPendingAttempts, status: info.status)
                 ? info.status
                 : .failed
-        case .failed, .inconsistent, .registered, .noNetwork:
+        case .noNetwork:
+            return pendingAttemptsCountFilter(oldPendingAttempts: oldPendingAttempts, status: info.status)
+                ? info.status
+                : .noNetworkFinal
+        case .failed, .inconsistent, .registered, .notInitiated, .noNetworkFinal:
             return info.status
         }
     }
 }
 
 private extension RichMessageProviderWithStatusCheck {
-    func timeFilter(transaction: RichMessageTransaction, statusInfo: TransactionStatusInfo) -> Bool {
-        guard let date = statusInfo.sentDate ?? transaction.sentDate else { return false }
-        
-        let timeAgo = -1 * date.timeIntervalSinceNow
-        return timeAgo <= consistencyMaxTime
+    func pendingAttemptsCountFilter(oldPendingAttempts: Int, status: TransactionStatus) -> Bool {
+        oldPendingAttempts < self.oldPendingAttempts
     }
     
     func consistencyFilter(transaction: RichMessageTransaction, statusInfo: TransactionStatusInfo) -> Bool {
@@ -41,9 +45,8 @@ private extension RichMessageProviderWithStatusCheck {
             let messageDate = transaction.sentDate
         else { return false }
         
-        let start = messageDate.addingTimeInterval(-60 * 5)
         let end = messageDate.addingTimeInterval(consistencyMaxTime)
-        let dateRange = start...end
+        let dateRange = messageDate...end
         
         return dateRange.contains(transactionDate)
     }

--- a/Adamant/ServiceProtocols/RichMessageProviderWithStatusCheck/RichMessageProviderWithStatusCheck+Extension.swift
+++ b/Adamant/ServiceProtocols/RichMessageProviderWithStatusCheck/RichMessageProviderWithStatusCheck+Extension.swift
@@ -21,7 +21,7 @@ extension RichMessageProviderWithStatusCheck {
             return timeFilter(transaction: transaction, statusInfo: info)
                 ? info.status
                 : .failed
-        case .failed, .inconsistent, .registered:
+        case .failed, .inconsistent, .registered, .noNetwork:
             return info.status
         }
     }

--- a/Adamant/Services/RichTransactionStatusService/AdamantRichTransactionStatusService.swift
+++ b/Adamant/Services/RichTransactionStatusService/AdamantRichTransactionStatusService.swift
@@ -16,6 +16,7 @@ actor AdamantRichTransactionStatusService: NSObject, RichTransactionStatusServic
     private lazy var controller = getRichTransactionsController()
     private var networkSubscription: AnyCancellable?
     private var subscriptions = [String: AnyCancellable]()
+    private var oldPendingAttempts = [String: ObservableValue<Int>]()
 
     init(
         coreDataStack: CoreDataStack,
@@ -29,11 +30,18 @@ actor AdamantRichTransactionStatusService: NSObject, RichTransactionStatusServic
 
     func forceUpdate(transaction: RichMessageTransaction) async {
         setStatus(for: transaction, status: .notInitiated)
-        guard let provider = getProvider(for: transaction) else { return }
+        
+        guard
+            let provider = getProvider(for: transaction),
+            let id = transaction.transactionId
+        else { return }
 
         await setStatus(
             for: transaction,
-            status: provider.statusWithFilters(transaction: transaction)
+            status: provider.statusWithFilters(
+                transaction: transaction,
+                oldPendingAttempts: oldPendingAttempts[id]?.wrappedValue ?? .zero
+            )
         )
     }
     
@@ -65,44 +73,55 @@ private extension AdamantRichTransactionStatusService {
             .removeDuplicates()
             .sink { connected in
                 guard connected else { return }
-                Task { [weak self] in await self?.reloadNoNetworkSubscriptions() }
+                Task { [weak self] in await self?.reloadNoNetworkTransactions() }
             }
     }
         
-    func reloadNoNetworkSubscriptions() {
-        controller.fetchedObjects?
-            .filter { $0.transactionStatus == .noNetwork || $0.transactionStatus == .notInitiated }
-            .forEach(add(transaction:))
+    func reloadNoNetworkTransactions() {
+        let transactions = controller.fetchedObjects?.filter {
+            switch $0.transactionStatus {
+            case .noNetwork, .noNetworkFinal, .notInitiated:
+                return true
+            case .failed, .pending, .registered, .success, .inconsistent, .none:
+                return false
+            }
+        }
+        
+        transactions?.compactMap { $0.transactionId }.forEach {
+            oldPendingAttempts[$0] = .init(wrappedValue: .zero)
+        }
+        
+        transactions?.forEach { transaction in
+            setStatus(for: transaction, status: .noNetwork)
+            add(transaction: transaction)
+        }
     }
     
     func add(transaction: RichMessageTransaction) {
         guard
-            let id = transaction.transactionId,
-            !subscriptions.keys.contains(id),
-            let provider = getProvider(for: transaction)
+            let provider = getProvider(for: transaction),
+            let id = transaction.transactionId
         else { return }
+        
+        let oldPendingAttempts = oldPendingAttempts[id] ?? .init(wrappedValue: .zero)
+        self.oldPendingAttempts[id] = oldPendingAttempts
 
         let publisher = RichTransactionStatusPublisher(
             provider: provider,
-            transaction: transaction
+            transaction: transaction,
+            oldPendingAttempts: oldPendingAttempts
         )
-
-        setupSubscription(publisher: publisher, transaction: transaction)
-    }
-
-    func remove(transaction: RichMessageTransaction) {
-        guard let id = transaction.transactionId else { return }
-        subscriptions[id] = nil
-    }
-
-    func setupSubscription(publisher: RichTransactionStatusPublisher, transaction: RichMessageTransaction) {
-        guard let id = transaction.transactionId else { return }
         
         subscriptions[id] = publisher.removeDuplicates().sink { status in
             Task { [weak self] in
                 await self?.setStatus(for: transaction, status: status)
             }
         }
+    }
+
+    func remove(transaction: RichMessageTransaction) {
+        guard let id = transaction.transactionId else { return }
+        subscriptions[id] = nil
     }
 
     func getProvider(for transaction: RichMessageTransaction) -> RichMessageProviderWithStatusCheck? {

--- a/Adamant/Services/RichTransactionStatusService/RichTransactionStatusPublisher.swift
+++ b/Adamant/Services/RichTransactionStatusService/RichTransactionStatusPublisher.swift
@@ -15,6 +15,7 @@ struct RichTransactionStatusPublisher: Publisher {
     
     let provider: RichMessageProviderWithStatusCheck
     let transaction: RichMessageTransaction
+    let oldPendingAttempts: ObservableValue<Int>
     
     func receive<S>(
         subscriber: S
@@ -22,6 +23,7 @@ struct RichTransactionStatusPublisher: Publisher {
         let subscription = RichTransactionStatusSubscription(
             provider: provider,
             transaction: transaction,
+            oldPendingAttempts: oldPendingAttempts,
             subscriber: subscriber
         )
         

--- a/Adamant/Services/RichTransactionStatusService/RichTransactionStatusSubscription.swift
+++ b/Adamant/Services/RichTransactionStatusService/RichTransactionStatusSubscription.swift
@@ -57,7 +57,7 @@ private extension RichTransactionStatusSubscription {
             return .final
         case .registered:
             return .registered
-        case .pending, .notInitiated:
+        case .pending, .notInitiated, .noNetwork:
             guard let sentDate = transaction.sentDate else { return .final }
             let sentInterval = Date.now.timeIntervalSince1970 - sentDate.timeIntervalSince1970
             

--- a/Adamant/Stories/Chat/View/ChatViewController.swift
+++ b/Adamant/Stories/Chat/View/ChatViewController.swift
@@ -296,7 +296,7 @@ private extension ChatViewController {
     
     func updateMessages() {
         defer { checkIsChatWasRead() }
-        chatMessagesCollectionView.reloadData(newModels: viewModel.messages)
+        chatMessagesCollectionView.reloadData(newIds: viewModel.messages.map { $0.id })
         scrollDownOnNewMessageIfNeeded(previousBottomMessageId: bottomMessageId)
         bottomMessageId = viewModel.messages.last?.messageId
         
@@ -460,7 +460,7 @@ private extension ChatViewController {
         switch transaction.transactionStatus {
         case .failed:
             viewModel.dialog.send(.alert(.adamantLocalized.sharedErrors.inconsistentTransaction))
-        case .notInitiated, .pending, .success, .none, .inconsistent, .registered, .noNetwork:
+        case .notInitiated, .pending, .success, .none, .inconsistent, .registered, .noNetwork, .noNetworkFinal:
             provider.richMessageTapped(for: transaction, in: self)
         }
     }

--- a/Adamant/Stories/Chat/View/ChatViewController.swift
+++ b/Adamant/Stories/Chat/View/ChatViewController.swift
@@ -460,7 +460,7 @@ private extension ChatViewController {
         switch transaction.transactionStatus {
         case .failed:
             viewModel.dialog.send(.alert(.adamantLocalized.sharedErrors.inconsistentTransaction))
-        case .notInitiated, .pending, .success, .none, .inconsistent, .registered:
+        case .notInitiated, .pending, .success, .none, .inconsistent, .registered, .noNetwork:
             provider.richMessageTapped(for: transaction, in: self)
         }
     }

--- a/Adamant/Stories/Chat/View/Managers/ChatDataSourceManager.swift
+++ b/Adamant/Stories/Chat/View/Managers/ChatDataSourceManager.swift
@@ -71,12 +71,15 @@ final class ChatDataSourceManager: MessagesDataSource {
             ChatViewController.TransactionCell.self,
             for: indexPath
         )
-    
-        if case let .transaction(model) = message.fullModel.content {
-            cell.wrappedView.actionHandler = { [weak self] in self?.handleAction($0) }
-            cell.wrappedView.model = model
+        
+        let publisher: any Observable<ChatTransactionContainerView.Model> = viewModel.$messages.compactMap {
+            let message = $0[safe: indexPath.section]
+            guard case let .transaction(model) = message?.fullModel.content else { return nil }
+            return model.value
         }
         
+        cell.wrappedView.actionHandler = { [weak self] in self?.handleAction($0) }
+        cell.wrappedView.setSubscription(publisher: publisher)
         return cell
     }
 }

--- a/Adamant/Stories/Chat/View/Subviews/ChatMessagesCollection.swift
+++ b/Adamant/Stories/Chat/View/Subviews/ChatMessagesCollection.swift
@@ -10,7 +10,7 @@ import MessageKit
 import UIKit
 
 final class ChatMessagesCollectionView: MessagesCollectionView {
-    private var currentModels = [ChatMessage]()
+    private var currentIds = [String]()
     
     var reportMessageAction: ((IndexPath) -> Void)?
     var removeMessageAction: ((IndexPath) -> Void)?
@@ -44,17 +44,17 @@ final class ChatMessagesCollectionView: MessagesCollectionView {
         }
     }
     
-    func reloadData(newModels: [ChatMessage]) {
-        guard newModels.last == currentModels.last || currentModels.isEmpty else {
-            return applyNewModels(newModels)
+    func reloadData(newIds: [String]) {
+        guard newIds.last == currentIds.last || currentIds.isEmpty else {
+            return applyNewIds(newIds)
         }
         
-        if Set(newModels.map { $0.id }) != Set(currentModels.map { $0.id }) {
+        if Set(newIds) != Set(currentIds) {
             stopDecelerating()
         }
         
         let bottomOffset = self.bottomOffset
-        applyNewModels(newModels)
+        applyNewIds(newIds)
         setBottomOffset(bottomOffset, safely: !isDragging && !isDecelerating)
     }
     
@@ -102,24 +102,10 @@ private extension ChatMessagesCollectionView {
         }
     }
     
-    func applyNewModels(_ newModels: [ChatMessage]) {
-        let fullUpdate = zip(newModels, currentModels).contains {
-            switch ($0.0.content, $0.1.content) {
-            case (.transaction, .transaction):
-                return false
-            default:
-                return $0.0 != $0.1
-            }
-        } || newModels.count != currentModels.count
-        
-        if fullUpdate {
-            reloadData()
-            layoutIfNeeded()
-        } else {
-            reloadTransactionCellsOnly(newModels)
-        }
-
-        currentModels = newModels
+    func applyNewIds(_ newIds: [String]) {
+        reloadData()
+        layoutIfNeeded()
+        currentIds = newIds
     }
     
     func stopDecelerating() {
@@ -139,16 +125,5 @@ private extension ChatMessagesCollectionView {
         }
         
         contentOffset.y = offset
-    }
-    
-    func reloadTransactionCellsOnly(_ newModels: [ChatMessage]) {
-        zip(visibleCells, indexPathsForVisibleItems).forEach { cell, indexPath in
-            guard
-                let cell = cell as? ChatViewController.TransactionCell,
-                case let .transaction(model) = newModels[indexPath.section].content
-            else { return }
-            
-            cell.wrappedView.model = model
-        }
     }
 }

--- a/Adamant/Stories/Chat/View/Subviews/ChatModelView.swift
+++ b/Adamant/Stories/Chat/View/Subviews/ChatModelView.swift
@@ -1,0 +1,36 @@
+//
+//  ChatModelView.swift
+//  Adamant
+//
+//  Created by Andrey Golubenko on 06.04.2023.
+//  Copyright © 2023 Adamant. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+protocol ChatReusableViewModelProtocol: Equatable {
+    static var `default`: Self { get }
+}
+
+protocol ChatModelView: UIView, ReusableView {
+    associatedtype Model: ChatReusableViewModelProtocol
+    
+    var model: Model { get set }
+    var actionHandler: (ChatAction) -> Void { get set }
+    var subscription: AnyCancellable? { get set }
+}
+
+extension ChatModelView {
+    func setSubscription<P: Observable<Model>>(publisher: P) {
+        subscription = publisher
+            .removeDuplicates()
+            .sink { [weak self] in self?.model = $0 }
+    }
+    
+    func prepareForReuse() {
+        model = .default
+        actionHandler = { _ in }
+        subscription = nil
+    }
+}

--- a/Adamant/Stories/Chat/View/Subviews/ChatTransaction/ChatTransactionCellSizeCalculator.swift
+++ b/Adamant/Stories/Chat/View/Subviews/ChatTransaction/ChatTransactionCellSizeCalculator.swift
@@ -34,7 +34,7 @@ final class ChatTransactionCellSizeCalculator: CellSizeCalculator {
         
         return .init(
             width: messagesFlowLayout.itemWidth,
-            height: model.height(for: messagesFlowLayout.itemWidth)
+            height: model.value.height(for: messagesFlowLayout.itemWidth)
         )
     }
 }

--- a/Adamant/Stories/Chat/View/Subviews/ChatTransaction/Container/ChatTransactionContainerView+Model.swift
+++ b/Adamant/Stories/Chat/View/Subviews/ChatTransaction/Container/ChatTransactionContainerView+Model.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 extension ChatTransactionContainerView {
-    struct Model: Equatable {
+    struct Model: ChatReusableViewModelProtocol {
         let id: String
         let isFromCurrentSender: Bool
         let content: ChatTransactionContentView.Model
-        var status: TransactionStatus
+        let status: TransactionStatus
         
         static let `default` = Self(
             id: "",

--- a/Adamant/Stories/Chat/View/Subviews/ChatTransaction/Container/ChatTransactionContainerView.swift
+++ b/Adamant/Stories/Chat/View/Subviews/ChatTransaction/Container/ChatTransactionContainerView.swift
@@ -10,12 +10,11 @@ import UIKit
 import SnapKit
 import Combine
 
-final class ChatTransactionContainerView: UIView {
+final class ChatTransactionContainerView: UIView, ChatModelView {
+    var subscription: AnyCancellable?
+    
     var model: Model = .default {
-        didSet {
-            guard model != oldValue else { return }
-            update()
-        }
+        didSet { update() }
     }
     
     var actionHandler: (ChatAction) -> Void = { _ in } {
@@ -23,7 +22,6 @@ final class ChatTransactionContainerView: UIView {
     }
     
     private let contentView = ChatTransactionContentView()
-    private var statusSubscription: AnyCancellable?
     
     private lazy var statusButton: UIButton = {
         let button = UIButton()
@@ -110,7 +108,7 @@ private extension TransactionStatus {
     var image: UIImage {
         switch self {
         case .notInitiated: return #imageLiteral(resourceName: "status_updating")
-        case .pending, .registered, .noNetwork: return #imageLiteral(resourceName: "status_pending")
+        case .pending, .registered, .noNetwork, .noNetworkFinal: return #imageLiteral(resourceName: "status_pending")
         case .success: return #imageLiteral(resourceName: "status_success")
         case .failed: return #imageLiteral(resourceName: "status_failed")
         case .inconsistent: return #imageLiteral(resourceName: "status_warning")
@@ -120,7 +118,7 @@ private extension TransactionStatus {
     var imageTintColor: UIColor {
         switch self {
         case .notInitiated: return .adamant.secondary
-        case .pending, .registered, .noNetwork: return .adamant.primary
+        case .pending, .registered, .noNetwork, .noNetworkFinal: return .adamant.primary
         case .success: return .adamant.active
         case .failed, .inconsistent: return .adamant.alert
         }

--- a/Adamant/Stories/Chat/View/Subviews/ChatTransaction/Container/ChatTransactionContainerView.swift
+++ b/Adamant/Stories/Chat/View/Subviews/ChatTransaction/Container/ChatTransactionContainerView.swift
@@ -110,7 +110,7 @@ private extension TransactionStatus {
     var image: UIImage {
         switch self {
         case .notInitiated: return #imageLiteral(resourceName: "status_updating")
-        case .pending, .registered: return #imageLiteral(resourceName: "status_pending")
+        case .pending, .registered, .noNetwork: return #imageLiteral(resourceName: "status_pending")
         case .success: return #imageLiteral(resourceName: "status_success")
         case .failed: return #imageLiteral(resourceName: "status_failed")
         case .inconsistent: return #imageLiteral(resourceName: "status_warning")
@@ -120,7 +120,7 @@ private extension TransactionStatus {
     var imageTintColor: UIColor {
         switch self {
         case .notInitiated: return .adamant.secondary
-        case .pending, .registered: return .adamant.primary
+        case .pending, .registered, .noNetwork: return .adamant.primary
         case .success: return .adamant.active
         case .failed, .inconsistent: return .adamant.alert
         }

--- a/Adamant/Stories/Chat/ViewModel/ChatMessageFactory.swift
+++ b/Adamant/Stories/Chat/ViewModel/ChatMessageFactory.swift
@@ -124,7 +124,7 @@ private extension ChatMessageFactory {
         guard let transfer = transaction.transfer else { return .default }
         let id = transaction.chatMessageId ?? ""
         
-        return .transaction(.init(
+        return .transaction(.init(value: .init(
             id: id,
             isFromCurrentSender: isFromCurrentSender,
             content: .init(
@@ -140,7 +140,7 @@ private extension ChatMessageFactory {
                 backgroundColor: backgroundColor
             ),
             status: transaction.transactionStatus ?? .notInitiated
-        ))
+        )))
     }
     
     func makeContent(
@@ -150,7 +150,7 @@ private extension ChatMessageFactory {
     ) -> ChatMessage.Content {
         let id = transaction.chatMessageId ?? ""
         
-        return .transaction(.init(
+        return .transaction(.init(value: .init(
             id: id,
             isFromCurrentSender: isFromCurrentSender,
             content: .init(
@@ -168,7 +168,7 @@ private extension ChatMessageFactory {
                 backgroundColor: backgroundColor
             ),
             status: transaction.statusEnum.toTransactionStatus()
-        ))
+        )))
     }
     
     func makeBottomString(

--- a/Adamant/Stories/Chat/ViewModel/Models/ChatMessage.swift
+++ b/Adamant/Stories/Chat/ViewModel/Models/ChatMessage.swift
@@ -34,6 +34,12 @@ struct ChatMessage: Identifiable, Equatable {
 }
 
 extension ChatMessage {
+    struct EqualWrapper<Value>: Equatable {
+        let value: Value
+        
+        static func == (lhs: Self, rhs: Self) -> Bool { true }
+    }
+    
     enum Status: Equatable {
         case delivered(blockchain: Bool)
         case pending
@@ -42,7 +48,7 @@ extension ChatMessage {
     
     enum Content: Equatable {
         case message(ComparableAttributedString)
-        case transaction(ChatTransactionContainerView.Model)
+        case transaction(EqualWrapper<ChatTransactionContainerView.Model>)
         
         static let `default` = Self.message(.init(string: .init()))
     }

--- a/Adamant/Wallets/Bitcoin/BtcWalletService+RichMessageProviderWithStatusCheck.swift
+++ b/Adamant/Wallets/Bitcoin/BtcWalletService+RichMessageProviderWithStatusCheck.swift
@@ -22,7 +22,12 @@ extension BtcWalletService: RichMessageProviderWithStatusCheck {
                 status: getStatus(transaction: transaction, btcTransaction: btcTransaction)
             )
         } catch {
-            return .init(sentDate: nil, status: .pending)
+            switch error {
+            case ApiServiceError.networkError(_):
+                return .init(sentDate: nil, status: .noNetwork)
+            default:
+                return .init(sentDate: nil, status: .pending)
+            }
         }
     }
 }

--- a/Adamant/Wallets/Dash/DashWalletService+RichMessageProviderWithStatusCheck.swift
+++ b/Adamant/Wallets/Dash/DashWalletService+RichMessageProviderWithStatusCheck.swift
@@ -14,8 +14,17 @@ extension DashWalletService: RichMessageProviderWithStatusCheck {
             return .init(sentDate: nil, status: .inconsistent)
         }
         
-        guard let dashTransaction = try? await getTransaction(by: hash) else {
-            return .init(sentDate: nil, status: .pending)
+        let dashTransaction: BTCRawTransaction
+        
+        do {
+            dashTransaction = try await getTransaction(by: hash)
+        } catch {
+            switch error {
+            case ApiServiceError.networkError(_):
+                return .init(sentDate: nil, status: .noNetwork)
+            default:
+                return .init(sentDate: nil, status: .pending)
+            }
         }
         
         return .init(

--- a/Adamant/Wallets/Doge/DogeWalletService+RichMessageProviderWithStatusCheck.swift
+++ b/Adamant/Wallets/Doge/DogeWalletService+RichMessageProviderWithStatusCheck.swift
@@ -14,8 +14,17 @@ extension DogeWalletService: RichMessageProviderWithStatusCheck {
             return .init(sentDate: nil, status: .inconsistent)
         }
         
-        guard let dogeTransaction = try? await getTransaction(by: hash) else {
-            return .init(sentDate: nil, status: .pending)
+        let dogeTransaction: BTCRawTransaction
+        
+        do {
+            dogeTransaction = try await getTransaction(by: hash)
+        } catch {
+            switch error {
+            case ApiServiceError.networkError(_):
+                return .init(sentDate: nil, status: .noNetwork)
+            default:
+                return .init(sentDate: nil, status: .pending)
+            }
         }
         
         return .init(

--- a/Adamant/Wallets/ERC20/ERC20WalletService+RichMessageProviderWithStatusCheck.swift
+++ b/Adamant/Wallets/ERC20/ERC20WalletService+RichMessageProviderWithStatusCheck.swift
@@ -16,8 +16,17 @@ extension ERC20WalletService: RichMessageProviderWithStatusCheck {
             return .init(sentDate: nil, status: .inconsistent)
         }
         
-        guard let erc20Transaction = try? await getTransaction(by: hash) else {
-            return .init(sentDate: nil, status: .pending)
+        let erc20Transaction: EthTransaction
+        
+        do {
+            erc20Transaction = try await getTransaction(by: hash)
+        } catch {
+            switch error {
+            case WalletServiceError.networkError:
+                return .init(sentDate: nil, status: .noNetwork)
+            default:
+                return .init(sentDate: nil, status: .pending)
+            }
         }
         
         return .init(

--- a/Adamant/Wallets/ERC20/ERC20WalletService.swift
+++ b/Adamant/Wallets/ERC20/ERC20WalletService.swift
@@ -442,6 +442,8 @@ extension ERC20WalletService {
             details = try await eth.transactionDetails(hash)
         } catch let error as Web3Error {
             throw error.asWalletServiceError()
+        } catch _ as URLError {
+            throw WalletServiceError.networkError
         } catch {
             throw WalletServiceError.internalError(message: "Failed to get transaction", error: error)
         }
@@ -517,8 +519,10 @@ extension ERC20WalletService {
             default:
                 throw error.asWalletServiceError()
             }
+        } catch _ as URLError {
+            throw WalletServiceError.networkError
         } catch {
-            throw WalletServiceError.internalError(message: "Failed to get transaction", error: error)
+            throw error
         }
     }
     

--- a/Adamant/Wallets/Ethereum/EthWalletService+RichMessageProviderWithStatusCheck.swift
+++ b/Adamant/Wallets/Ethereum/EthWalletService+RichMessageProviderWithStatusCheck.swift
@@ -19,10 +19,19 @@ extension EthWalletService: RichMessageProviderWithStatusCheck {
             return .init(sentDate: nil, status: .inconsistent)
         }
         
+        let transactionInfo: EthTransactionInfo
+        
+        do {
+            transactionInfo = try await getTransactionInfo(hash: hash, web3: web3)
+        } catch _ as URLError {
+            return .init(sentDate: nil, status: .noNetwork)
+        } catch {
+            return .init(sentDate: nil, status: .pending)
+        }
+        
         guard
-            let info = try? await getTransactionInfo(hash: hash, web3: web3),
-            let details = info.details,
-            let receipt = info.receipt
+            let details = transactionInfo.details,
+            let receipt = transactionInfo.receipt
         else {
             return .init(sentDate: nil, status: .pending)
         }

--- a/Adamant/Wallets/Lisk/LskWalletService+RichMessageProviderWithStatusCheck.swift
+++ b/Adamant/Wallets/Lisk/LskWalletService+RichMessageProviderWithStatusCheck.swift
@@ -15,8 +15,17 @@ extension LskWalletService: RichMessageProviderWithStatusCheck {
             return .init(sentDate: nil, status: .inconsistent)
         }
         
-        guard var lskTransaction = try? await getTransaction(by: hash) else {
-            return .init(sentDate: nil, status: .pending)
+        var lskTransaction: Transactions.TransactionModel
+        
+        do {
+            lskTransaction = try await getTransaction(by: hash)
+        } catch {
+            switch error {
+            case ApiServiceError.networkError(_):
+                return .init(sentDate: nil, status: .noNetwork)
+            default:
+                return .init(sentDate: nil, status: .pending)
+            }
         }
         
         lskTransaction.updateConfirmations(value: lastHeight)

--- a/Adamant/Wallets/Lisk/LskWalletService.swift
+++ b/Adamant/Wallets/Lisk/LskWalletService.swift
@@ -601,8 +601,16 @@ extension LskWalletService {
                         continuation.resume(throwing: ApiServiceError.internalError(message: "No transaction", error: nil))
                     }
                 case .error(response: let error):
-                    print("ERROR: " + error.message)
-                    continuation.resume(throwing: ApiServiceError.internalError(message: error.message, error: nil))
+                    switch error.message {
+                    case APIError.unexpected.message:
+                        continuation.resume(
+                            throwing: ApiServiceError.networkError(error: error)
+                        )
+                    default:
+                        continuation.resume(
+                            throwing: ApiServiceError.internalError(message: error.message, error: error)
+                        )
+                    }
                 }
             }
         }

--- a/AdamantShared/Helpers/CollectionUtilites.swift
+++ b/AdamantShared/Helpers/CollectionUtilites.swift
@@ -6,6 +6,15 @@
 //  Copyright © 2022 Adamant. All rights reserved.
 //
 
+extension Collection {
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index)
+            ? self[index]
+            : nil
+    }
+}
+
 extension Collection where Element: AnyObject {
     func hasTheSameReferences(as collection: Self) -> Bool {
         count == collection.count

--- a/LiskKit/Sources/Core/APIError.swift
+++ b/LiskKit/Sources/Core/APIError.swift
@@ -27,9 +27,10 @@ public struct APIErrors: Decodable {
 }
 
 /// Protocol describing an error
-public struct APIError {
-
+public struct APIError: LocalizedError {
     public let message: String
+    
+    public var errorDescription: String? { message }
 
     public init(message: String) {
         self.message = message


### PR DESCRIPTION
1. Обработка статусов, когда нет интернета
2. Фикс установки `failed` статуса. Теперь он устанавливается после всех проваленных `oldPendingAttempts`

3. Пофиксил ленту. При слишком частых обновлениях контента она пропускала обновления для некоторых ячеек.
Теперь сделал так, что ячейки непосредственно подписываются на вью модель. Так обновления контента не пропускаются