### PR TITLE
[trello.com/c/etjLStc6] KVS-related code refactoring

### DIFF
--- a/Adamant/Services/AdamantAddressBookService.swift
+++ b/Adamant/Services/AdamantAddressBookService.swift
@@ -90,7 +90,7 @@ final class AdamantAddressBookService: AddressBookService {
     // MARK: - Observer Actions
     
     private func userWillLogOut() async {
-        guard hasChanges else {
+        guard hasChanges, let keypair = accountService.keypair else {
             return
         }
         
@@ -99,7 +99,7 @@ final class AdamantAddressBookService: AddressBookService {
             self.savingBookOnLogoutTaskId = .invalid
         }
         
-        _ = try? await saveAddressBook(self.addressBook)
+        _ = try? await saveAddressBook(self.addressBook, keypair: keypair)
         
         UIApplication.shared.endBackgroundTask(savingBookOnLogoutTaskId)
         savingBookOnLogoutTaskId = .invalid
@@ -214,7 +214,7 @@ final class AdamantAddressBookService: AddressBookService {
     // MARK: - Saving
     
     func saveIfNeeded() async {
-        guard hasChanges else {
+        guard hasChanges, let keypair = accountService.keypair else {
             return
         }
         
@@ -224,7 +224,7 @@ final class AdamantAddressBookService: AddressBookService {
             self.savingBookTaskId = .invalid
         }
         
-        guard let id = try? await saveAddressBook(addressBook) else {
+        guard let id = try? await saveAddressBook(addressBook, keypair: keypair) else {
             return
         }
         
@@ -249,8 +249,8 @@ final class AdamantAddressBookService: AddressBookService {
         self.savingBookTaskId = .invalid
     }
     
-    private func saveAddressBook(_ book: [String: String]) async throws -> UInt64 {
-        guard let loggedAccount = accountService.account, let keypair = accountService.keypair else {
+    private func saveAddressBook(_ book: [String: String], keypair: Keypair) async throws -> UInt64 {
+        guard let loggedAccount = accountService.account else {
             throw AddressBookServiceError.notLogged
         }
         
@@ -279,13 +279,11 @@ final class AdamantAddressBookService: AddressBookService {
         // MARK: 2. Submit to KVS
         
         do {
-            let id = try await apiService.store(
+            let id = try await apiService.store(.init(
                 key: addressBookKey,
                 value: value,
-                type: .keyValue,
-                sender: address,
                 keypair: keypair
-            ).get()
+            )).get()
             
             return id
         } catch let error {

--- a/CommonKit/Sources/CommonKit/Models/KVSValueModel.swift
+++ b/CommonKit/Sources/CommonKit/Models/KVSValueModel.swift
@@ -1,0 +1,22 @@
+//
+//  KVSValueModel.swift
+//  CommonKit
+//
+//  Created by Andrew G on 15.01.2025.
+//
+
+public struct KVSValueModel: Sendable {
+    public let key: String
+    public let value: String
+    public let keypair: Keypair
+    
+    public init(
+        key: String,
+        value: String,
+        keypair: Keypair
+    ) {
+        self.key = key
+        self.value = value
+        self.keypair = keypair
+    }
+}

--- a/CommonKit/Sources/CommonKit/Protocols/AdamantApiServiceProtocol.swift
+++ b/CommonKit/Sources/CommonKit/Protocols/AdamantApiServiceProtocol.swift
@@ -74,13 +74,7 @@ public protocol AdamantApiServiceProtocol: ApiServiceProtocol {
     // MARK: - States
     
     /// - Returns: Transaction ID
-    func store(
-        key: String,
-        value: String,
-        type: StateType,
-        sender: String,
-        keypair: Keypair
-    ) async -> ApiServiceResult<UInt64>
+    func store(_ model: KVSValueModel) async -> ApiServiceResult<UInt64>
     
     func get(
         key: String,

--- a/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApi+States.swift
+++ b/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApi+States.swift
@@ -20,27 +20,27 @@ public extension ApiCommands {
 extension AdamantApiService {
     public static let KvsFee: Decimal = 0.001
     
-    public func store(
-        key: String,
-        value: String,
-        type: StateType,
-        sender: String,
-        keypair: Keypair
-    ) async -> ApiServiceResult<UInt64> {
+    public func store(_ model: KVSValueModel) async -> ApiServiceResult<UInt64> {
         let transaction = NormalizedTransaction(
             type: .state,
             amount: .zero,
-            senderPublicKey: keypair.publicKey,
+            senderPublicKey: model.keypair.publicKey,
             requesterPublicKey: nil,
             date: .now,
             recipientId: nil,
-            asset: TransactionAsset(state: StateAsset(key: key, value: value, type: .keyValue))
+            asset: TransactionAsset(state: StateAsset(
+                key: model.key,
+                value: model.value,
+                type: .keyValue
+            ))
         )
         
         guard let transaction = adamantCore.makeSignedTransaction(
             transaction: transaction,
-            senderId: sender,
-            keypair: keypair
+            senderId: AdamantUtilities.generateAddress(
+                publicKey: model.keypair.publicKey
+            ),
+            keypair: model.keypair
         ) else {
             return .failure(.internalError(error: InternalAPIError.signTransactionFailed))
         }


### PR DESCRIPTION
**Before:**
A blockchain address is passed as a parameter, the keypair is being received just before sending the address to the KVS. It can cause inconsistency and bugs such as saving a blockchain address from an old account to a new account's storage.

**After:**
A model, containing all the required data, is generated on wallet initialization. Then it's passed to methods to store data in KVS. No more inconsistency.