### PR TITLE
[trello.com/c/QSbUdocE]: KlyWalletService tests

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -471,6 +471,15 @@
 		AAB01CB32D3AF0B4007D6BF4 /* DogeApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB22D3AF0AE007D6BF4 /* DogeApiServiceProtocolMock.swift */; };
 		AAB01CB52D3AF27E007D6BF4 /* DogeInternalApiProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB42D3AF278007D6BF4 /* DogeInternalApiProtocol.swift */; };
 		AAC641332D3ED1BB00619DFE /* DogeWalletServiceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641322D3ED1B200619DFE /* DogeWalletServiceIntegrationTests.swift */; };
+		AAC641352D40325400619DFE /* KlyWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641342D40324D00619DFE /* KlyWalletServiceTests.swift */; };
+		AAC641372D40393400619DFE /* KlyTransactionFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641362D40392800619DFE /* KlyTransactionFactoryProtocol.swift */; };
+		AAC641392D4039ED00619DFE /* KlyTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641382D4039E700619DFE /* KlyTransactionFactory.swift */; };
+		AAC6413B2D403C3300619DFE /* KlyTransactionFactoryProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6413A2D403C3000619DFE /* KlyTransactionFactoryProtocolMock.swift */; };
+		AAC6413D2D40456700619DFE /* KlyNodeApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6413C2D40456100619DFE /* KlyNodeApiServiceProtocol.swift */; };
+		AAC6413F2D40466B00619DFE /* KlyNodeApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6413E2D40464600619DFE /* KlyNodeApiServiceProtocolMock.swift */; };
+		AAC641412D4049DA00619DFE /* RpsRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641402D4049D400619DFE /* RpsRequestBody.swift */; };
+		AAC641452D404AE100619DFE /* KlyTransactionSubmitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */; };
+		AAC641472D404D8400619DFE /* URLSessionSwizzlingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */; };
 		AAFB3C8B2D31C0DD000CCCE9 /* Actor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8A2D31C0D0000CCCE9 /* Actor+Extensions.swift */; };
 		AAFB3C8D2D31C0EE000CCCE9 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8C2D31C0EA000CCCE9 /* Result+Extensions.swift */; };
 		AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */; };
@@ -1121,6 +1130,15 @@
 		AAB01CB22D3AF0AE007D6BF4 /* DogeApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeApiServiceProtocolMock.swift; sourceTree = "<group>"; };
 		AAB01CB42D3AF278007D6BF4 /* DogeInternalApiProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeInternalApiProtocol.swift; sourceTree = "<group>"; };
 		AAC641322D3ED1B200619DFE /* DogeWalletServiceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeWalletServiceIntegrationTests.swift; sourceTree = "<group>"; };
+		AAC641342D40324D00619DFE /* KlyWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyWalletServiceTests.swift; sourceTree = "<group>"; };
+		AAC641362D40392800619DFE /* KlyTransactionFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyTransactionFactoryProtocol.swift; sourceTree = "<group>"; };
+		AAC641382D4039E700619DFE /* KlyTransactionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyTransactionFactory.swift; sourceTree = "<group>"; };
+		AAC6413A2D403C3000619DFE /* KlyTransactionFactoryProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyTransactionFactoryProtocolMock.swift; sourceTree = "<group>"; };
+		AAC6413C2D40456100619DFE /* KlyNodeApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyNodeApiServiceProtocol.swift; sourceTree = "<group>"; };
+		AAC6413E2D40464600619DFE /* KlyNodeApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyNodeApiServiceProtocolMock.swift; sourceTree = "<group>"; };
+		AAC641402D4049D400619DFE /* RpsRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RpsRequestBody.swift; sourceTree = "<group>"; };
+		AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyTransactionSubmitModel.swift; sourceTree = "<group>"; };
+		AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlingMock.swift; sourceTree = "<group>"; };
 		AAFB3C8A2D31C0D0000CCCE9 /* Actor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Actor+Extensions.swift"; sourceTree = "<group>"; };
 		AAFB3C8C2D31C0EA000CCCE9 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletServiceError+Equatable.swift"; sourceTree = "<group>"; };
@@ -1479,6 +1497,7 @@
 		3A26D9312C3C1B55003AD832 /* Klayr */ = {
 			isa = PBXGroup;
 			children = (
+				AAC6413C2D40456100619DFE /* KlyNodeApiServiceProtocol.swift */,
 				3A26D94E2C3D3983003AD832 /* WalletService */,
 				3A26D9362C3C1C01003AD832 /* KlyWallet.swift */,
 				3A26D9382C3C1C62003AD832 /* KlyWalletFactory.swift */,
@@ -1497,6 +1516,8 @@
 		3A26D94E2C3D3983003AD832 /* WalletService */ = {
 			isa = PBXGroup;
 			children = (
+				AAC641382D4039E700619DFE /* KlyTransactionFactory.swift */,
+				AAC641362D40392800619DFE /* KlyTransactionFactoryProtocol.swift */,
 				3A26D9342C3C1BE2003AD832 /* KlyWalletService.swift */,
 				3A26D94F2C3D3A5A003AD832 /* KlyWalletService+WalletCore.swift */,
 				3A26D9402C3C2DC4003AD832 /* KlyWalletService+Send.swift */,
@@ -2292,6 +2313,7 @@
 		AA33BEB02D303C470083E59C /* Wallets */ = {
 			isa = PBXGroup;
 			children = (
+				AAC641342D40324D00619DFE /* KlyWalletServiceTests.swift */,
 				AAC641322D3ED1B200619DFE /* DogeWalletServiceIntegrationTests.swift */,
 				AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */,
 				AAFB3C9A2D383BA9000CCCE9 /* EthWalletServiceTests.swift */,
@@ -2304,6 +2326,10 @@
 		AA33BEB32D303CA30083E59C /* Stubs */ = {
 			isa = PBXGroup;
 			children = (
+				AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */,
+				AAC641402D4049D400619DFE /* RpsRequestBody.swift */,
+				AAC6413E2D40464600619DFE /* KlyNodeApiServiceProtocolMock.swift */,
+				AAC6413A2D403C3000619DFE /* KlyTransactionFactoryProtocolMock.swift */,
 				AAFB3CA82D3860EC000CCCE9 /* EthResponseBody.swift */,
 				AAFB3CA62D385BBB000CCCE9 /* EthRequestBody.swift */,
 				AAFB3CA22D384F4D000CCCE9 /* IEthMock.swift */,
@@ -2322,6 +2348,7 @@
 		AAFB3C892D31C0C4000CCCE9 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */,
 				AAFB3CA42D3854B7000CCCE9 /* MockURLProtocol.swift */,
 				AAFB3C962D31CB6B000CCCE9 /* UnspentTransaction+Equatable.swift */,
 				AAFB3C902D31C140000CCCE9 /* BitcoinKitTransaction+Equatable.swift */,
@@ -3496,6 +3523,7 @@
 				E9FCA1E6218334C00005E83D /* SimpleTransactionDetails.swift in Sources */,
 				41A1995829D5733D0031AD75 /* ChatMessageCell+Model.swift in Sources */,
 				3A299C7D2B85F98700B54C61 /* ChatFile.swift in Sources */,
+				AAC6413D2D40456700619DFE /* KlyNodeApiServiceProtocol.swift in Sources */,
 				932F77592989F999006D8801 /* ChatCellManager.swift in Sources */,
 				9377FBE2296C2ACA00C9211B /* ChatTransactionContentView+Model.swift in Sources */,
 				E933475B225539390083839E /* DogeGetTransactionsResponse.swift in Sources */,
@@ -3760,6 +3788,7 @@
 				93C7944A2B077A1C00408826 /* DashGetUnspentTransactionsDTO.swift in Sources */,
 				E9240BF5215D686500187B09 /* AdmWalletService+RichMessageProvider.swift in Sources */,
 				648C697122915CB8006645F5 /* BTCRPCServerResponce.swift in Sources */,
+				AAC641372D40393400619DFE /* KlyTransactionFactoryProtocol.swift in Sources */,
 				E9A174B32057EC47003667CD /* BackgroundFetchService.swift in Sources */,
 				3AE0A4332BC6A9EB00BF7125 /* FileApiServiceProtocol.swift in Sources */,
 				E9E7CDBE2003AEFB00DFC4DB /* CellFactory.swift in Sources */,
@@ -3887,6 +3916,7 @@
 				648DD7A22237D9A000B811FD /* DogeTransaction.swift in Sources */,
 				E90847372196FEA80095825D /* Chatroom+CoreDataProperties.swift in Sources */,
 				648CE3A8229AD1E20070A2CC /* DashWalletService+RichMessageProvider.swift in Sources */,
+				AAC641392D4039ED00619DFE /* KlyTransactionFactory.swift in Sources */,
 				9332C3A52C76C4EC00164B80 /* ApiServiceCompose.swift in Sources */,
 				E90055FB20ECE78A00D0CB2D /* SecurityViewController+notifications.swift in Sources */,
 				938F7D662955C966001915CA /* ChatInputBar.swift in Sources */,
@@ -3924,12 +3954,17 @@
 				AAFB3C9D2D383F7D000CCCE9 /* EthApiServiceProtocolMock.swift in Sources */,
 				AAFB3C992D357E1D000CCCE9 /* BtcWalletServiceIntegrationTests.swift in Sources */,
 				AAFB3C9F2D3843E0000CCCE9 /* Web3ProviderMock.swift in Sources */,
+				AAC6413F2D40466B00619DFE /* KlyNodeApiServiceProtocolMock.swift in Sources */,
 				AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */,
 				AAFB3CA72D385BBE000CCCE9 /* EthRequestBody.swift in Sources */,
 				AA33BEB92D3044760083E59C /* BtcApiServiceProtocolMock.swift in Sources */,
 				AAFB3CA52D3854BB000CCCE9 /* MockURLProtocol.swift in Sources */,
+				AAC641352D40325400619DFE /* KlyWalletServiceTests.swift in Sources */,
+				AAC641412D4049DA00619DFE /* RpsRequestBody.swift in Sources */,
 				AAFB3C9B2D383BB1000CCCE9 /* EthWalletServiceTests.swift in Sources */,
 				AAC641332D3ED1BB00619DFE /* DogeWalletServiceIntegrationTests.swift in Sources */,
+				AAC641472D404D8400619DFE /* URLSessionSwizzlingMock.swift in Sources */,
+				AAC6413B2D403C3300619DFE /* KlyTransactionFactoryProtocolMock.swift in Sources */,
 				AA33BEB22D303C730083E59C /* BtcWalletServiceTests.swift in Sources */,
 				AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */,
 				AA33BEB72D3041A30083E59C /* AddressConverterMock.swift in Sources */,
@@ -3937,6 +3972,7 @@
 				AAB01CB32D3AF0B4007D6BF4 /* DogeApiServiceProtocolMock.swift in Sources */,
 				AA33BEB62D303E240083E59C /* APICoreProtocolMock.swift in Sources */,
 				AAFB3C912D31C14A000CCCE9 /* BitcoinKitTransaction+Equatable.swift in Sources */,
+				AAC641452D404AE100619DFE /* KlyTransactionSubmitModel.swift in Sources */,
 				AAFB3C8B2D31C0DD000CCCE9 /* Actor+Extensions.swift in Sources */,
 				AAFB3CA32D384F52000CCCE9 /* IEthMock.swift in Sources */,
 				AAFB3C952D31C58B000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift in Sources */,

--- a/Adamant/App/DI/AppAssembly.swift
+++ b/Adamant/App/DI/AppAssembly.swift
@@ -226,6 +226,10 @@ struct AppAssembly: MainThreadAssembly {
             ))
         }.inObjectScope(.container)
         
+        container.register(KlyTransactionFactoryProtocol.self) { r in
+            KlyTransactionFactory()
+        }.inObjectScope(.container)
+        
         // MARK: EthApiService
         container.register(EthApiService.self) { r in
             r.resolve(ERC20ApiService.self)!

--- a/Adamant/Modules/Wallets/Klayr/KlyNodeApiService.swift
+++ b/Adamant/Modules/Wallets/Klayr/KlyNodeApiService.swift
@@ -10,7 +10,7 @@ import LiskKit
 import Foundation
 import CommonKit
 
-final class KlyNodeApiService: ApiServiceProtocol {
+final class KlyNodeApiService: KlyNodeApiServiceProtocol {
     let api: BlockchainHealthCheckWrapper<KlyApiCore>
     
     @MainActor

--- a/Adamant/Modules/Wallets/Klayr/KlyNodeApiServiceProtocol.swift
+++ b/Adamant/Modules/Wallets/Klayr/KlyNodeApiServiceProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  KlyNodeApiServiceProtocol.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CommonKit
+import LiskKit
+
+protocol KlyNodeApiServiceProtocol: ApiServiceProtocol {
+    
+    func requestTransactionsApi<Output>(
+        _ request: @Sendable @escaping (Transactions) async throws -> Output
+    ) async -> WalletServiceResult<Output>
+    
+    func requestAccountsApi<Output>(
+        _ request: @Sendable @escaping (Accounts) async throws -> Output
+    ) async -> WalletServiceResult<Output>
+}

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyTransactionFactory.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyTransactionFactory.swift
@@ -1,0 +1,30 @@
+//
+//  KlyTransactionFactory.swift
+//  Adamant
+//
+//  Created by Christian Benua on 21.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+import LiskKit
+
+final class KlyTransactionFactory: KlyTransactionFactoryProtocol {
+    func createTx(
+        amount: Decimal,
+        fee: Decimal,
+        nonce: UInt64,
+        senderPublicKey: String,
+        recipientAddressBinary: String,
+        comment: String
+    ) -> TransactionEntity {
+        TransactionEntity().createTx(
+            amount: amount,
+            fee: fee,
+            nonce: nonce,
+            senderPublicKey: senderPublicKey,
+            recipientAddressBinary: recipientAddressBinary,
+            comment: comment
+        )
+    }
+}

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyTransactionFactoryProtocol.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyTransactionFactoryProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  KlyTransactionFactoryProtocol.swift
+//  Adamant
+//
+//  Created by Christian Benua on 21.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+import LiskKit
+
+protocol KlyTransactionFactoryProtocol: AnyObject {
+    func createTx(
+        amount: Decimal,
+        fee: Decimal,
+        nonce: UInt64,
+        senderPublicKey: String,
+        recipientAddressBinary: String,
+        comment: String
+    ) -> TransactionEntity
+}

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService+Send.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService+Send.swift
@@ -21,17 +21,19 @@ extension KlyWalletService: WalletServiceTwoStepSend {
         comment: String?
     ) async throws -> TransactionEntity {
         // MARK: 1. Prepare
-        guard let wallet = klyWallet,
-                let binaryAddress = LiskKit.Crypto.getBinaryAddressFromBase32(recipient)
-        else {
+        guard let wallet = klyWallet else {
             throw WalletServiceError.notLogged
+        }
+        
+        guard let binaryAddress = LiskKit.Crypto.getBinaryAddressFromBase32(recipient) else {
+            throw WalletServiceError.accountNotFound
         }
         
         let keys = wallet.keyPair
         
         // MARK: 2. Create local transaction
         
-        let transaction = TransactionEntity().createTx(
+        let transaction = klyTransactionFactory.createTx(
             amount: amount,
             fee: fee,
             nonce: wallet.nonce,

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
@@ -24,8 +24,9 @@ final class KlyWalletService: WalletCoreProtocol, @unchecked Sendable {
     // MARK: Dependencies
     
     var apiService: AdamantApiServiceProtocol!
-    var klyNodeApiService: KlyNodeApiService!
+    var klyNodeApiService: KlyNodeApiServiceProtocol!
     var klyServiceApiService: KlyServiceApiService!
+    var klyTransactionFactory: KlyTransactionFactoryProtocol!
     var accountService: AccountService!
     var dialogService: DialogService!
     var vibroService: VibroService!
@@ -180,6 +181,7 @@ extension KlyWalletService: SwinjectDependentService {
         apiService = container.resolve(AdamantApiServiceProtocol.self)
         dialogService = container.resolve(DialogService.self)
         klyServiceApiService = container.resolve(KlyServiceApiService.self)
+        klyTransactionFactory = container.resolve(KlyTransactionFactoryProtocol.self)
         klyNodeApiService = container.resolve(KlyNodeApiService.self)
         vibroService = container.resolve(VibroService.self)
         coreDataStack = container.resolve(CoreDataStack.self)
@@ -584,6 +586,15 @@ private extension KlyWalletService {
         }
     }
 }
+
+#if DEBUG
+extension KlyWalletService {
+    @available(*, deprecated, message: "For testing purposes only")
+    func setWalletForTests(_ wallet: KlyWallet?) {
+        self.klyWallet = wallet
+    }
+}
+#endif
 
 private extension KlyWalletService {
     func getTransactions(

--- a/AdamantTests/Extensions/URLSessionSwizzlingMock.swift
+++ b/AdamantTests/Extensions/URLSessionSwizzlingMock.swift
@@ -1,0 +1,32 @@
+//
+//  URLSessionSwizzlingMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+
+final class URLSessionSwizzlingHolder {
+    static var _stubbedUrlSessionConfiguration: URLSessionConfiguration?
+}
+
+extension URLSession {
+    
+    // Perform the swizzling
+    static func swizzleInitializer() {
+        let originalSelector = #selector(URLSession.init(configuration:delegate:delegateQueue:))
+        let swizzledSelector = #selector(URLSession.swizzledInit)
+        
+        guard let originalMethod = class_getClassMethod(URLSession.self, originalSelector),
+              let swizzledMethod = class_getClassMethod(URLSession.self, swizzledSelector) else { return }
+        
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+    
+    // Swizzled init with custom configuration
+    @objc class func swizzledInit(configuration: URLSessionConfiguration, delegate: URLSessionDelegate?, delegateQueue queue: OperationQueue?) -> URLSession {
+        swizzledInit(configuration: URLSessionSwizzlingHolder._stubbedUrlSessionConfiguration ?? configuration, delegate: delegate, delegateQueue: queue)
+    }
+}

--- a/AdamantTests/Modules/Wallets/KlyWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/KlyWalletServiceTests.swift
@@ -130,18 +130,22 @@ final class KlyWalletServiceTests: XCTestCase {
         XCTAssertNil(result2.error)
         XCTAssertTrue(calledCompletion)
     }
-    
-    private static func applyURLSessionSwizzling() {
+}
+
+// MARK: Private
+
+private extension KlyWalletServiceTests {
+    static func applyURLSessionSwizzling() {
         URLSession.swizzleInitializer()
     }
     
-    private static func makeSessionConfig() -> URLSessionConfiguration {
+    static func makeSessionConfig() -> URLSessionConfiguration {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
         return config
     }
     
-    private func makeKlySendMock(expectedHash: String, _ onCall: @escaping () -> Void) {
+    func makeKlySendMock(expectedHash: String, _ onCall: @escaping () -> Void) {
         let prevHandler = MockURLProtocol.requestHandler
         MockURLProtocol.requestHandler = MockURLProtocol.combineHandlers(
             prevHandler
@@ -159,7 +163,7 @@ final class KlyWalletServiceTests: XCTestCase {
         }
     }
     
-    private func makeResponseAndMockData(
+    func makeResponseAndMockData(
         url: URL,
         klyResponse: KlyTransactionSubmitModel
     ) throws -> (HTTPURLResponse, Data) {
@@ -174,7 +178,7 @@ final class KlyWalletServiceTests: XCTestCase {
         return (response, mockData)
     }
     
-    private func makeWallet() throws -> KlyWallet {
+    func makeWallet() throws -> KlyWallet {
         let keyPair = try LiskKit.Crypto.keyPair(
             fromPassphrase: Constants.passphrase,
             salt: sut.salt
@@ -191,7 +195,7 @@ final class KlyWalletServiceTests: XCTestCase {
         )
     }
     
-    private func checkMakeTransactionParameters(
+    func checkMakeTransactionParameters(
         nonce: UInt64,
         file: StaticString = #file,
         line: UInt = #line
@@ -220,7 +224,7 @@ final class KlyWalletServiceTests: XCTestCase {
         )
     }
     
-    private func checkTransaction(
+    func checkTransaction(
         transaction: TransactionEntity,
         file: StaticString = #file,
         line: UInt = #line

--- a/AdamantTests/Modules/Wallets/KlyWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/KlyWalletServiceTests.swift
@@ -1,0 +1,267 @@
+//
+//  KlyWalletServiceTests.swift
+//  Adamant
+//
+//  Created by Christian Benua on 21.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import XCTest
+@testable import Adamant
+import CommonKit
+import LiskKit
+
+final class KlyWalletServiceTests: XCTestCase {
+    
+    private var sut: KlyWalletService!
+    private var transactionFactoryMock: KlyTransactionFactoryProtocolMock!
+    private var apiServiceMock: KlyNodeApiServiceProtocolMock!
+    
+    override class func setUp() {
+        super.setUp()
+        applyURLSessionSwizzling()
+    }
+    
+    override func setUp() {
+        super.setUp()
+
+        URLSessionSwizzlingHolder._stubbedUrlSessionConfiguration = Self.makeSessionConfig()
+        sut = KlyWalletService()
+        apiServiceMock = KlyNodeApiServiceProtocolMock()
+        transactionFactoryMock = KlyTransactionFactoryProtocolMock()
+        sut.klyTransactionFactory = transactionFactoryMock
+        sut.klyNodeApiService = apiServiceMock
+    }
+    
+    override func tearDown() {
+        sut = nil
+        transactionFactoryMock = nil
+        apiServiceMock = nil
+        MockURLProtocol.requestHandler = nil
+        URLSessionSwizzlingHolder._stubbedUrlSessionConfiguration = nil
+        super.tearDown()
+    }
+    
+    func test_createTransaction_noWalletServiceThrowsError() async throws {
+        // given
+        sut.setWalletForTests(nil)
+        
+        // when
+        let result = await Swift.Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: "recipient",
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notLogged)
+    }
+    
+    func test_createTransaction_invalidRecipientAddress() async throws {
+        // given
+        sut.setWalletForTests(try makeWallet())
+        
+        // when
+        let result = await Swift.Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.invalidKlyAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+    }
+    
+    func test_createTransaction_createsValidTransaction() async throws {
+        // given
+        let wallet = try makeWallet()
+        sut.setWalletForTests(wallet)
+        
+        // when
+        let result = await Swift.Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.validKlyAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertNil(result.error)
+        checkMakeTransactionParameters(nonce: wallet.nonce)
+        
+        let transaction = try XCTUnwrap(result.value)
+        checkTransaction(transaction: transaction)
+    }
+    
+    func test_createAndSendTransaction() async throws {
+        // given
+        let wallet = try makeWallet()
+        sut.setWalletForTests(wallet)
+        
+        // when 1
+        let result = await Swift.Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.validKlyAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then 1
+        let transaction = try XCTUnwrap(result.value)
+        var calledCompletion = false
+        makeKlySendMock(expectedHash: transaction.getTxHash() ?? "") {
+            calledCompletion = true
+        }
+        let result2 = await Swift.Result(catchingAsync: {
+            try await self.sut.sendTransaction(transaction)
+        })
+        
+        // when 2
+        XCTAssertNil(result2.error)
+        XCTAssertTrue(calledCompletion)
+    }
+    
+    private static func applyURLSessionSwizzling() {
+        URLSession.swizzleInitializer()
+    }
+    
+    private static func makeSessionConfig() -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        return config
+    }
+    
+    private func makeKlySendMock(expectedHash: String, _ onCall: @escaping () -> Void) {
+        let prevHandler = MockURLProtocol.requestHandler
+        MockURLProtocol.requestHandler = MockURLProtocol.combineHandlers(
+            prevHandler
+        ) { request in
+            guard let stream = request.httpBodyStream else { return nil }
+            let body = try JSONDecoder().decode(RpcRequestBody.self, from: Data(reading: stream))
+            guard body.method == Constants.sendTransactionMethod else { return nil }
+            
+            XCTAssertEqual(body.params as? [String: String], ["transaction": expectedHash])
+            onCall()
+            return try self.makeResponseAndMockData(
+                url: request.url!,
+                klyResponse: KlyTransactionSubmitModel(transactionId: expectedHash)
+            )
+        }
+    }
+    
+    private func makeResponseAndMockData(
+        url: URL,
+        klyResponse: KlyTransactionSubmitModel
+    ) throws -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        
+        let mockData = try JSONEncoder().encode(klyResponse)
+        return (response, mockData)
+    }
+    
+    private func makeWallet() throws -> KlyWallet {
+        let keyPair = try LiskKit.Crypto.keyPair(
+            fromPassphrase: Constants.passphrase,
+            salt: sut.salt
+        )
+        
+        let address = LiskKit.Crypto.address(fromPublicKey: keyPair.publicKeyString)
+        
+        return KlyWallet(
+            unicId: "KLYKLY",
+            address: address,
+            keyPair: keyPair,
+            nonce: .zero,
+            isNewApi: true
+        )
+    }
+    
+    private func checkMakeTransactionParameters(
+        nonce: UInt64,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(transactionFactoryMock.invokedCreateTxCount, 1, file: file, line: line)
+        XCTAssertEqual(transactionFactoryMock.invokedCreateTxParameters?.amount, 10, file: file, line: line)
+        XCTAssertEqual(transactionFactoryMock.invokedCreateTxParameters?.fee, 0.1, file: file, line: line)
+        XCTAssertEqual(transactionFactoryMock.invokedCreateTxParameters?.nonce, nonce, file: file, line: line)
+        XCTAssertEqual(
+            transactionFactoryMock.invokedCreateTxParameters?.recipientAddressBinary,
+            Constants.validKlyAddressBinary,
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            transactionFactoryMock.invokedCreateTxParameters?.senderPublicKey,
+            Constants.senderPublicKey,
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            transactionFactoryMock.invokedCreateTxParameters?.comment,
+            "",
+            file: file,
+            line: line
+        )
+    }
+    
+    private func checkTransaction(
+        transaction: TransactionEntity,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            transaction.senderPublicKey,
+            Data(Constants.senderPublicKey.hexBytes()),
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            transaction.params.recipientAddressBinary,
+            Data(Constants.validKlyAddressBinary.hexBytes()),
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(transaction.fee, UInt64(0.1 * pow(10, 8)), file: file, line: line)
+        XCTAssertEqual(transaction.amountValue, 10, file: file, line: line)
+        XCTAssertEqual(transaction.signatures, [Constants.expectedSignature], file: file, line: line)
+    }
+}
+
+private enum Constants {
+    
+    static let passphrase = "village lunch say patrol glow first hurt shiver name method dolphin dead"
+    
+    static let senderPublicKey = "cb8bb87e2fa8050da0c193c74621698e1bba73851245b0bbbc45ec5905324c71"
+        
+    static let validKlyAddress = "klycufr5yusb5uphgbg8accfkka7tpe3x9zv872tq"
+    
+    static let validKlyAddressBinary = "1c3d25c61b32e04efcdf7e463f529974c96405a0"
+    
+    static let invalidKlyAddress = String(validKlyAddress[0..<38]) // valid KLY address is always 41 chars length
+    
+    static let expectedSignature = Data([
+        176, 1, 177, 131, 119, 246, 146, 122, 152, 92, 10,
+        239, 28, 204, 82, 249, 65, 5, 20, 54, 49, 18, 109, 220,
+        229, 84, 94, 135, 143, 174, 230, 147, 166, 150, 67, 94,
+        250, 75, 58, 28, 81, 175, 96, 207, 19, 228, 24, 38, 185,
+        94, 46, 128, 88, 233, 97, 205, 30, 249, 233, 163, 148, 250, 76, 8
+    ])
+    
+    static let sendTransactionMethod = "txpool_postTransaction"
+}

--- a/AdamantTests/Stubs/KlyNodeApiServiceProtocolMock.swift
+++ b/AdamantTests/Stubs/KlyNodeApiServiceProtocolMock.swift
@@ -1,0 +1,45 @@
+//
+//  KlyNodeApiServiceProtocolMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CommonKit
+import LiskKit
+@testable import Adamant
+
+final class KlyNodeApiServiceProtocolMock: KlyNodeApiServiceProtocol {
+    var nodesInfo: NodesListInfo {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var nodesInfoPublisher: AnyObservable<NodesListInfo> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func requestTransactionsApi<Output>(
+        _ request: @Sendable @escaping (Transactions) async throws -> Output
+    ) async -> WalletServiceResult<Output> {
+        do {
+            return .success(try await request(Transactions(client: APIClient())))
+        } catch {
+            return .failure(.internalError(.endpointBuildFailed))
+        }
+    }
+     
+    func requestAccountsApi<Output>(
+        _ request: @Sendable @escaping (Accounts) async throws -> Output
+    ) async -> WalletServiceResult<Output> {
+        do {
+            return .success(try await request(Accounts(client: APIClient())))
+        } catch {
+            return .failure(.internalError(.endpointBuildFailed))
+        }
+    }
+    
+    func healthCheck() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/KlyTransactionFactoryProtocolMock.swift
+++ b/AdamantTests/Stubs/KlyTransactionFactoryProtocolMock.swift
@@ -1,0 +1,40 @@
+//
+//  KlyTransactionFactoryProtocolMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 21.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import Foundation
+import LiskKit
+
+final class KlyTransactionFactoryProtocolMock: KlyTransactionFactoryProtocol {
+    
+    var invokedCreateTx: Bool = false
+    var invokedCreateTxCount: Int = 0
+    var invokedCreateTxParameters: (amount: Decimal, fee: Decimal, nonce: UInt64, senderPublicKey: String, recipientAddressBinary: String, comment: String)?
+    
+    func createTx(
+        amount: Decimal,
+        fee: Decimal,
+        nonce: UInt64,
+        senderPublicKey: String,
+        recipientAddressBinary: String,
+        comment: String
+    ) -> TransactionEntity {
+        invokedCreateTx = true
+        invokedCreateTxCount += 1
+        invokedCreateTxParameters = (amount, fee, nonce, senderPublicKey, recipientAddressBinary, comment)
+        
+        return TransactionEntity().createTx(
+            amount: amount,
+            fee: fee,
+            nonce: nonce,
+            senderPublicKey: senderPublicKey,
+            recipientAddressBinary: recipientAddressBinary,
+            comment: comment
+        )
+    }
+}

--- a/AdamantTests/Stubs/KlyTransactionSubmitModel.swift
+++ b/AdamantTests/Stubs/KlyTransactionSubmitModel.swift
@@ -1,0 +1,11 @@
+//
+//  KlyTransactionSubmitModel.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+struct KlyTransactionSubmitModel: Codable {
+    let transactionId: String
+}

--- a/AdamantTests/Stubs/RpsRequestBody.swift
+++ b/AdamantTests/Stubs/RpsRequestBody.swift
@@ -1,0 +1,23 @@
+//
+//  RpsRequestBody.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+struct RpcRequestBody: Decodable {
+    var method: String
+    var params: [String: Any]
+    
+    enum CodingKeys: String, CodingKey {
+        case method
+        case params
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.method = try container.decode(String.self, forKey: .method)
+        self.params = try container.decode([String: Any].self, forKey: .params)
+    }
+}


### PR DESCRIPTION
KlyWalletService test.

For testing purposes `KlyNodeApiServiceProtocol` and `KlyTransactionFactoryProtocol` were introduced.

For testing URL-request inside `sendTransaction` `RpcRequestBody` was used. To return real response body, I've used `KlyTransactionSubmitModel`.

Because LiskKit inside uses private `URLSession`, default practice using `MockURLProtocol` won't work, because it requires to instantiate `URLSession` with custom `URLSessionConfiguration`. So I've used swizzling for mocking `URLSession.init`. Because internally `URLSession.init` is actually `class method`, so for swizzling we should exchange two class methods implementations:

```
guard let originalMethod = class_getClassMethod(URLSession.self, originalSelector),
           let swizzledMethod = class_getClassMethod(URLSession.self, swizzledSelector) else { return }
```

Inside swizzled method we change actual `URLConfiguration` with custom `URLConfiguration` with mocking using `MockURLProtocol`