### PR TITLE
[trello.com/c/C8MNrgFw] Small macos fixes

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		93547BCA29E2262D00B0914B /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93547BC929E2262D00B0914B /* WelcomeViewController.swift */; };
 		935F53D629BE8F7400779492 /* RichTransactionStatusPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935F53D529BE8F7400779492 /* RichTransactionStatusPublisher.swift */; };
 		935F53D829BEA7CA00779492 /* TimeInterval+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935F53D729BEA7CA00779492 /* TimeInterval+Extension.swift */; };
+		93684A2A29EFA28A00F9EFFE /* FixedTextMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93684A2929EFA28A00F9EFFE /* FixedTextMessageSizeCalculator.swift */; };
 		9371130F2996EDA900F64CF9 /* ChatRefreshMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371130E2996EDA900F64CF9 /* ChatRefreshMock.swift */; };
 		9371E561295CD53100438F2C /* ChatLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9371E560295CD53100438F2C /* ChatLocalization.swift */; };
 		9377FBDF296C2A2F00C9211B /* ChatTransactionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9377FBDE296C2A2F00C9211B /* ChatTransactionContentView.swift */; };
@@ -937,6 +938,7 @@
 		93547BC929E2262D00B0914B /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
 		935F53D529BE8F7400779492 /* RichTransactionStatusPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichTransactionStatusPublisher.swift; sourceTree = "<group>"; };
 		935F53D729BEA7CA00779492 /* TimeInterval+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Extension.swift"; sourceTree = "<group>"; };
+		93684A2929EFA28A00F9EFFE /* FixedTextMessageSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedTextMessageSizeCalculator.swift; sourceTree = "<group>"; };
 		9371130E2996EDA900F64CF9 /* ChatRefreshMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRefreshMock.swift; sourceTree = "<group>"; };
 		9371E560295CD53100438F2C /* ChatLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLocalization.swift; sourceTree = "<group>"; };
 		9377FBDE296C2A2F00C9211B /* ChatTransactionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTransactionContentView.swift; sourceTree = "<group>"; };
@@ -1580,6 +1582,7 @@
 				9390C5022976B42800270CDF /* ChatDialogManager.swift */,
 				932F77582989F999006D8801 /* ChatCellManager.swift */,
 				9340077F29AC341000A20622 /* ChatAction.swift */,
+				93684A2929EFA28A00F9EFFE /* FixedTextMessageSizeCalculator.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -3084,6 +3087,7 @@
 				A578BDE52623051C00090141 /* DashWalletService+Transactions.swift in Sources */,
 				E96D64BC2295BED700CA5587 /* Transaction.swift in Sources */,
 				6449BA69235CA0930033B936 /* ERC20TransferViewController.swift in Sources */,
+				93684A2A29EFA28A00F9EFFE /* FixedTextMessageSizeCalculator.swift in Sources */,
 				E9E7CD8B20026B0600DFC4DB /* AccountService.swift in Sources */,
 				640EFAA42558613A00E9724B /* EthProvider.swift in Sources */,
 				9371130F2996EDA900F64CF9 /* ChatRefreshMock.swift in Sources */,

--- a/Adamant/AppDelegate.swift
+++ b/Adamant/AppDelegate.swift
@@ -340,11 +340,7 @@ extension AppDelegate {
         
         let chatroom = chatListVC.chatsController?.fetchedObjects?.first(
             where: {
-                $0.transactions?.contains(
-                    where: {
-                        ($0 as? ChatTransaction)?.senderAddress == senderAddress
-                    }
-                ) ?? false
+                $0.partner?.address == senderAddress
             }
         )
         

--- a/Adamant/Stories/Chat/View/Managers/ChatLayoutManager.swift
+++ b/Adamant/Stories/Chat/View/Managers/ChatLayoutManager.swift
@@ -76,6 +76,22 @@ final class ChatLayoutManager: MessagesLayoutDelegate {
         )
     }
     
+    func textCellSizeCalculator(
+        for _: MessageType,
+        at _: IndexPath,
+        in messagesCollectionView: MessagesCollectionView
+    ) -> CellSizeCalculator? {
+        FixedTextMessageSizeCalculator(layout: messagesCollectionView.messagesCollectionViewFlowLayout)
+    }
+    
+    func attributedTextCellSizeCalculator(
+        for _: MessageType,
+        at _: IndexPath,
+        in messagesCollectionView: MessagesCollectionView
+    ) -> CellSizeCalculator? {
+        FixedTextMessageSizeCalculator(layout: messagesCollectionView.messagesCollectionViewFlowLayout)
+    }
+    
     func customCellSizeCalculator(
         for _: MessageType,
         at _: IndexPath,

--- a/Adamant/Stories/Chat/View/Managers/FixedTextMessageSizeCalculator.swift
+++ b/Adamant/Stories/Chat/View/Managers/FixedTextMessageSizeCalculator.swift
@@ -1,0 +1,127 @@
+//
+ //  FixedTextMessageSizeCalculator.swift
+ //  Adamant
+ //
+ //  Created by Andrey Golubenko on 19.04.2023.
+ //  Copyright © 2023 Adamant. All rights reserved.
+ //
+
+ import UIKit
+ import MessageKit
+
+ final class FixedTextMessageSizeCalculator: MessageSizeCalculator {
+     override func messageContainerMaxWidth(
+         for message: MessageType,
+         at indexPath: IndexPath
+     ) -> CGFloat {
+         let maxWidth = super.messageContainerMaxWidth(for: message, at: indexPath)
+         let textInsets = messageLabelInsets(for: message)
+         return maxWidth - textInsets.horizontal
+     }
+
+     override func messageContainerSize(for message: MessageType, at indexPath: IndexPath) -> CGSize {
+         let maxWidth = messageContainerMaxWidth(for: message, at: indexPath)
+
+         var messageContainerSize: CGSize
+         let attributedText: NSAttributedString
+
+         let textMessageKind = message.kind.textMessageKind
+         switch textMessageKind {
+         case .attributedText(let text):
+             attributedText = text
+         case .text(let text), .emoji(let text):
+             attributedText = NSAttributedString(string: text, attributes: [.font: messageLabelFont])
+         default:
+             assertionFailure("messageContainerSize received unhandled MessageDataType: \(message.kind)")
+             return .zero
+         }
+
+         messageContainerSize = labelSize(for: attributedText, considering: maxWidth)
+
+         let messageInsets = messageLabelInsets(for: message)
+         messageContainerSize.width += messageInsets.horizontal
+         messageContainerSize.height += messageInsets.vertical
+
+         return messageContainerSize
+     }
+
+     override func configure(attributes: UICollectionViewLayoutAttributes) {
+         super.configure(attributes: attributes)
+         guard let attributes = attributes as? MessagesCollectionViewLayoutAttributes else { return }
+
+         let dataSource = messagesLayout.messagesDataSource
+         let indexPath = attributes.indexPath
+
+         let message = dataSource.messageForItem(
+             at: indexPath,
+             in: messagesLayout.messagesCollectionView
+         )
+
+         attributes.messageLabelInsets = messageLabelInsets(for: message)
+         attributes.messageLabelFont = messageLabelFont
+
+         switch message.kind {
+         case .attributedText(let text):
+             guard
+                 !text.string.isEmpty,
+                 let font = text.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+             else { break }
+
+             attributes.messageLabelFont = font
+         default:
+             break
+         }
+     }
+ }
+
+ private extension FixedTextMessageSizeCalculator {
+     func messageLabelInsets(for message: MessageType) -> UIEdgeInsets {
+         let dataSource = messagesLayout.messagesDataSource
+         let isFromCurrentSender = dataSource.isFromCurrentSender(message: message)
+         return isFromCurrentSender
+             ? outgoingMessageLabelInsets
+             : incomingMessageLabelInsets
+     }
+
+     func labelSize(for attributedText: NSAttributedString, considering maxWidth: CGFloat) -> CGSize {
+         let constraintBox = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
+         var size = attributedText.boundingRect(
+             with: constraintBox,
+             options: [.usesLineFragmentOrigin, .usesFontLeading],
+             context: nil
+         ).integral.size
+         size.width += additionalWidth
+         return size
+     }
+ }
+
+ private extension UIEdgeInsets {
+     var vertical: CGFloat {
+         top + bottom
+     }
+
+     var horizontal: CGFloat {
+         left + right
+     }
+ }
+
+ private extension MessageKind {
+     var textMessageKind: MessageKind {
+         switch self {
+         case .linkPreview(let linkItem):
+             return linkItem.textKind
+         case .text, .emoji, .attributedText:
+             return self
+         default:
+             assertionFailure("textMessageKind not supported for messageKind: \(self)")
+             return .text("")
+         }
+     }
+ }
+
+ private let incomingMessageLabelInsets = UIEdgeInsets(top: 7, left: 18, bottom: 7, right: 14)
+ private let outgoingMessageLabelInsets = UIEdgeInsets(top: 7, left: 14, bottom: 7, right: 18)
+ private let messageLabelFont = UIFont.preferredFont(forTextStyle: .body)
+
+ /// Additional width to fix incorrect size calculating
+ private let additionalWidth: CGFloat = 5


### PR DESCRIPTION
1. Пофиксил открытие чата по пушу в macos
2. На маке MessageKit иногда неправильно рисует ячейку сообщения, последнее слово пропадает. Пофиксил это.