### PR TITLE
[trello.com/c/CuwIeGst] fix: select all text when rename

### DIFF
--- a/Adamant/Services/AdamantDialogService.swift
+++ b/Adamant/Services/AdamantDialogService.swift
@@ -558,7 +558,10 @@ private class MailDelegate: NSObject, MFMailComposeViewControllerDelegate {
 extension AdamantDialogService {
     func selectAllTextFields(in alert: UIAlertController) {
         alert.textFields?.forEach { textField in
-            textField.selectAll(nil)
+            textField.selectedTextRange = textField.textRange(
+                from: textField.beginningOfDocument,
+                to: textField.endOfDocument
+            )
         }
     }
 }


### PR DESCRIPTION
The `textField.selectAll(nil)` method does not work correctly when the text volume is large. Replaced by `selectedTextRange`.