### PR TITLE
[trello.com/c/WmyCJE1a] Fix rename alert on Partner's QR screen.

### DIFF
--- a/Adamant/Modules/PartnerQR/PartnerQRViewModel.swift
+++ b/Adamant/Modules/PartnerQR/PartnerQRViewModel.swift
@@ -225,7 +225,7 @@ private extension PartnerQRViewModel {
         alert.addTextField { [weak self] textField in
             textField.placeholder = .adamant.chat.name
             textField.autocapitalizationType = .words
-            textField.text = self?.addressBookService.getName(for: address)
+            textField.text = self?.addressBookService.getName(for: address) ?? self?.partnerName
         }
         
         let renameAction = UIAlertAction(


### PR DESCRIPTION
There was a problem: partner contacts created by the application have not been saved in CoreData's address book when creating the contacts list. So then, when creating the alert controller with TextField the app was trying to get the saved contact from the address book.