### PR TITLE
[trello.com/c/zUXIwW2y] Fixed a crash on wallets sorting

### DIFF
--- a/Adamant/Services/AdamantVisibleWalletsService.swift
+++ b/Adamant/Services/AdamantVisibleWalletsService.swift
@@ -223,7 +223,7 @@ final class AdamantVisibleWalletsService: VisibleWalletsService {
             
             let wallet = availableServices.remove(at: index)
             
-            if (0 ... availableServices.count).contains(newIndex) {
+            if availableServices.indices.contains(newIndex) {
                 availableServices.insert(wallet, at: newIndex)
             } else {
                 availableServices.append(wallet)

--- a/Adamant/Services/AdamantVisibleWalletsService.swift
+++ b/Adamant/Services/AdamantVisibleWalletsService.swift
@@ -222,7 +222,12 @@ final class AdamantVisibleWalletsService: VisibleWalletsService {
             }
             
             let wallet = availableServices.remove(at: index)
-            availableServices.insert(wallet, at: newIndex)
+            
+            if (0 ... availableServices.count).contains(newIndex) {
+                availableServices.insert(wallet, at: newIndex)
+            } else {
+                availableServices.append(wallet)
+            }
         }
         
         return availableServices


### PR DESCRIPTION
The algorithm was crashing in some situations when previously visible by default coins are no longer visible by default.

Example:
1. Make WOO visible by default in adamant-wallets
2. Replace WOO with ADM
3. Remove its visibility by default in adamant-wallets