### PR TITLE
[trello.com/c/PCRdHb2o] fix: no message deletion in the chat

### DIFF
--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -1113,6 +1113,7 @@ extension AdamantChatsProvider {
             
             // Update ID with recieved, add to unconfirmed transactions.
             transaction.transactionId = String(id)
+            transaction.chatMessageId = String(id)
             transaction.statusEnum = .pending
             
             if let index = unconfirmedTransactionsBySignature.firstIndex(


### PR DESCRIPTION
Issue: Deleting a recently sent message is not possible.
Resolution: The issue stems from the `chatMessageId`. It is generated before sending a message and is not updated afterward. As a result, the message cannot be found in the database when attempting to delete it