### PR TITLE
[trello.com/c/rPkNd6IB] fix: replace "updating" status

### DIFF
--- a/Adamant/Models/BTCRawTransaction.swift
+++ b/Adamant/Models/BTCRawTransaction.swift
@@ -35,7 +35,7 @@ struct BTCRawTransaction {
             transactionStatus = confirmations > 0 ? .success : .pending
         } else {
             confirmationsValue = nil
-            transactionStatus = .pending
+            transactionStatus = .notInitiated
         }
         
         // Transfers

--- a/Adamant/Models/TransactionStatus.swift
+++ b/Adamant/Models/TransactionStatus.swift
@@ -22,7 +22,7 @@ enum TransactionStatus: Int16 {
     var localized: String {
         switch self {
         case .notInitiated:
-            return .localized("TransactionStatus.Updating", comment: "Transaction status: updating in progress")
+            return "⏱"
         case .pending, .registered:
             return .localized("TransactionStatus.Pending", comment: "Transaction status: transaction is pending")
         case .success:

--- a/Adamant/Modules/Wallets/TransactionDetailsViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/TransactionDetailsViewControllerBase.swift
@@ -164,7 +164,7 @@ class TransactionDetailsViewControllerBase: FormViewController {
         return dateFormatter
     }()
     
-    static let awaitingValueString = "⏱"
+    static let awaitingValueString = TransactionStatus.notInitiated.localized
     
     private lazy var currencyFormatter: NumberFormatter = {
         return AdamantBalanceFormat.currencyFormatter(for: .full, currencySymbol: currencySymbol)


### PR DESCRIPTION
For `notInitiated` status we show "updating" status.
Replaced "updating" status with clock icon "⏱".