### PR TITLE
[trello.com/c/pOZzbfOy] fixed bug: coin carousel scroll drop

### DIFF
--- a/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
+++ b/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
@@ -149,7 +149,7 @@ final class AdmWalletService: NSObject, WalletCoreProtocol {
             if wallet.balance != account.balance {
                 wallet.balance = account.balance
                 notify = true
-            } else if wallet.isBalanceInitialized {
+            } else if !wallet.isBalanceInitialized {
                 notify = true
             } else {
                 notify = false


### PR DESCRIPTION
The problem was that the wallet collection was being updated every 15 seconds. I believe that the data should only be updated if a wallet was previously uninitialized and then became initialized, or if its balance changed.