### PR TITLE
[trello.com/c/FZGCNq57] Fixed inconsistent status

### DIFF
--- a/Adamant/ServiceProtocols/RichMessageProviderWithStatusCheck/RichMessageProviderWithStatusCheck+Extension.swift
+++ b/Adamant/ServiceProtocols/RichMessageProviderWithStatusCheck/RichMessageProviderWithStatusCheck+Extension.swift
@@ -44,9 +44,8 @@ private extension RichMessageProviderWithStatusCheck {
             let messageDate = transaction.sentDate
         else { return false }
         
-        let end = messageDate.addingTimeInterval(consistencyMaxTime)
-        let dateRange = messageDate...end
+        let timeDifference = abs(transactionDate.timeIntervalSince(messageDate))
         
-        return dateRange.contains(transactionDate)
+        return timeDifference <= consistencyMaxTime
     }
 }

--- a/AdamantShared/Assets/l18n/de.lproj/Localizable.strings
+++ b/AdamantShared/Assets/l18n/de.lproj/Localizable.strings
@@ -887,10 +887,10 @@
 "TransactionStatus.Inconsistent" = "Inconsistent";
 
 /* Transaction status: inconsistent wrong timestamp */
-"TransactionStatus.Inconsistent.WrongTimestamp" = "Сообщение и транзакция имеют различное время. Это возможно, но лучше перепроверьте";
+"TransactionStatus.Inconsistent.WrongTimestamp" = "Nachricht und Tx haben unterschiedliche Zeitstempel. Es ist möglich, aber überprüfen Sie es zweimal";
 
 /* Transaction status: inconsistent reason title */
-"TransactionStatus.Inconsistent.Reason.Title" = "Противоречивая причина";
+"TransactionStatus.Inconsistent.Reason.Title" = "Inkonsistenter Grund";
 
 /* Transaction details: scene title */
 "TransactionDetailsScene.Title" = "Details";

--- a/AdamantShared/Assets/l18n/ru.lproj/Localizable.strings
+++ b/AdamantShared/Assets/l18n/ru.lproj/Localizable.strings
@@ -872,10 +872,10 @@
 "TransactionStatus.Inconsistent" = "Несогласованно";
 
 /* Transaction status: inconsistent wrong timestamp */
-"TransactionStatus.Inconsistent.WrongTimestamp" = "Nachricht und Tx haben unterschiedliche Zeitstempel. Es ist möglich, aber überprüfen Sie es zweimal";
+"TransactionStatus.Inconsistent.WrongTimestamp" = "Сообщение и транзакция имеют различное время. Это возможно, но лучше перепроверьте";
 
 /* Transaction status: inconsistent reason title */
-"TransactionStatus.Inconsistent.Reason.Title" = "Inkonsistenter Grund";
+"TransactionStatus.Inconsistent.Reason.Title" = "Противоречивая причина";
 
 /* Transaction details: scene title */
 "TransactionDetailsScene.Title" = "Подробности";


### PR DESCRIPTION
The problem is that the transaction was sent before the message, so it is not included in the segment `messageDate...end` , where `end` is `messageDate + consistencyMaxTime`

Solution: check the difference between `messageDate` and `txDate` is not bigger than `consistencyMaxTime`