### PR TITLE
[trello.com/c/Pcl4UC2p] Transactions processing improvement

### DIFF
--- a/Adamant/AppDelegate.swift
+++ b/Adamant/AppDelegate.swift
@@ -211,7 +211,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             })
             
         } else {
-            dialogService.showError(withMessage: "Failed to register ChatsProvider autoupdate. Please, report a bug", error: nil)
+            dialogService.showError(withMessage: "Failed to register ChatsProvider autoupdate. Please, report a bug", supportEmail: true, error: nil)
         }
         
         if let transfersProvider = container.resolve(TransfersProvider.self) {
@@ -221,13 +221,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
             })
         } else {
-            dialogService.showError(withMessage: "Failed to register TransfersProvider autoupdate. Please, report a bug", error: nil)
+            dialogService.showError(withMessage: "Failed to register TransfersProvider autoupdate. Please, report a bug", supportEmail: true, error: nil)
         }
         
         if let accountService = container.resolve(AccountService.self) {
             repeater.registerForegroundCall(label: "accountService", interval: 15, queue: .global(qos: .utility), callback: accountService.update)
         } else {
-            dialogService.showError(withMessage: "Failed to register AccountService autoupdate. Please, report a bug", error: nil)
+            dialogService.showError(withMessage: "Failed to register AccountService autoupdate. Please, report a bug", supportEmail: true, error: nil)
         }
         
         if let addressBookService = container.resolve(AddressBookService.self) {
@@ -237,14 +237,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
             })
         } else {
-            dialogService.showError(withMessage: "Failed to register AddressBookService autoupdate. Please, report a bug", error: nil)
+            dialogService.showError(withMessage: "Failed to register AddressBookService autoupdate. Please, report a bug", supportEmail: true, error: nil)
         }
         
         if let currencyInfoService = container.resolve(CurrencyInfoService.self) {
             currencyInfoService.update() // Initial update
             repeater.registerForegroundCall(label: "currencyInfoService", interval: 60, queue: .global(qos: .utility), callback: currencyInfoService.update)
         } else {
-            dialogService.showError(withMessage: "Failed to register CurrencyInfoService autoupdate. Please, report a bug", error: nil)
+            dialogService.showError(withMessage: "Failed to register CurrencyInfoService autoupdate. Please, report a bug", supportEmail: true, error: nil)
         }
         
         // MARK: 7. Logout reset
@@ -310,7 +310,7 @@ extension AppDelegate {
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         if let service = container.resolve(DialogService.self) {
-            service.showError(withMessage: String.localizedStringWithFormat(String.adamantLocalized.notifications.registerRemotesError, error.localizedDescription), error: error)
+            service.showError(withMessage: String.localizedStringWithFormat(String.adamantLocalized.notifications.registerRemotesError, error.localizedDescription), supportEmail: true, error: error)
         }
     }
     

--- a/Adamant/Models/ApiServiceError.swift
+++ b/Adamant/Models/ApiServiceError.swift
@@ -50,8 +50,11 @@ extension ApiServiceError: RichError {
         case .accountNotFound, .notLogged, .networkError, .requestCancelled:
             return .warning
             
-        case .internalError, .serverError:
+        case .serverError:
             return .error
+            
+        case .internalError:
+            return .internalError
         }
     }
     

--- a/Adamant/ServiceProtocols/AccountService.swift
+++ b/Adamant/ServiceProtocols/AccountService.swift
@@ -130,16 +130,10 @@ extension AccountServiceError: RichError {
             return .warning
             
         case .apiError(let error):
-            switch error {
-            case .accountNotFound, .notLogged, .networkError, .requestCancelled:
-                return .warning
-                
-            case .serverError, .internalError:
-                return .error
-            }
+            return error.level
             
         case .internalError:
-            return .error
+            return .internalError
         }
     }
 }

--- a/Adamant/ServiceProtocols/AddressBookService.swift
+++ b/Adamant/ServiceProtocols/AddressBookService.swift
@@ -75,7 +75,7 @@ extension AddressBookServiceError: RichError {
         switch self {
         case .notLogged, .notEnoughMoney: return .warning
         case .apiServiceError(let error): return error.level
-        case .internalError: return .error
+        case .internalError: return .internalError
         }
     }
 }

--- a/Adamant/ServiceProtocols/DataProviders/ChatsProvider.swift
+++ b/Adamant/ServiceProtocols/DataProviders/ChatsProvider.swift
@@ -96,21 +96,22 @@ extension ChatsProviderError: RichError {
     
     var level: ErrorLevel {
         switch self {
-            case .accountNotFound,
-                 .messageNotValid,
-                 .networkError,
-                 .notEnoughMoneyToSend,
-                 .accountNotInitiated,
-                 .requestCancelled,
-                 .invalidTransactionStatus,
-                 .notLogged:
+        case .accountNotFound,
+                .messageNotValid,
+                .networkError,
+                .notEnoughMoneyToSend,
+                .accountNotInitiated,
+                .requestCancelled,
+                .invalidTransactionStatus,
+                .notLogged:
             return .warning
             
-        case .dependencyError,
-             .internalError,
-             .serverError,
-             .transactionNotFound:
+        case .serverError, .transactionNotFound:
             return .error
+            
+        case .dependencyError,
+             .internalError:
+            return .internalError
         }
     }
 }

--- a/Adamant/ServiceProtocols/DataProviders/TransfersProvider.swift
+++ b/Adamant/ServiceProtocols/DataProviders/TransfersProvider.swift
@@ -78,9 +78,12 @@ extension TransfersProviderError: RichError {
         switch self {
         case .notLogged, .accountNotFound, .transactionNotFound, .networkError, .notEnoughMoney, .requestCancelled:
             return .warning
-            
-        case .serverError, .internalError, .dependencyError:
+        
+        case .serverError:
             return .error
+            
+        case .internalError, .dependencyError:
+            return .internalError
         }
     }
     

--- a/Adamant/ServiceProtocols/DialogService.swift
+++ b/Adamant/ServiceProtocols/DialogService.swift
@@ -85,13 +85,21 @@ enum ShareContentType {
 }
 
 enum ErrorLevel {
-    case warning, error
+    case warning
+    case error
+    case internalError
 }
 
-protocol RichError: Error {
+protocol RichError: LocalizedError {
     var message: String { get }
     var internalError: Error? { get }
     var level: ErrorLevel { get }
+}
+
+extension RichError {
+    var errorDescription: String? {
+        message
+    }
 }
 
 enum AdamantAlertStyle {
@@ -122,7 +130,7 @@ protocol DialogService: AnyObject {
     func dismissProgress()
     func showSuccess(withMessage: String)
     func showWarning(withMessage: String)
-    func showError(withMessage: String, error: Error?)
+    func showError(withMessage: String, supportEmail: Bool, error: Error?)
     func showRichError(error: RichError)
     func showRichError(error: Error)
     func showNoConnectionNotification()

--- a/Adamant/Stories/Account/AccountViewController.swift
+++ b/Adamant/Stories/Account/AccountViewController.swift
@@ -197,7 +197,7 @@ class AccountViewController: FormViewController {
             do {
                 try controller.performFetch()
             } catch {
-                dialogService.showError(withMessage: "Error fetching transfers: report a bug", error: error)
+                dialogService.showError(withMessage: "Error fetching transfers: report a bug", supportEmail: true, error: error)
             }
         }
         

--- a/Adamant/Stories/Chat/View/Managers/ChatDialogManager.swift
+++ b/Adamant/Stories/Chat/View/Managers/ChatDialogManager.swift
@@ -44,8 +44,12 @@ private extension ChatDialogManager {
             dialogService.showToastMessage(message)
         case let .alert(message):
             showAlert(message: message)
-        case let .error(message):
-            dialogService.showError(withMessage: message, error: nil)
+        case let .error(message, supportEmail):
+            dialogService.showError(
+                withMessage: message,
+                supportEmail: supportEmail,
+                error: nil
+            )
         case let .warning(message):
             dialogService.showWarning(withMessage: message)
         case let .richError(error):

--- a/Adamant/Stories/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Stories/Chat/ViewModel/ChatViewModel.swift
@@ -79,7 +79,10 @@ final class ChatViewModel: NSObject {
         let urlString: String = .adamantLocalized.wallets.getFreeTokensUrl(for: address)
         
         guard let url = URL(string: urlString) else {
-            dialog.send(.error("Failed to create URL with string: \(urlString)"))
+            dialog.send(.error(
+                "Failed to create URL with string: \(urlString)",
+                supportEmail: true
+            ))
             return nil
         }
         
@@ -527,10 +530,13 @@ private extension ChatViewModel {
                     return
                 }
                 
-                self.dialog.send(.error(error.localized))
+                self.dialog.send(.error(error.localized, supportEmail: false))
             }
         } catch {
-            self.dialog.send(.error(error.localizedDescription))
+            self.dialog.send(.error(
+                error.localizedDescription,
+                supportEmail: false
+            ))
         }
     }
     

--- a/Adamant/Stories/Chat/ViewModel/Models/ChatDialog.swift
+++ b/Adamant/Stories/Chat/ViewModel/Models/ChatDialog.swift
@@ -11,7 +11,7 @@ import UIKit
 enum ChatDialog {
     case toast(String)
     case alert(String)
-    case error(String)
+    case error(String, supportEmail: Bool)
     case warning(String)
     case richError(Error)
     case freeTokenAlert

--- a/Adamant/Stories/ChatsList/ChatListViewController.swift
+++ b/Adamant/Stories/ChatsList/ChatListViewController.swift
@@ -1154,7 +1154,7 @@ extension ChatListViewController: UISearchBarDelegate, UISearchResultsUpdating, 
     
     func didSelected(_ message: MessageTransaction) {
         guard let chatroom = message.chatroom else {
-            dialogService.showError(withMessage: "Error getting chatroom in SearchController result. Please, report an error", error: nil)
+            dialogService.showError(withMessage: "Error getting chatroom in SearchController result. Please, report an error", supportEmail: true, error: nil)
             searchController?.dismiss(animated: true, completion: nil)
             return
         }

--- a/Adamant/Stories/ChatsList/NewChatViewController.swift
+++ b/Adamant/Stories/ChatsList/NewChatViewController.swift
@@ -200,7 +200,7 @@ class NewChatViewController: FormViewController {
                     self?.present(vc, animated: true, completion: nil)
                     
                 case .failure(error: let error):
-                    self?.dialogService.showError(withMessage: error.localizedDescription, error: error)
+                    self?.dialogService.showError(withMessage: error.localizedDescription, supportEmail: true, error: error)
                 }
             }
             
@@ -305,10 +305,10 @@ class NewChatViewController: FormViewController {
                         return
                     }
                     
-                    self.dialogService.showError(withMessage: error.localized, error: error)
+                    self.dialogService.showError(withMessage: error.localized, supportEmail: false, error: error)
                 }
             } catch {
-                self.dialogService.showError(withMessage: error.localizedDescription, error: error)
+                self.dialogService.showError(withMessage: error.localizedDescription, supportEmail: false, error: error)
             }
         }
     }

--- a/Adamant/Stories/Settings/AboutViewController.swift
+++ b/Adamant/Stories/Settings/AboutViewController.swift
@@ -287,6 +287,7 @@ class AboutViewController: FormViewController {
                             String.adamantLocalized.sharedErrors.remoteServerError(
                                 message: error.localizedDescription
                             ),
+                        supportEmail: false,
                         error: error
                     )
                 }
@@ -296,6 +297,7 @@ class AboutViewController: FormViewController {
                         String.adamantLocalized.sharedErrors.remoteServerError(
                             message: error.localizedDescription
                         ),
+                    supportEmail: false,
                     error: error
                 )
             }

--- a/Adamant/Stories/Settings/QRGeneratorViewController.swift
+++ b/Adamant/Stories/Settings/QRGeneratorViewController.swift
@@ -188,7 +188,7 @@ extension QRGeneratorViewController {
             setQr(image: qr)
             
         case .failure(let error):
-            dialogService.showError(withMessage: String.localizedStringWithFormat(String.adamantLocalized.qrGenerator.internalError, error.localizedDescription), error: error)
+            dialogService.showError(withMessage: String.localizedStringWithFormat(String.adamantLocalized.qrGenerator.internalError, error.localizedDescription), supportEmail: true, error: error)
         }
     }
     

--- a/Adamant/Wallets/Adamant/AdmTransactionDetailsViewController.swift
+++ b/Adamant/Wallets/Adamant/AdmTransactionDetailsViewController.swift
@@ -117,17 +117,17 @@ class AdmTransactionDetailsViewController: TransactionDetailsViewControllerBase 
         }
         
         guard let vc = self.router.get(scene: AdamantScene.Chats.chat) as? ChatViewController else {
-            dialogService.showError(withMessage: "AdmTransactionDetailsViewController: Failed to get ChatViewController", error: nil)
+            dialogService.showError(withMessage: "AdmTransactionDetailsViewController: Failed to get ChatViewController", supportEmail: true, error: nil)
             return
         }
 
         guard let chatroom = transfer.chatroom else {
-            dialogService.showError(withMessage: "AdmTransactionDetailsViewController: Failed to get chatroom for transaction.", error: nil)
+            dialogService.showError(withMessage: "AdmTransactionDetailsViewController: Failed to get chatroom for transaction.", supportEmail: true, error: nil)
             return
         }
 
         guard let account = accountService.account else {
-            dialogService.showError(withMessage: "AdmTransactionDetailsViewController: User not logged.", error: nil)
+            dialogService.showError(withMessage: "AdmTransactionDetailsViewController: User not logged.", supportEmail: true, error: nil)
             return
         }
 

--- a/Adamant/Wallets/Adamant/AdmTransactionsViewController.swift
+++ b/Adamant/Wallets/Adamant/AdmTransactionsViewController.swift
@@ -92,7 +92,7 @@ class AdmTransactionsViewController: TransactionsListViewControllerBase {
             do {
                 try controller?.performFetch()
             } catch {
-                dialogService.showError(withMessage: "Failed to get transactions. Please, report a bug", error: error)
+                dialogService.showError(withMessage: "Failed to get transactions. Please, report a bug", supportEmail: true, error: error)
                 controller = nil
             }
             

--- a/Adamant/Wallets/Adamant/AdmWalletService.swift
+++ b/Adamant/Wallets/Adamant/AdmWalletService.swift
@@ -123,6 +123,11 @@ class AdmWalletService: NSObject, WalletService {
     }
     
     // MARK: - Tools
+    func getBalance(address: String) async throws -> Decimal {
+        let account = try await apiService.getAccount(byAddress: address)
+        return account.balance
+    }
+    
     func validate(address: String) -> AddressValidationResult {
         guard !AdamantContacts.systemAddresses.contains(address) else {
             return .system

--- a/Adamant/Wallets/Adamant/AdmWalletViewController.swift
+++ b/Adamant/Wallets/Adamant/AdmWalletViewController.swift
@@ -128,7 +128,11 @@ class AdmWalletViewController: WalletViewControllerBase {
             if let address = self?.service?.wallet?.address {
                 let urlRaw = String.adamantLocalized.wallets.getFreeTokensUrl(for: address)
                 guard let url = URL(string: urlRaw) else {
-                    self?.dialogService.showError(withMessage: "Failed to create URL with string: \(urlRaw)", error: nil)
+                    self?.dialogService.showError(
+                        withMessage: "Failed to create URL with string: \(urlRaw)",
+                        supportEmail: true,
+                        error: nil
+                    )
                     return
                 }
                 

--- a/Adamant/Wallets/Adamant/BuyAndSellViewController.swift
+++ b/Adamant/Wallets/Adamant/BuyAndSellViewController.swift
@@ -121,7 +121,7 @@ class BuyAndSellViewController: FormViewController {
                 return
             }
             guard let url = URL(string: urlRaw) else {
-                self?.dialogService.showError(withMessage: "Failed to create URL with string: \(urlRaw)", error: nil)
+                self?.dialogService.showError(withMessage: "Failed to create URL with string: \(urlRaw)", supportEmail: true, error: nil)
                 return
             }
             

--- a/Adamant/Wallets/Bitcoin/BtcWalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/Bitcoin/BtcWalletService+RichMessageProvider.swift
@@ -101,14 +101,8 @@ extension BtcWalletService: RichMessageProvider {
                     richTransaction: transaction,
                     in: chat
                 )
-            } catch let error as WalletServiceError {
+            } catch {
                 dialogService.dismissProgress()
-                guard case let .internalError(message, _) = error,
-                      message == "No transaction"
-                else {
-                    dialogService.showRichError(error: error)
-                    return
-                }
                 
                 presentDetailTransactionVC(
                     hash: hash,

--- a/Adamant/Wallets/Dash/DashWalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/Dash/DashWalletService+RichMessageProvider.swift
@@ -104,15 +104,8 @@ extension DashWalletService: RichMessageProvider {
                     richTransaction: transaction,
                     in: chat
                 )
-            } catch let error as ApiServiceError {
+            } catch {
                 dialogService.dismissProgress()
-                
-                guard case let .internalError(message, _) = error,
-                      message == "No transaction"
-                else {
-                    dialogService.showRichError(error: error)
-                    return
-                }
                 
                 presentDetailTransactionVC(
                     hash: hash,
@@ -125,9 +118,6 @@ extension DashWalletService: RichMessageProvider {
                     richTransaction: transaction,
                     in: chat
                 )
-            } catch {
-                dialogService.dismissProgress()
-                dialogService.showRichError(error: error)
             }
         }
     }

--- a/Adamant/Wallets/Doge/DogeWalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/Doge/DogeWalletService+RichMessageProvider.swift
@@ -103,38 +103,31 @@ extension DogeWalletService: RichMessageProvider {
                 dialogService.dismissProgress()
                 chat.navigationController?.pushViewController(vc, animated: true)
                 
-            } catch let error as ApiServiceError {
-                switch error {
-                case .internalError(let message, _) where message == "Unaviable transaction":
-                    dialogService.dismissProgress()
-                    dialogService.showAlert(title: nil, message: String.adamantLocalized.sharedErrors.transactionUnavailable, style: AdamantAlertStyle.alert, actions: nil, from: nil)
-                case .internalError(let message, _) where message == "No transaction":
-                    let amount: Decimal
-                    if let amountRaw = transaction.richContent?[RichContentKeys.transfer.amount], let decimal = Decimal(string: amountRaw) {
-                        amount = decimal
-                    } else {
-                        amount = 0
-                    }
-                    
-                    let failedTransaction = SimpleTransactionDetails(txId: hash,
-                                                                     senderAddress: transaction.senderAddress,
-                                                                     recipientAddress: transaction.recipientAddress,
-                                                                     dateValue: nil,
-                                                                     amountValue: amount,
-                                                                     feeValue: nil,
-                                                                     confirmationsValue: nil,
-                                                                     blockValue: nil,
-                                                                     isOutgoing: transaction.isOutgoing,
-                                                                     transactionStatus: TransactionStatus.failed)
-                    
-                    vc.transaction = failedTransaction
-                    
-                    dialogService.dismissProgress()
-                    chat.navigationController?.pushViewController(vc, animated: true)
-                default:
-                    dialogService.dismissProgress()
-                    dialogService.showRichError(error: error)
+            } catch {
+                let amount: Decimal
+                if let amountRaw = transaction.richContent?[RichContentKeys.transfer.amount], let decimal = Decimal(string: amountRaw) {
+                    amount = decimal
+                } else {
+                    amount = 0
                 }
+                
+                let failedTransaction = SimpleTransactionDetails(
+                    txId: hash,
+                    senderAddress: transaction.senderAddress,
+                    recipientAddress: transaction.recipientAddress,
+                    dateValue: nil,
+                    amountValue: amount,
+                    feeValue: nil,
+                    confirmationsValue: nil,
+                    blockValue: nil,
+                    isOutgoing: transaction.isOutgoing,
+                    transactionStatus: TransactionStatus.failed
+                )
+                
+                vc.transaction = failedTransaction
+                
+                dialogService.dismissProgress()
+                chat.navigationController?.pushViewController(vc, animated: true)
             }
         }
     }

--- a/Adamant/Wallets/ERC20/ERC20WalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/ERC20/ERC20WalletService+RichMessageProvider.swift
@@ -95,39 +95,28 @@ extension ERC20WalletService: RichMessageProvider {
             do {
                 let ethTransaction = try await getTransaction(by: hash)
                 vc.transaction = ethTransaction
-            } catch let error as WalletServiceError {
-                dialogService.dismissProgress()
-                switch error {
-                case .remoteServiceError:
-                    let amount: Decimal
-                    if let amountRaw = transaction.richContent?[RichContentKeys.transfer.amount], let decimal = Decimal(string: amountRaw) {
-                        amount = decimal
-                    } else {
-                        amount = 0
-                    }
-                    
-                    let failedTransaction = SimpleTransactionDetails(
-                        txId: hash,
-                        senderAddress: transaction.senderAddress,
-                        recipientAddress: transaction.recipientAddress,
-                        dateValue: nil,
-                        amountValue: amount,
-                        feeValue: nil,
-                        confirmationsValue: nil,
-                        blockValue: nil,
-                        isOutgoing: transaction.isOutgoing,
-                        transactionStatus: TransactionStatus.failed
-                    )
-                    
-                    vc.transaction = failedTransaction
-                    
-                default:
-                    dialogService.showRichError(error: error)
-                    return
-                }
             } catch {
-                dialogService.showRichError(error: error)
-                return
+                let amount: Decimal
+                if let amountRaw = transaction.richContent?[RichContentKeys.transfer.amount], let decimal = Decimal(string: amountRaw) {
+                    amount = decimal
+                } else {
+                    amount = 0
+                }
+                
+                let failedTransaction = SimpleTransactionDetails(
+                    txId: hash,
+                    senderAddress: transaction.senderAddress,
+                    recipientAddress: transaction.recipientAddress,
+                    dateValue: nil,
+                    amountValue: amount,
+                    feeValue: nil,
+                    confirmationsValue: nil,
+                    blockValue: nil,
+                    isOutgoing: transaction.isOutgoing,
+                    transactionStatus: TransactionStatus.failed
+                )
+                
+                vc.transaction = failedTransaction
             }
             
             dialogService.dismissProgress()

--- a/Adamant/Wallets/ERC20/ERC20WalletService.swift
+++ b/Adamant/Wallets/ERC20/ERC20WalletService.swift
@@ -298,9 +298,8 @@ class ERC20WalletService: WalletService {
             let price = try await web3.eth.gasPrice()
             return price
         } catch {
-            throw WalletServiceError.internalError(
-                message: error.localizedDescription,
-                error: error
+            throw WalletServiceError.remoteServiceError(
+                message: error.localizedDescription
             )
         }
     }
@@ -323,9 +322,8 @@ class ERC20WalletService: WalletService {
             let price = try await web3.eth.estimateGas(for: transaction)
             return price
         } catch {
-            throw WalletServiceError.internalError(
-                message: error.localizedDescription,
-                error: error
+            throw WalletServiceError.remoteServiceError(
+                message: error.localizedDescription
             )
         }
     }
@@ -423,7 +421,7 @@ extension ERC20WalletService {
         } catch _ as URLError {
             throw WalletServiceError.networkError
         } catch {
-            throw WalletServiceError.internalError(message: "Failed to get transaction", error: error)
+            throw WalletServiceError.remoteServiceError(message: "Failed to get transaction")
         }
         
         // MARK: 2. Transaction receipt
@@ -451,9 +449,8 @@ extension ERC20WalletService {
             let block = try await eth.block(by: receipt.blockHash)
             
             guard currentBlock >= blockNumber else {
-                throw WalletServiceError.internalError(
-                    message: "ERC20 confirmations calculating error",
-                    error: nil
+                throw WalletServiceError.remoteServiceError(
+                    message: "ERC20 confirmations calculating error"
                 )
             }
             
@@ -504,6 +501,14 @@ extension ERC20WalletService {
         }
     }
     
+    func getBalance(address: String) async throws -> Decimal {
+        guard let address = EthereumAddress(address) else {
+            throw WalletServiceError.internalError(message: "Incorrect address", error: nil)
+        }
+        
+        return try await getBalance(forAddress: address)
+    }
+    
     func getBalance(forAddress address: EthereumAddress) async throws -> Decimal {
         guard let address = self.ethWallet?.address,
               let walletAddress = EthereumAddress(address),
@@ -522,9 +527,8 @@ extension ERC20WalletService {
             let value = balance.asDecimal(exponent: exponent)
             return value
         } catch {
-            throw WalletServiceError.internalError(
-                message: "ERC 20 Service - Fail to get balance",
-                error: error
+            throw WalletServiceError.remoteServiceError(
+                message: "ERC 20 Service - Fail to get balance"
             )
         }
     }
@@ -539,9 +543,8 @@ extension ERC20WalletService {
             
             return result
         } catch let error as ApiServiceError {
-            throw WalletServiceError.internalError(
-                message: "ETH Wallet: failed to get address from KVS",
-                error: error
+            throw WalletServiceError.remoteServiceError(
+                message: "ETH Wallet: failed to get address from KVS"
             )
         }
     }

--- a/Adamant/Wallets/Ethereum/EthWalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/Ethereum/EthWalletService+RichMessageProvider.swift
@@ -100,34 +100,30 @@ extension EthWalletService: RichMessageProvider {
             do {
                 let ethTransaction = try await getTransaction(by: hash)
                 vc.transaction = ethTransaction
-            } catch let error as WalletServiceError {
-                switch error {
-                case .remoteServiceError:
-                    let amount: Decimal
-                    if let amountRaw = transaction.richContent?[RichContentKeys.transfer.amount], let decimal = Decimal(string: amountRaw) {
-                        amount = decimal
-                    } else {
-                        amount = 0
-                    }
-                    
-                    let failedTransaction = SimpleTransactionDetails(txId: hash,
-                                                             senderAddress: transaction.senderAddress,
-                                                             recipientAddress: transaction.recipientAddress,
-                                                             dateValue: nil,
-                                                             amountValue: amount,
-                                                             feeValue: nil,
-                                                             confirmationsValue: nil,
-                                                             blockValue: nil,
-                                                             isOutgoing: transaction.isOutgoing,
-                                                             transactionStatus: TransactionStatus.failed)
-                    
-                    vc.transaction = failedTransaction
-                    
-                default:
-                    dialogService.showRichError(error: error)
-                }
             } catch {
-                dialogService.showRichError(error: error)
+                var amount: Decimal = .zero
+                
+                if
+                    let amountRaw = transaction.richContent?[RichContentKeys.transfer.amount],
+                    let decimal = Decimal(string: amountRaw)
+                {
+                    amount = decimal
+                }
+                
+                let failedTransaction = SimpleTransactionDetails(
+                    txId: hash,
+                    senderAddress: transaction.senderAddress,
+                    recipientAddress: transaction.recipientAddress,
+                    dateValue: nil,
+                    amountValue: amount,
+                    feeValue: nil,
+                    confirmationsValue: nil,
+                    blockValue: nil,
+                    isOutgoing: transaction.isOutgoing,
+                    transactionStatus: TransactionStatus.failed
+                )
+                
+                vc.transaction = failedTransaction
             }
             
             dialogService.dismissProgress()

--- a/Adamant/Wallets/Lisk/LskTransferViewController.swift
+++ b/Adamant/Wallets/Lisk/LskTransferViewController.swift
@@ -16,6 +16,24 @@ final class LskTransferViewController: TransferViewControllerBase {
     
     private let chatsProvider: ChatsProvider
     
+    // MARK: Properties
+    
+    override var minToTransfer: Decimal {
+        get async throws {
+            guard let recipientAddress = recipientAddress else {
+                throw WalletServiceError.accountNotFound
+            }
+            
+            guard let service = service else {
+                throw WalletServiceError.walletNotInitiated
+            }
+            
+            let recepientBalance = try await service.getBalance(address: recipientAddress)
+            let minimumAmount = service.minBalance - recepientBalance
+            return try await max(super.minToTransfer, minimumAmount)
+        }
+    }
+    
     init(
         chatsProvider: ChatsProvider,
         accountService: AccountService,

--- a/Adamant/Wallets/Lisk/LskWalletService+RichMessageProvider.swift
+++ b/Adamant/Wallets/Lisk/LskWalletService+RichMessageProvider.swift
@@ -104,15 +104,7 @@ extension LskWalletService: RichMessageProvider {
                     in: chat
                 )
                 
-            } catch let error as ApiServiceError {
-                guard case let .internalError(message, _) = error,
-                      message.contains("does not exist")
-                else {
-                    dialogService.dismissProgress()
-                    dialogService.showRichError(error: error)
-                    return
-                }
-                
+            } catch {
                 do {
                     let senderAddress = try await getWalletAddress(byAdamantAddress: transaction.senderAddress)
                     let recipientAddress = try await getWalletAddress(byAdamantAddress: transaction.recipientAddress)
@@ -134,9 +126,6 @@ extension LskWalletService: RichMessageProvider {
                     dialogService.dismissProgress()
                     dialogService.showRichError(error: error)
                 }
-            } catch {
-                dialogService.dismissProgress()
-                dialogService.showRichError(error: error)
             }
         }
     }

--- a/Adamant/Wallets/WalletService.swift
+++ b/Adamant/Wallets/WalletService.swift
@@ -92,18 +92,15 @@ extension WalletServiceError: RichError {
         switch self {
         case .notLogged, .notEnoughMoney, .networkError, .accountNotFound, .invalidAmount, .walletNotInitiated, .transactionNotFound, .requestCancelled:
             return .warning
-            
-        case .remoteServiceError, .internalError, .dustAmountError:
+        
+        case .dustAmountError, .remoteServiceError:
             return .error
             
+        case .internalError:
+            return .internalError
+            
         case .apiError(let error):
-            switch error {
-            case .accountNotFound, .notLogged, .networkError, .requestCancelled:
-                return .warning
-                
-            case .serverError, .internalError:
-                return .error
-            }
+            return error.level
         }
     }
 }
@@ -244,6 +241,7 @@ protocol WalletService: AnyObject {
     // MARK: Tools
     func validate(address: String) -> AddressValidationResult
     func getWalletAddress(byAdamantAddress address: String) async throws -> String
+    func getBalance(address: String) async throws -> Decimal
 }
 
 protocol SwinjectDependentService: WalletService {

--- a/LiskKit/Sources/API/Transactions/Transactions.swift
+++ b/LiskKit/Sources/API/Transactions/Transactions.swift
@@ -38,7 +38,7 @@ extension Transactions {
     /// Submit a signed transaction to the network
     public func submit(signedTransaction: LocalTransaction, completionHandler: @escaping (Response<TransactionBroadcastResponse>) -> Void) {
         guard signedTransaction.isSigned else {
-            let response = APIError(message: "Invalid Transaction - Transaction has not been signed")
+            let response = APIError(message: "Invalid Transaction - Transaction has not been signed", code: nil)
             return completionHandler(.error(response: response))
         }
 
@@ -61,7 +61,7 @@ extension Transactions {
             let signedTransaction = try transaction.signed(passphrase: passphrase, secondPassphrase: secondPassphrase)
             submit(signedTransaction: signedTransaction, completionHandler: completionHandler)
         } catch {
-            let response = APIError(message: error.localizedDescription)
+            let response = APIError(message: error.localizedDescription, code: nil)
             completionHandler(.error(response: response))
         }
     }
@@ -73,7 +73,7 @@ extension Transactions {
             let signedTransaction = try transaction.signed(keyPair: keyPair)
             submit(signedTransaction: signedTransaction, completionHandler: completionHandler)
         } catch {
-            let response = APIError(message: error.localizedDescription)
+            let response = APIError(message: error.localizedDescription, code: nil)
             completionHandler(.error(response: response))
         }
     }
@@ -92,7 +92,7 @@ extension Transactions {
             let signedTransaction = try transaction.signed(passphrase: passphrase, secondPassphrase: nil)
             submit(signedTransaction: signedTransaction, completionHandler: completionHandler)
         } catch {
-            let response = APIError(message: error.localizedDescription)
+            let response = APIError(message: error.localizedDescription, code: nil)
             completionHandler(.error(response: response))
         }
     }

--- a/LiskKit/Sources/Core/APIError.swift
+++ b/LiskKit/Sources/Core/APIError.swift
@@ -27,12 +27,13 @@ public struct APIErrors: Decodable {
 }
 
 /// Protocol describing an error
-public struct APIError: LocalizedError {
+public struct APIError: LocalizedError, Equatable {
     public let message: String
+    public var code: Int?
     
     public var errorDescription: String? { message }
 
-    public init(message: String) {
+    public init(message: String, code: Int?) {
         self.message = message
     }
 }
@@ -55,10 +56,15 @@ extension APIError: Decodable {
 }
 
 extension APIError {
-
+    public static let noNetwork = Self.unexpected(code: nil)
+    
     /// Describes an unexpected error
-    public static let unexpected = APIError(message: "Unexpected Error")
+    public static func unexpected(code: Int?) -> Self {
+        .init(message: "Unexpected Error", code: code)
+    }
 
     /// Describes an unknown error response
-    public static let unknown = APIError(message: "Unknown Error")
+    public static func unknown(code: Int?) -> Self {
+        .init(message: "Unknown Error", code: code)
+    }
 }

--- a/PopupKit/Sources/PopupKit/Implementation/Models/AdvancedAlertModel.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Models/AdvancedAlertModel.swift
@@ -11,14 +11,14 @@ public struct AdvancedAlertModel: Equatable, Hashable {
     public let icon: UIImage
     public let title: String
     public let text: String
-    public let secondaryButton: Button
+    public let secondaryButton: Button?
     public let primaryButton: Button
     
     public init(
         icon: UIImage,
         title: String,
         text: String,
-        secondaryButton: Button,
+        secondaryButton: Button?,
         primaryButton: Button
     ) {
         self.icon = icon

--- a/PopupKit/Sources/PopupKit/Implementation/Views/AdvancedAlertView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/AdvancedAlertView.swift
@@ -21,8 +21,11 @@ struct AdvancedAlertView: View {
                     .padding(.bottom, smallSpacing)
                 textView
                     .padding(.bottom, bigSpacing)
-                secondaryButton
-                    .padding(.bottom, bigSpacing)
+                
+                if let secondaryButton = model.secondaryButton {
+                    makeSecondaryButton(model: secondaryButton)
+                        .padding(.bottom, bigSpacing)
+                }
             }.padding(.horizontal, bigSpacing)
             .background(widthReader)
             .onPreferenceChange(ViewPreferenceKey.self) { width = $0 }
@@ -49,8 +52,7 @@ private extension AdvancedAlertView {
     
     var iconView: some View {
         Image(uiImage: model.icon)
-            .renderingMode(.template)
-            .foregroundColor(.primary)
+            .renderingMode(.original)
             .frame(squareSize: 37)
     }
     
@@ -63,13 +65,6 @@ private extension AdvancedAlertView {
         Text(model.text)
             .multilineTextAlignment(.center)
             .font(.system(size: 13))
-    }
-    
-    var secondaryButton: some View {
-        Button(
-            model.secondaryButton.title,
-            action: model.secondaryButton.action.action
-        )
     }
     
     var primaryButton: some View {
@@ -87,6 +82,10 @@ private extension AdvancedAlertView {
                 value: $0.frame(in: .local).size.width
             )
         }
+    }
+    
+    func makeSecondaryButton(model: AdvancedAlertModel.Button) -> some View {
+        Button(model.title, action: model.action.action)
     }
 }
 


### PR DESCRIPTION
1. Для Lisk добавил проверку на минимальный баланс получателя. На любом инициализированном аккаунте должно быть не менее `minBalance` денег.
2. Добавил новый тип ошибки - обычная ошибка. Для нее показываем тот же алерт, что и для `internalError`, но без почты саппорта. Нужен для того, чтобы дать пользователю время полностью прочитать текст ошибки.
3. Убрал пустые подсказки, которые снова появились на macOS (из-за Eureka).
4. Упростил логику показа экрана с деталями неподтвержденной транзакции. Теперь всегда показываем экран с деталями и заполняем его известными данными. Ошибки не показываем.
5. Пофиксил цвет иконки алерта в `PopupKit`.
6. В сервисах блокчейнов убрал возврат `internalError` на ошибочные ответы от сервера. Теперь возвращаем `.remoteServiceError`, если ошибка связана с запросом в сеть.