### PR TITLE
[trello.com/c/rxAVDtVH]: EthWalletService tests

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -474,6 +474,15 @@
 		AAFB3C952D31C58B000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C942D31C587000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift */; };
 		AAFB3C972D31CB72000CCCE9 /* UnspentTransaction+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C962D31CB6B000CCCE9 /* UnspentTransaction+Equatable.swift */; };
 		AAFB3C992D357E1D000CCCE9 /* BtcWalletServiceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C982D357E16000CCCE9 /* BtcWalletServiceIntegrationTests.swift */; };
+		AAFB3C9B2D383BB1000CCCE9 /* EthWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C9A2D383BA9000CCCE9 /* EthWalletServiceTests.swift */; };
+		AAFB3C9D2D383F7D000CCCE9 /* EthApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C9C2D383F73000CCCE9 /* EthApiServiceProtocolMock.swift */; };
+		AAFB3C9F2D3843E0000CCCE9 /* Web3ProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C9E2D3843D8000CCCE9 /* Web3ProviderMock.swift */; };
+		AAFB3CA12D384AF7000CCCE9 /* IncreaseFeeServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3CA02D384AF5000CCCE9 /* IncreaseFeeServiceMock.swift */; };
+		AAFB3CA32D384F52000CCCE9 /* IEthMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3CA22D384F4D000CCCE9 /* IEthMock.swift */; };
+		AAFB3CA52D3854BB000CCCE9 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3CA42D3854B7000CCCE9 /* MockURLProtocol.swift */; };
+		AAFB3CA72D385BBE000CCCE9 /* EthRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3CA62D385BBB000CCCE9 /* EthRequestBody.swift */; };
+		AAFB3CA92D3860F2000CCCE9 /* EthResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3CA82D3860EC000CCCE9 /* EthResponseBody.swift */; };
+		AAFB3CAB2D3997DD000CCCE9 /* EthApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3CAA2D3997D8000CCCE9 /* EthApiServiceProtocol.swift */; };
 		E90055F520EBF5DA00D0CB2D /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90055F420EBF5DA00D0CB2D /* AboutViewController.swift */; };
 		E90055F720EC200900D0CB2D /* SecurityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90055F620EC200900D0CB2D /* SecurityViewController.swift */; };
 		E90055F920ECD86800D0CB2D /* SecurityViewController+StayIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90055F820ECD86800D0CB2D /* SecurityViewController+StayIn.swift */; };
@@ -1110,6 +1119,15 @@
 		AAFB3C942D31C587000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinKitTransactionFactoryProtocolMock.swift; sourceTree = "<group>"; };
 		AAFB3C962D31CB6B000CCCE9 /* UnspentTransaction+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnspentTransaction+Equatable.swift"; sourceTree = "<group>"; };
 		AAFB3C982D357E16000CCCE9 /* BtcWalletServiceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BtcWalletServiceIntegrationTests.swift; sourceTree = "<group>"; };
+		AAFB3C9A2D383BA9000CCCE9 /* EthWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthWalletServiceTests.swift; sourceTree = "<group>"; };
+		AAFB3C9C2D383F73000CCCE9 /* EthApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthApiServiceProtocolMock.swift; sourceTree = "<group>"; };
+		AAFB3C9E2D3843D8000CCCE9 /* Web3ProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Web3ProviderMock.swift; sourceTree = "<group>"; };
+		AAFB3CA02D384AF5000CCCE9 /* IncreaseFeeServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncreaseFeeServiceMock.swift; sourceTree = "<group>"; };
+		AAFB3CA22D384F4D000CCCE9 /* IEthMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IEthMock.swift; sourceTree = "<group>"; };
+		AAFB3CA42D3854B7000CCCE9 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
+		AAFB3CA62D385BBB000CCCE9 /* EthRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthRequestBody.swift; sourceTree = "<group>"; };
+		AAFB3CA82D3860EC000CCCE9 /* EthResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthResponseBody.swift; sourceTree = "<group>"; };
+		AAFB3CAA2D3997D8000CCCE9 /* EthApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthApiServiceProtocol.swift; sourceTree = "<group>"; };
 		AD258997F050B24C0051CC8D /* Pods-Adamant.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adamant.release.xcconfig"; path = "Target Support Files/Pods-Adamant/Pods-Adamant.release.xcconfig"; sourceTree = "<group>"; };
 		ADDFD2FA17E41CCBD11A1733 /* Pods-Adamant.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adamant.debug.xcconfig"; path = "Target Support Files/Pods-Adamant/Pods-Adamant.debug.xcconfig"; sourceTree = "<group>"; };
 		E90055F420EBF5DA00D0CB2D /* AboutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
@@ -2262,6 +2280,7 @@
 		AA33BEB02D303C470083E59C /* Wallets */ = {
 			isa = PBXGroup;
 			children = (
+				AAFB3C9A2D383BA9000CCCE9 /* EthWalletServiceTests.swift */,
 				AAFB3C982D357E16000CCCE9 /* BtcWalletServiceIntegrationTests.swift */,
 				AA33BEB12D303C5F0083E59C /* BtcWalletServiceTests.swift */,
 			);
@@ -2271,6 +2290,12 @@
 		AA33BEB32D303CA30083E59C /* Stubs */ = {
 			isa = PBXGroup;
 			children = (
+				AAFB3CA82D3860EC000CCCE9 /* EthResponseBody.swift */,
+				AAFB3CA62D385BBB000CCCE9 /* EthRequestBody.swift */,
+				AAFB3CA22D384F4D000CCCE9 /* IEthMock.swift */,
+				AAFB3CA02D384AF5000CCCE9 /* IncreaseFeeServiceMock.swift */,
+				AAFB3C9E2D3843D8000CCCE9 /* Web3ProviderMock.swift */,
+				AAFB3C9C2D383F73000CCCE9 /* EthApiServiceProtocolMock.swift */,
 				AAFB3C942D31C587000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift */,
 				AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */,
 				AA33BEB52D303DB60083E59C /* APICoreProtocolMock.swift */,
@@ -2282,6 +2307,7 @@
 		AAFB3C892D31C0C4000CCCE9 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AAFB3CA42D3854B7000CCCE9 /* MockURLProtocol.swift */,
 				AAFB3C962D31CB6B000CCCE9 /* UnspentTransaction+Equatable.swift */,
 				AAFB3C902D31C140000CCCE9 /* BitcoinKitTransaction+Equatable.swift */,
 				AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */,
@@ -2640,6 +2666,7 @@
 		E94008792114ECF100CD2D67 /* Ethereum */ = {
 			isa = PBXGroup;
 			children = (
+				AAFB3CAA2D3997D8000CCCE9 /* EthApiServiceProtocol.swift */,
 				E940087C2114EDEE00CD2D67 /* EthWallet.swift */,
 				E993302121354BC300CD5200 /* EthWalletFactory.swift */,
 				E940087A2114ED0600CD2D67 /* EthWalletService.swift */,
@@ -3621,6 +3648,7 @@
 				E9AA8C02212C5BF500F9249F /* AdmWalletService+Send.swift in Sources */,
 				E90847332196FEA80095825D /* TransferTransaction+CoreDataProperties.swift in Sources */,
 				9366588D2B0AB6BD00BDB2D3 /* CoinsNodesListState.swift in Sources */,
+				AAFB3CAB2D3997DD000CCCE9 /* EthApiServiceProtocol.swift in Sources */,
 				E99818942120892F0018C84C /* WalletViewControllerBase.swift in Sources */,
 				3AA6DF462BA9BEB700EA2E16 /* MediaContentView.swift in Sources */,
 				E9B3D39E201F99F40019EB36 /* DataProvider.swift in Sources */,
@@ -3875,16 +3903,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAFB3C972D31CB72000CCCE9 /* UnspentTransaction+Equatable.swift in Sources */,
+				AAFB3CA92D3860F2000CCCE9 /* EthResponseBody.swift in Sources */,
+				AAFB3C9D2D383F7D000CCCE9 /* EthApiServiceProtocolMock.swift in Sources */,
 				AAFB3C992D357E1D000CCCE9 /* BtcWalletServiceIntegrationTests.swift in Sources */,
+				AAFB3C9F2D3843E0000CCCE9 /* Web3ProviderMock.swift in Sources */,
 				AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */,
+				AAFB3CA72D385BBE000CCCE9 /* EthRequestBody.swift in Sources */,
 				AA33BEB92D3044760083E59C /* BtcApiServiceProtocolMock.swift in Sources */,
+				AAFB3CA52D3854BB000CCCE9 /* MockURLProtocol.swift in Sources */,
+				AAFB3C9B2D383BB1000CCCE9 /* EthWalletServiceTests.swift in Sources */,
 				AA33BEB22D303C730083E59C /* BtcWalletServiceTests.swift in Sources */,
 				AA33BEB72D3041A30083E59C /* AddressConverterMock.swift in Sources */,
 				AAFB3C8D2D31C0EE000CCCE9 /* Result+Extensions.swift in Sources */,
 				AA33BEB62D303E240083E59C /* APICoreProtocolMock.swift in Sources */,
 				AAFB3C912D31C14A000CCCE9 /* BitcoinKitTransaction+Equatable.swift in Sources */,
 				AAFB3C8B2D31C0DD000CCCE9 /* Actor+Extensions.swift in Sources */,
+				AAFB3CA32D384F52000CCCE9 /* IEthMock.swift in Sources */,
 				AAFB3C952D31C58B000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift in Sources */,
+				AAFB3CA12D384AF7000CCCE9 /* IncreaseFeeServiceMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Adamant/Modules/Wallets/Ethereum/EthApiService.swift
+++ b/Adamant/Modules/Wallets/Ethereum/EthApiService.swift
@@ -11,7 +11,7 @@ import Foundation
 import web3swift
 @preconcurrency import Web3Core
 
-class EthApiService: ApiServiceProtocol, @unchecked Sendable {
+class EthApiService: EthApiServiceProtocol, @unchecked Sendable {
     let api: BlockchainHealthCheckWrapper<EthApiCore>
     
     var keystoreManager: KeystoreManager? {

--- a/Adamant/Modules/Wallets/Ethereum/EthApiServiceProtocol.swift
+++ b/Adamant/Modules/Wallets/Ethereum/EthApiServiceProtocol.swift
@@ -1,0 +1,25 @@
+//
+//  EthApiServiceProtocol.swift
+//  Adamant
+//
+//  Created by Christian Benua on 16.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CommonKit
+import web3swift
+@preconcurrency import Web3Core
+
+protocol EthApiServiceProtocol: ApiServiceProtocol {
+    func requestWeb3<Output>(
+        waitsForConnectivity: Bool,
+        _ request: @Sendable @escaping (Web3) async throws -> Output
+    ) async -> WalletServiceResult<Output>
+    
+    func requestApiCore<Output>(
+        waitsForConnectivity: Bool,
+        _ request: @Sendable @escaping (APICoreProtocol, NodeOrigin) async -> ApiServiceResult<Output>
+    ) async -> WalletServiceResult<Output>
+    
+    func setKeystoreManager(_ keystoreManager: KeystoreManager) async
+}

--- a/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
+++ b/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
@@ -138,7 +138,7 @@ final class EthWalletService: WalletCoreProtocol, @unchecked Sendable {
     // MARK: - Dependencies
     weak var accountService: AccountService?
     var apiService: AdamantApiServiceProtocol!
-    var ethApiService: EthApiService!
+    var ethApiService: EthApiServiceProtocol!
     var dialogService: DialogService!
     var increaseFeeService: IncreaseFeeService!
     var vibroService: VibroService!
@@ -580,6 +580,15 @@ extension EthWalletService {
         }
 	}
 }
+
+#if DEBUG
+extension EthWalletService {
+    @available(*, deprecated, message: "For testing purposes only")
+    func setWalletForTests(_ wallet: EthWallet?) {
+        self.ethWallet = wallet
+    }
+}
+#endif
 
 // MARK: - KVS
 extension EthWalletService {

--- a/AdamantTests/Extensions/MockURLProtocol.swift
+++ b/AdamantTests/Extensions/MockURLProtocol.swift
@@ -1,0 +1,76 @@
+//
+//  URLProtocolMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 15.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import XCTest
+import Foundation
+
+final class MockURLProtocol: URLProtocol {
+    typealias Handler = (URLRequest) throws -> (HTTPURLResponse, Data)?
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+    
+    static var requestHandler: Handler?
+    
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocolDidFinishLoading(self)
+            XCTFail("No request handler provided")
+            return
+        }
+        
+        do {
+            guard let (response, data) = try handler(request) else {
+                client?.urlProtocolDidFinishLoading(self)
+                XCTFail("No request handler provided")
+                return
+            }
+            
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            XCTFail("Error handling request, url: \(String(describing: request.url)): error \(error)")
+        }
+    }
+    
+    override func stopLoading() {}
+}
+
+extension Data {
+    init(reading input: InputStream) {
+        self.init()
+        input.open()
+        
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        while input.hasBytesAvailable {
+            let read = input.read(buffer, maxLength: bufferSize)
+            if (read == 0) {
+                break  // added
+            }
+            self.append(buffer, count: read)
+        }
+        buffer.deallocate()
+        
+        input.close()
+    }
+}
+
+extension MockURLProtocol {
+    static func combineHandlers(_ prevHandler: Handler?, _ new: @escaping Handler) -> Handler {
+        { request in            
+            return try new(request) ?? prevHandler?(request)
+        }
+    }
+}

--- a/AdamantTests/Modules/Wallets/EthWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/EthWalletServiceTests.swift
@@ -1,0 +1,286 @@
+//
+//  EthWalletServiceTests.swift
+//  Adamant
+//
+//  Created by Christian Benua on 15.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import XCTest
+@testable import Adamant
+import CommonKit
+import Web3Core
+@testable import web3swift
+import BigInt
+
+final class EthWalletServiceTests: XCTestCase {
+    private var sut: EthWalletService!
+
+    private var apiCoreMock: APICoreProtocolMock!
+    private var ethApiMock: EthApiServiceProtocolMock!
+    private var walletStorage: EthWalletStorage!
+    private var web3ProviderMock: Web3ProviderMock!
+    private var increaseFeeServiceMock: IncreaseFeeServiceMock!
+    private var keystoreManager: KeystoreManager!
+    private var ethMock: IEthMock!
+    private var web3: Web3!
+    private var session: URLSession!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        apiCoreMock = APICoreProtocolMock()
+        ethApiMock = EthApiServiceProtocolMock()
+        web3ProviderMock = Web3ProviderMock()
+        web3 = Web3(provider: web3ProviderMock)
+        ethMock = IEthMock()
+        web3.ethInstance = ethMock
+        ethMock._provider = web3ProviderMock
+        ethApiMock.api = EthApiCore(apiCore: apiCoreMock)
+        ethApiMock.web3 = web3
+        session = makeSession()
+        web3ProviderMock.session = session
+        let store = try XCTUnwrap(try makeKeystore())
+        
+        walletStorage = .init(keystore: store, unicId: "ERC20ETH")
+        keystoreManager = .init([store])
+        increaseFeeServiceMock = IncreaseFeeServiceMock()
+        
+        sut = EthWalletService()
+        sut.increaseFeeService = increaseFeeServiceMock
+        sut.setWalletForTests(walletStorage.getWallet())
+        sut.ethApiService = ethApiMock
+    }
+    
+    override func tearDown() {
+        sut = nil
+        apiCoreMock = nil
+        ethApiMock = nil
+        walletStorage = nil
+        web3ProviderMock = nil
+        increaseFeeServiceMock = nil
+        web3 = nil
+        keystoreManager = nil
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+    
+    func test_createTransaction_noWalletThrowsError() async throws {
+        // given
+        sut.setWalletForTests(nil)
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: "recipient",
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notLogged)
+    }
+    
+    func test_createTransaction_invalidAddressThrowsError() async throws {
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.invalidEthAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+    }
+    
+    func test_createTransaction_invalidAmountThrowsError() async throws {
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.toEthAddress,
+                amount: Decimal.nan,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .invalidAmount(.nan))
+    }
+    
+    func test_createTransaction_noKeystoreManagerThrowsError() async throws {
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.toEthAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertEqual(
+            result.error as? WalletServiceError,
+            .internalError(message: "Failed to get web3.provider.KeystoreManager", error: nil)
+        )
+    }
+    
+    func test_createTransaction_correctFields() async throws {
+        // given
+        await setupKeyStoreManager()
+        makeTransactionsCountMock()
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.toEthAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertNil(result.error)
+        let transaction = try XCTUnwrap(result.value)
+        XCTAssertEqual(transaction.from?.address, Constants.ethAddress)
+        XCTAssertEqual(transaction.to.address, Constants.toEthAddress)
+        XCTAssertEqual(transaction.nonce, BigUInt(exactly: Constants.nonce))
+        XCTAssertEqual(transaction.gasPrice, BigUInt(clamping: 11).toWei())
+        XCTAssertEqual(transaction.encode(), Constants.expectedTxData)
+        XCTAssertEqual(transaction.hashForSignature(), Constants.extectedSignatureHash)
+    }
+    
+    func test_createAndSendTransaction_sendsCorrectData() async throws {
+        // given
+        var didCallSendMock = false
+        await setupKeyStoreManager()
+        makeTransactionsCountMock()
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.toEthAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        let transaction = try XCTUnwrap(result.value)
+        let data = try XCTUnwrap(transaction.encode())
+        let hash = data.toHexString().addHexPrefix()
+        makeEthSendMock(expectedHash: hash) { didCallSendMock = true }
+        
+        let sendResult = await Result {
+            try await self.sut.sendTransaction(transaction)
+        }
+        
+        // then
+        XCTAssertNil(sendResult.error)
+        XCTAssertTrue(ethMock.invokedSendRaw)
+        XCTAssertTrue(didCallSendMock)
+    }
+    
+    private func setupKeyStoreManager() async {
+        await ethApiMock.setKeystoreManager(keystoreManager)
+        web3ProviderMock.attachedKeystoreManager = keystoreManager
+    }
+    
+    private func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    private func makeTransactionsCountMock() {
+        let prevHandler = MockURLProtocol.requestHandler
+        MockURLProtocol.requestHandler = MockURLProtocol.combineHandlers(
+            prevHandler
+        ) { request in
+            guard let stream = request.httpBodyStream else { return nil }
+
+            let ethBody = try JSONDecoder().decode(EthRequestBody.self, from: Data(reading: stream))
+            guard ethBody.method == Constants.transactionCountResponseMethod else { return nil }
+            
+            return try self.makeResponseAndMockData(
+                url: request.url!,
+                ethResponse: EthAPIResponse(result: "\(Constants.nonce)")
+            )
+        }
+    }
+
+    private func makeEthSendMock(expectedHash: String, _ onCall: @escaping () -> Void) {
+        let prevHandler = MockURLProtocol.requestHandler
+        MockURLProtocol.requestHandler = MockURLProtocol.combineHandlers(
+            prevHandler
+        ) { request in
+            guard let stream = request.httpBodyStream else { return nil }
+
+            let ethBody = try JSONDecoder().decode(EthRequestBody.self, from: Data(reading: stream))
+            guard ethBody.method == Constants.sendTransactionResponseMethod else { return nil }
+
+            XCTAssertEqual(ethBody.params[0] as? String, expectedHash)
+            onCall()
+            return try self.makeResponseAndMockData(
+                url: request.url!,
+                ethResponse: EthAPIResponse(result: expectedHash)
+            )
+        }
+    }
+
+    private func makeResponseAndMockData<T: Codable>(
+        url: URL,
+        ethResponse: EthAPIResponse<T>
+    ) throws -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+
+        let mockData = try JSONEncoder().encode(ethResponse)
+        return (response, mockData)
+    }
+    
+    private func makeKeystore() throws -> BIP32Keystore? {
+        try BIP32Keystore(
+            mnemonics: "village lunch say patrol glow first hurt shiver name method dolphin sample",
+            password: EthWalletService.walletPassword,
+            mnemonicsPassword: "",
+            language: .english,
+            prefixPath: EthWalletService.walletPath
+        )
+    }
+}
+
+private enum Constants {
+    static let transactionCountResponseMethod = "eth_getTransactionCount"
+    static let sendTransactionResponseMethod = "eth_sendRawTransaction"
+
+    static let extectedSignatureHash = Data([
+        96, 116, 68, 167, 52, 14, 211, 94, 127, 63, 95, 104, 12, 204, 124,
+        91, 13, 9, 179, 80, 252, 71, 102, 108, 115, 61, 254, 105, 0, 115, 81, 242
+    ])
+    static let expectedTxData = Data([
+            248, 108, 2, 133, 2, 143, 166, 174, 0, 130, 94, 136, 148, 171, 253, 245,
+            5, 255, 213, 88, 125, 158, 119, 7, 223, 180, 127, 69, 175, 31, 3, 226, 117,
+            136, 138, 199, 35, 4, 137, 232, 0, 0, 128, 36, 160, 142, 188, 94, 138, 169,
+            58, 131, 110, 28, 87, 29, 119, 40, 126, 98, 187, 13, 210, 2, 58, 244, 151, 234,
+            149, 49, 14, 49, 195, 53, 129, 29, 40, 160, 79, 100, 92, 44, 207, 73, 57, 12, 184,
+            108, 82, 24, 242, 197, 97, 151, 32, 107, 254, 152, 1, 73, 147, 254, 141, 113, 51,
+            45, 211, 225, 3, 2
+    ])
+
+    static let nonce = 2
+
+    static let ethAddress = "0xBA5CE20aE344CDBd6eAA01ffdDF1976d35Be142d"
+    static let toEthAddress = "0xabfDF505fFd5587D9E7707dFB47F45AF1f03E275"
+    static let invalidEthAddress = "0xBA5CE20aE344CDBd6eAA01ffdDF1976d35Be14"
+}

--- a/AdamantTests/Modules/Wallets/EthWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/EthWalletServiceTests.swift
@@ -124,10 +124,12 @@ final class EthWalletServiceTests: XCTestCase {
         })
         
         // then
-        XCTAssertEqual(
-            result.error as? WalletServiceError,
-            .internalError(message: "Failed to get web3.provider.KeystoreManager", error: nil)
-        )
+        switch result.error as? WalletServiceError {
+        case .internalError?:
+            break
+        default:
+            XCTFail("Expected `.internalError`, got :\(String(describing: result.error))")
+        }
     }
     
     func test_createTransaction_correctFields() async throws {

--- a/AdamantTests/Stubs/EthApiServiceProtocolMock.swift
+++ b/AdamantTests/Stubs/EthApiServiceProtocolMock.swift
@@ -1,0 +1,56 @@
+//
+//  EthApiServiceProtocolMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 15.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import CommonKit
+import Foundation
+import web3swift
+@preconcurrency import Web3Core
+
+final class EthApiServiceProtocolMock: EthApiServiceProtocol {
+    
+    var api: EthApiCore!
+    var web3: Web3!
+    
+    func requestWeb3<Output>(
+        waitsForConnectivity: Bool,
+        _ request: @escaping @Sendable (Web3) async throws -> Output
+    ) async -> WalletServiceResult<Output>  {
+        await api.performRequest(
+            origin: NodeOrigin(url: URL(string: "http://samplenodeorigin.com")!)
+        ) { _ in
+            try await request(self.web3)
+        }
+    }
+    
+    func requestApiCore<Output>(
+        waitsForConnectivity: Bool,
+        _ request: @escaping @Sendable (APICoreProtocol, NodeOrigin) async -> ApiServiceResult<Output>
+    ) async -> WalletServiceResult<Output> {
+        await request(
+            api.apiCore,
+            NodeOrigin(url: URL(string: "http://samplenodeorigin.com")!)
+        ).mapError { $0.asWalletServiceError() }
+    }
+    
+    func setKeystoreManager(_ keystoreManager: KeystoreManager) async {
+        await api.setKeystoreManager(keystoreManager)
+    }
+    
+    var nodesInfo: CommonKit.NodesListInfo {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var nodesInfoPublisher: CommonKit.AnyObservable<CommonKit.NodesListInfo> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func healthCheck() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/EthRequestBody.swift
+++ b/AdamantTests/Stubs/EthRequestBody.swift
@@ -1,0 +1,25 @@
+//
+//  EthRequestBody.swift
+//  Adamant
+//
+//  Created by Christian Benua on 16.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Web3Core
+
+struct EthRequestBody: Decodable {
+    var method: String
+    var params: [Any]
+    
+    enum CodingKeys: String, CodingKey {
+        case method
+        case params
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.method = try container.decode(String.self, forKey: .method)
+        self.params = try container.decode([Any].self, forKey: .params)
+    }
+}

--- a/AdamantTests/Stubs/EthResponseBody.swift
+++ b/AdamantTests/Stubs/EthResponseBody.swift
@@ -1,0 +1,19 @@
+//
+//  EthResponseBody.swift
+//  Adamant
+//
+//  Created by Christian Benua on 16.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+struct EthAPIResponse<Result: Codable>: Codable {
+    var id: Int = 1
+    var jsonrpc = "2.0"
+    var result: Result
+    
+    init(id: Int = 1, jsonrpc: String = "2.0", result: Result) {
+        self.id = id
+        self.jsonrpc = jsonrpc
+        self.result = result
+    }
+}

--- a/AdamantTests/Stubs/IEthMock.swift
+++ b/AdamantTests/Stubs/IEthMock.swift
@@ -1,0 +1,112 @@
+//
+//  IEthMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 15.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+import BigInt
+import web3swift
+import Web3Core
+@testable import Adamant
+
+final class IEthMock: IEth {
+    var provider: Web3Provider {
+        _provider
+    }
+    
+    var _provider: Web3Provider! {
+        didSet {
+            ethDefault._provider = _provider
+        }
+    }
+    
+    var ethDefault: EthDefault = EthDefault()
+    
+    func callTransaction(_ transaction: CodableTransaction) async throws -> Data {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func send(_ transaction: CodableTransaction) async throws -> TransactionSendingResult {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var invokedSendRaw: Bool = false
+    var invokedSendRawParameters: Data?
+    
+    func send(raw data: Data) async throws -> TransactionSendingResult {
+        invokedSendRaw = true
+        invokedSendRawParameters = data
+        return try await ethDefault.send(raw: data)
+    }
+    
+    var stubbedEstimateGas: BigUInt = BigUInt(clamping: 22000)
+
+    func estimateGas(for transaction: CodableTransaction, onBlock: BlockNumber) async throws -> BigUInt {
+        return stubbedEstimateGas
+    }
+    
+    func feeHistory(blockCount: BigUInt, block: BlockNumber, percentiles: [Double]) async throws -> Oracle.FeeHistory {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func ownedAccounts() async throws -> [EthereumAddress] {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getBalance(for address: EthereumAddress, onBlock: BlockNumber) async throws -> BigUInt {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func block(by hash: Data, fullTransactions: Bool) async throws -> Block {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func block(by number: BlockNumber, fullTransactions: Bool) async throws -> Block {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func block(by hash: Hash, fullTransactions: Bool) async throws -> Block {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func blockNumber() async throws -> BigUInt {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func code(for address: EthereumAddress, onBlock: BlockNumber) async throws -> Hash {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getLogs(eventFilter: EventFilterParameters) async throws -> [EventLog] {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var stubbedGasPrice: BigUInt = BigUInt(clamping: 10).toWei()
+    
+    func gasPrice() async throws -> BigUInt {
+        return stubbedGasPrice
+    }
+    
+    func getTransactionCount(for address: EthereumAddress, onBlock: BlockNumber) async throws -> BigUInt {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func transactionDetails(_ txHash: Data) async throws -> Web3Core.TransactionDetails {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func transactionReceipt(_ txHash: Data) async throws -> TransactionReceipt {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}
+
+final class EthDefault: IEth {
+    var provider: Web3Provider {
+        _provider
+    }
+    
+    var _provider: Web3Provider!
+}

--- a/AdamantTests/Stubs/IncreaseFeeServiceMock.swift
+++ b/AdamantTests/Stubs/IncreaseFeeServiceMock.swift
@@ -1,0 +1,19 @@
+//
+//  IncreaseFeeServiceMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 15.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+
+final class IncreaseFeeServiceMock: IncreaseFeeService {
+    
+    var stubbedIncreaseFeeEnabled: Bool = false
+    func isIncreaseFeeEnabled(for tokenUnicID: String) -> Bool {
+        return stubbedIncreaseFeeEnabled
+    }
+    
+    func setIncreaseFeeEnabled(for tokenUnicID: String, value: Bool) {}
+}

--- a/AdamantTests/Stubs/Web3ProviderMock.swift
+++ b/AdamantTests/Stubs/Web3ProviderMock.swift
@@ -1,0 +1,36 @@
+//
+//  Web3ProviderMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 15.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+import Web3Core
+
+final class Web3ProviderMock: Web3Provider {
+    var network: Networks?
+    var attachedKeystoreManager: KeystoreManager?
+    var policies: Policies
+    var url: URL
+    var session: URLSession
+    
+    init(
+        network: Networks? = nil,
+        attachedKeystoreManager: KeystoreManager? = nil,
+        policies: Policies = .auto,
+        url: URL = Web3ProviderMock.defaultURL,
+        session: URLSession = .shared
+    ) {
+        self.network = network
+        self.attachedKeystoreManager = attachedKeystoreManager
+        self.policies = policies
+        self.url = url
+        self.session = session
+    }
+}
+
+extension Web3ProviderMock {
+    private static let defaultURL = URL(string: "http://google.com")!
+}


### PR DESCRIPTION
Tests for `EthWalletService`.

Because Web3Core uses raw URLSession calls for networking, so I've done mocking and tracking request using `URLProtocol` in `MockURLProtocol`. I set custom `URLSession` with custom configuration with `MockURLProtocol` through `Web3ProviderMock`.  For correct checking request body and response body, added `EthRequestBody` for request bodies and `EthAPIResponse`.

To proxy `Eth` calls, added `IEthMock`. All default logic of `IEth` protocol is located in extension: `IEth+Defaults`, so for calling original implementation added `EthDefault` class.

PR is opened in branch with tests for `BTCWalletService` to reduce reviewed diff. After BTCWalletService PR will be merge, I will change branch to develop