### PR TITLE
[trello.com/c/NYywQAGz] fix: recipient is re-checked

### DIFF
--- a/Adamant/Wallets/TransferViewControllerBase.swift
+++ b/Adamant/Wallets/TransferViewControllerBase.swift
@@ -496,6 +496,7 @@ class TransferViewControllerBase: FormViewController {
             markAddres(isValid: true)
             return true
         } else {
+            recipientAddress = nil
             markAddres(isValid: false)
             return false
         }


### PR DESCRIPTION
- Account ⟶ BTC ⟶ Send BTC
- Put bc1qe8y4708t8333vt3alfdzmf2gfwnjxsmt3htw2x address and any amount
- Tap send
- Cancel
- Delete the address
- Tap send

You’ll see “Do you want to send to bc1qe8y4708t8333vt3alfdzmf2gfwnjxsmt3htw2x”? (not expected)