### PR TITLE
[trello.com/c/ciHCs1De]: fix not updating row height after balance change

### DIFF
--- a/Adamant/Modules/Wallets/WalletViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/WalletViewControllerBase.swift
@@ -156,7 +156,6 @@ class WalletViewControllerBase: FormViewController, WalletViewController {
         
         balanceRow.cell.selectionStyle = .gray
         balanceRow.cellUpdate { (cell, _) in
-            cell.accessoryType = .disclosureIndicator
             cell.titleLabel.text = BaseRows.balance.localized
         }.onCellSelection { [weak self] (_, _) in
             guard

--- a/Adamant/Modules/Wallets/WalletViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/WalletViewControllerBase.swift
@@ -120,6 +120,7 @@ class WalletViewControllerBase: FormViewController, WalletViewController {
         
         // MARK: Balance
         let balanceRow = BalanceRow { [weak self] in
+            $0.cell.accessoryType = .disclosureIndicator
             $0.tag = BaseRows.balance.tag
             $0.cell.titleLabel.text = BaseRows.balance.localized
             
@@ -134,24 +135,9 @@ class WalletViewControllerBase: FormViewController, WalletViewController {
                 alert: self?.service?.core.wallet?.notifications,
                 isBalanceInitialized: self?.service?.core.wallet?.isBalanceInitialized ?? false
             )
-            
-            let height = $0.value?.fiat != nil ? BalanceTableViewCell.fullHeight : BalanceTableViewCell.compactHeight
-            
-            $0.cell.height = { height }
-        }.cellUpdate { [weak self] (cell, row) in
-            let symbol = self?.service?.core.tokenSymbol ?? ""
-            
-            row.value = self?.balanceRowValueFor(
-                balance: self?.service?.core.wallet?.balance ?? 0,
-                symbol: symbol,
-                alert: self?.service?.core.wallet?.notifications,
-                isBalanceInitialized: self?.service?.core.wallet?.isBalanceInitialized ?? false
-            )
-            
-            let height = row.value?.fiat != nil ? BalanceTableViewCell.fullHeight : BalanceTableViewCell.compactHeight
-            
-            cell.height = { height }
-            cell.titleLabel.text = BaseRows.balance.localized
+
+            let row = $0
+            $0.cell.height = { row.value?.fiat != nil ? BalanceTableViewCell.fullHeight : BalanceTableViewCell.compactHeight }
         }
         
         balanceRow.cell.selectionStyle = .gray
@@ -487,6 +473,7 @@ private extension WalletViewControllerBase {
             isBalanceInitialized: wallet.isBalanceInitialized
         )
         row.updateCell()
+        row.reload()
     }
     
     func makeNodesList() -> UIViewController {


### PR DESCRIPTION
`.cellUpdate` from 141 line was overwritten in 158 line. So, code from line 141 is useless, we can delete it. But it was not the only reason caused bug.

Now height of balance cell is calculated based on current row ViewModel: `$0.cell.height = { row.value?.fiat != nil ? BalanceTableViewCell.fullHeight : BalanceTableViewCell.compactHeight }`.

According to docs, to update cell height (not the content), we should call `updateCell` just before `reload` call. Without `reload` call height of cell will not be updated