### PR TITLE
[trello.com/c/Xj60TSNy] Stuck requests fix

### DIFF
--- a/Adamant.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Adamant.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "d120af1e8638c7da36c8481fd61a66c0c08dc4fc",
-          "version": "5.4.4"
+          "revision": "bc268c28fb170f494de9e9927c371b8342979ece",
+          "version": "5.7.1"
         }
       },
       {

--- a/Adamant/Modules/Wallets/Doge/DogeWalletService+Send.swift
+++ b/Adamant/Modules/Wallets/Doge/DogeWalletService+Send.swift
@@ -76,6 +76,7 @@ extension DogeWalletService: WalletServiceTwoStepSend {
                 method: .post,
                 parameters: ["rawtx": txHex],
                 encoding: .json,
+                timeout: .common,
                 downloadProgress: { _ in }
             )
             

--- a/Adamant/Services/FilesNetworkManager/IPFSApiService.swift
+++ b/Adamant/Services/FilesNetworkManager/IPFSApiService.swift
@@ -49,6 +49,7 @@ final class IPFSApiService: FileApiServiceProtocol {
                 origin: origin,
                 path: IPFSApiCommands.file.upload,
                 models: [model],
+                timeout: .extended,
                 uploadProgress: uploadProgress
             )
         }
@@ -72,6 +73,7 @@ final class IPFSApiService: FileApiServiceProtocol {
             let result: APIResponseModel = await core.sendRequest(
                 origin: origin,
                 path: "\(IPFSApiCommands.file.download)\(id)",
+                timeout: .extended,
                 downloadProgress: downloadProgress
             )
             

--- a/CommonKit/Package.swift
+++ b/CommonKit/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/Alamofire/Alamofire.git",
-            .upToNextMinor(from: "5.4.2")
+            .upToNextMinor(from: "5.7.1")
         ),
         .package(path: "../BitcoinKit")
     ],

--- a/CommonKit/Sources/CommonKit/Protocols/APICoreProtocol.swift
+++ b/CommonKit/Sources/CommonKit/Protocols/APICoreProtocol.swift
@@ -72,6 +72,7 @@ public extension APICoreProtocol {
         method: HTTPMethod,
         parameters: Parameters,
         encoding: APIParametersEncoding,
+        timeout: TimeoutSize,
         downloadProgress: @escaping ((Progress) -> Void)
     ) async -> APIResponseModel {
         await sendRequestBasic(
@@ -80,7 +81,7 @@ public extension APICoreProtocol {
             method: method,
             parameters: parameters,
             encoding: encoding,
-            timeout: .extended,
+            timeout: timeout,
             downloadProgress: downloadProgress
         )
     }
@@ -130,6 +131,7 @@ public extension APICoreProtocol {
     func sendRequest(
         origin: NodeOrigin,
         path: String,
+        timeout: TimeoutSize,
         downloadProgress: @escaping ((Progress) -> Void)
     ) async -> ApiServiceResult<Data> {
         await sendRequest(
@@ -138,6 +140,7 @@ public extension APICoreProtocol {
             method: .get,
             parameters: emptyParameters,
             encoding: .url,
+            timeout: timeout,
             downloadProgress: downloadProgress
         ).result
     }
@@ -145,6 +148,7 @@ public extension APICoreProtocol {
     func sendRequest(
         origin: NodeOrigin,
         path: String,
+        timeout: TimeoutSize,
         downloadProgress: @escaping ((Progress) -> Void)
     ) async -> APIResponseModel {
         await sendRequest(
@@ -153,6 +157,7 @@ public extension APICoreProtocol {
             method: .get,
             parameters: emptyParameters,
             encoding: .url,
+            timeout: timeout,
             downloadProgress: downloadProgress
         )
     }
@@ -176,13 +181,14 @@ public extension APICoreProtocol {
         origin: NodeOrigin,
         path: String,
         models: [MultipartFormDataModel],
+        timeout: TimeoutSize,
         uploadProgress: @escaping ((Progress) -> Void)
     ) async -> ApiServiceResult<JSONOutput> {
         await sendRequestMultipartFormData(
             origin: origin,
             path: path,
             models: models,
-            timeout: .extended,
+            timeout: timeout,
             uploadProgress: uploadProgress
         ).result.flatMap { parseJSON(data: $0) }
     }


### PR DESCRIPTION
> The property `timeoutIntervalForRequest` determines the request timeout interval for all tasks within sessions based on this configuration. The request timeout interval controls how long (in seconds) a task should wait for additional data to arrive before giving up. The timer associated with this value is reset whenever new data arrives. When the request timer reaches the specified interval without receiving any new data, it triggers a timeout.
>

It seems that the system receives additional data instantly if it's an internal error and for some reason doesn't finish the request.

So I made the decision to use `timeoutIntervalForResource` that works for the entire request. But now it has different values for file requests and other common requests.