### PR TITLE
trello.com/c/Uh04lfmQ default "fastest node" button value

### DIFF
--- a/Adamant/Modules/CoinsNodesList/ViewModel/CoinsNodesListViewModel.swift
+++ b/Adamant/Modules/CoinsNodesList/ViewModel/CoinsNodesListViewModel.swift
@@ -47,6 +47,8 @@ final class CoinsNodesListViewModel: ObservableObject {
 
 private extension CoinsNodesListViewModel {
     func setup() {
+        setInitialFastestModeState()
+
         state.sections = processedGroups.compactMap {
             guard let info = apiServiceCompose.get($0)?.nodesInfo else { return nil }
             return mapper.map(group: $0, nodesInfo: info)
@@ -93,5 +95,12 @@ private extension CoinsNodesListViewModel {
         processedGroups.forEach {
             apiServiceCompose.get($0)?.healthCheck()
         }
+    }
+    
+    func setInitialFastestModeState() {
+        // We are getting any group from params storage on init, because the
+        // setting of fastest mode affects all the nodes except adamant,
+        // which are set in other ViewController
+        state.fastestNodeMode = nodesAdditionalParamsStorage.isFastestNodeMode(group: .dash)
     }
 }


### PR DESCRIPTION
By default, all items except .amd should have a value of true. The current fix adjusts the default logic to ensure it functions correctly.