### PR TITLE
[trello.com/c/Htm0a2Qp]: DashWalletService tests

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -501,6 +501,14 @@
 		AAC641592D44F81700619DFE /* ERC20WalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */; };
 		AAC6415B2D44FB0100619DFE /* ERC20ApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */; };
 		AAC6415D2D44FD5B00619DFE /* ERC20ApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */; };
+		AAC641492D417B0D00619DFE /* DashLastTransactionStorageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641482D417AF400619DFE /* DashLastTransactionStorageProtocol.swift */; };
+		AAC6414B2D417B5300619DFE /* DashLastTransactionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6414A2D417B4D00619DFE /* DashLastTransactionStorage.swift */; };
+		AAC6414D2D4180B600619DFE /* DashLastTransactionStorageProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6414C2D4180B200619DFE /* DashLastTransactionStorageProtocolMock.swift */; };
+		AAC6414F2D41829900619DFE /* DashWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6414E2D41829300619DFE /* DashWalletServiceTests.swift */; };
+		AAC641512D42D67B00619DFE /* DashApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641502D42D67700619DFE /* DashApiServiceProtocol.swift */; };
+		AAC641532D42D70100619DFE /* DashApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641522D42D6FB00619DFE /* DashApiServiceProtocolMock.swift */; };
+		AAC641552D42D74800619DFE /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641542D42D74300619DFE /* NodeOrigin+Extensions.swift */; };
+		AAC641572D42F9E200619DFE /* DashWalletServiceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641562D42F9DA00619DFE /* DashWalletServiceIntegrationTests.swift */; };
 		AAFB3C8B2D31C0DD000CCCE9 /* Actor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8A2D31C0D0000CCCE9 /* Actor+Extensions.swift */; };
 		AAFB3C8D2D31C0EE000CCCE9 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8C2D31C0EA000CCCE9 /* Result+Extensions.swift */; };
 		AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */; };
@@ -1182,6 +1190,14 @@
 		AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20WalletServiceTests.swift; sourceTree = "<group>"; };
 		AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocol.swift; sourceTree = "<group>"; };
 		AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocolMock.swift; sourceTree = "<group>"; };
+		AAC641482D417AF400619DFE /* DashLastTransactionStorageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashLastTransactionStorageProtocol.swift; sourceTree = "<group>"; };
+		AAC6414A2D417B4D00619DFE /* DashLastTransactionStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashLastTransactionStorage.swift; sourceTree = "<group>"; };
+		AAC6414C2D4180B200619DFE /* DashLastTransactionStorageProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashLastTransactionStorageProtocolMock.swift; sourceTree = "<group>"; };
+		AAC6414E2D41829300619DFE /* DashWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashWalletServiceTests.swift; sourceTree = "<group>"; };
+		AAC641502D42D67700619DFE /* DashApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashApiServiceProtocol.swift; sourceTree = "<group>"; };
+		AAC641522D42D6FB00619DFE /* DashApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashApiServiceProtocolMock.swift; sourceTree = "<group>"; };
+		AAC641542D42D74300619DFE /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
+		AAC641562D42F9DA00619DFE /* DashWalletServiceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashWalletServiceIntegrationTests.swift; sourceTree = "<group>"; };
 		AAFB3C8A2D31C0D0000CCCE9 /* Actor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Actor+Extensions.swift"; sourceTree = "<group>"; };
 		AAFB3C8C2D31C0EA000CCCE9 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletServiceError+Equatable.swift"; sourceTree = "<group>"; };
@@ -1780,10 +1796,13 @@
 			children = (
 				93B28EC32B076DFD007F268B /* DTO */,
 				6403F5DD22723C6800D58779 /* DashMainnet.swift */,
+				AAC641482D417AF400619DFE /* DashLastTransactionStorageProtocol.swift */,
+				AAC6414A2D417B4D00619DFE /* DashLastTransactionStorage.swift */,
 				6403F5DF22723F6400D58779 /* DashWalletFactory.swift */,
 				6403F5E122723F7500D58779 /* DashWallet.swift */,
 				6403F5E322723F8C00D58779 /* DashWalletService.swift */,
 				93B28EC12B076D31007F268B /* DashApiService.swift */,
+				AAC641502D42D67700619DFE /* DashApiServiceProtocol.swift */,
 				4186B339294200F4006594A3 /* DashWalletService+DynamicConstants.swift */,
 				A578BDE42623051C00090141 /* DashWalletService+Transactions.swift */,
 				648CE3A5229AD1CD0070A2CC /* DashWalletService+Send.swift */,
@@ -2381,6 +2400,8 @@
 			children = (
 				AA8FFFC32D4C1168001D8576 /* NativeAdamantCoreTests.swift */,
 				AA8FFFAF2D49716D001D8576 /* AdmWalletServiceTests.swift */,
+				AAC641562D42F9DA00619DFE /* DashWalletServiceIntegrationTests.swift */,
+				AAC6414E2D41829300619DFE /* DashWalletServiceTests.swift */,
 				AAC641342D40324D00619DFE /* KlyWalletServiceTests.swift */,
 				AAC641322D3ED1B200619DFE /* DogeWalletServiceIntegrationTests.swift */,
 				AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */,
@@ -2403,6 +2424,8 @@
 				AA8FFFB32D497509001D8576 /* AccountServiceMock.swift */,
 				AA8FFFB12D49726B001D8576 /* SecuredStoreMock.swift */,
 				AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */,
+				AAC641522D42D6FB00619DFE /* DashApiServiceProtocolMock.swift */,
+				AAC6414C2D4180B200619DFE /* DashLastTransactionStorageProtocolMock.swift */,
 				AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */,
 				AAC641402D4049D400619DFE /* RpsRequestBody.swift */,
 				AAC6413E2D40464600619DFE /* KlyNodeApiServiceProtocolMock.swift */,
@@ -3557,6 +3580,7 @@
 				E987024920C2B1F700E393F4 /* AdamantChatsProvider+fakeMessages.swift in Sources */,
 				934FD9B02C78481500336841 /* InfoServiceApiError.swift in Sources */,
 				6403F5E222723F7500D58779 /* DashWallet.swift in Sources */,
+				AAC641492D417B0D00619DFE /* DashLastTransactionStorageProtocol.swift in Sources */,
 				26A975FF2B7E843E0095C367 /* SelectTextView.swift in Sources */,
 				93294B822AAD0BB400911109 /* BtcWalletFactory.swift in Sources */,
 				AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */,
@@ -3577,6 +3601,7 @@
 				E94008872114F05B00CD2D67 /* AddressValidationResult.swift in Sources */,
 				E993301E212EF39700CD5200 /* EthTransferViewController.swift in Sources */,
 				648CE3A42299A94D0070A2CC /* DashTransactionDetailsViewController.swift in Sources */,
+				AAC641512D42D67B00619DFE /* DashApiServiceProtocol.swift in Sources */,
 				934FD9AC2C78443600336841 /* InfoServiceHistoryItemDTO.swift in Sources */,
 				E90847362196FEA80095825D /* Chatroom+CoreDataClass.swift in Sources */,
 				3A4068342ACD7C18007E87BD /* CoinTransaction+TransactionDetails.swift in Sources */,
@@ -3589,6 +3614,7 @@
 				649D6BF221C27D5C009E727B /* SearchResultsViewController.swift in Sources */,
 				E9E7CD8D20026B6600DFC4DB /* DialogService.swift in Sources */,
 				3ACD30802BBD86C800ABF671 /* FilesStorageProprietiesProtocol.swift in Sources */,
+				AAC6414B2D417B5300619DFE /* DashLastTransactionStorage.swift in Sources */,
 				E9E7CDB72003994E00DFC4DB /* AdamantUtilities+extended.swift in Sources */,
 				3A2478B32BB461A7009D89E9 /* StorageUsageViewModel.swift in Sources */,
 				E9147B6320505C7500145913 /* QRCodeReader+adamant.swift in Sources */,
@@ -4042,9 +4068,11 @@
 			files = (
 				AAFB3C972D31CB72000CCCE9 /* UnspentTransaction+Equatable.swift in Sources */,
 				AAFB3CA92D3860F2000CCCE9 /* EthResponseBody.swift in Sources */,
+				AAC6414F2D41829900619DFE /* DashWalletServiceTests.swift in Sources */,
 				AAFB3C9D2D383F7D000CCCE9 /* EthApiServiceProtocolMock.swift in Sources */,
 				AA8FFFBC2D49796A001D8576 /* ChatsProviderMock.swift in Sources */,
 				AAFB3C992D357E1D000CCCE9 /* BtcWalletServiceIntegrationTests.swift in Sources */,
+				AAC641532D42D70100619DFE /* DashApiServiceProtocolMock.swift in Sources */,
 				AAFB3C9F2D3843E0000CCCE9 /* Web3ProviderMock.swift in Sources */,
 				AAC6415D2D44FD5B00619DFE /* ERC20ApiServiceProtocolMock.swift in Sources */,
 				AA8FFFC02D4AC011001D8576 /* AdamantCoreMock.swift in Sources */,
@@ -4063,6 +4091,7 @@
 				AAC641472D404D8400619DFE /* URLSessionSwizzlingMock.swift in Sources */,
 				AA8FFFB42D497510001D8576 /* AccountServiceMock.swift in Sources */,
 				AAC6413B2D403C3300619DFE /* KlyTransactionFactoryProtocolMock.swift in Sources */,
+				AAC641572D42F9E200619DFE /* DashWalletServiceIntegrationTests.swift in Sources */,
 				AA33BEB22D303C730083E59C /* BtcWalletServiceTests.swift in Sources */,
 				AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */,
 				AA33BEB72D3041A30083E59C /* AddressConverterMock.swift in Sources */,
@@ -4078,6 +4107,7 @@
 				AAFB3CA32D384F52000CCCE9 /* IEthMock.swift in Sources */,
 				AA8FFFB82D497772001D8576 /* AdamantApiServiceProtocolMock.swift in Sources */,
 				AAFB3C952D31C58B000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift in Sources */,
+				AAC6414D2D4180B600619DFE /* DashLastTransactionStorageProtocolMock.swift in Sources */,
 				AAFB3CA12D384AF7000CCCE9 /* IncreaseFeeServiceMock.swift in Sources */,
 				AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */,
 			);

--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -483,6 +483,12 @@
 		AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */; };
 		AA8FFFE32D513681001D8576 /* CustomFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */; };
 		AA8FFFE52D513787001D8576 /* EdgeInsetTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */; };
+		AA8FFFD52D50DCEF001D8576 /* dash_send_transation_response.json in Resources */ = {isa = PBXBuildFile; fileRef = AA8FFFD42D50DCE4001D8576 /* dash_send_transation_response.json */; };
+		AA8FFFD72D50DD0E001D8576 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFD62D50DD07001D8576 /* Data+Extensions.swift */; };
+		AA8FFFD82D50DF63001D8576 /* dash_unspent_transaction_intergration_test.json in Resources */ = {isa = PBXBuildFile; fileRef = AA8FFFD22D50DC0C001D8576 /* dash_unspent_transaction_intergration_test.json */; };
+		AA8FFFDA2D50DFB2001D8576 /* dash_unspent_transaction_unit_test.json in Resources */ = {isa = PBXBuildFile; fileRef = AA8FFFD92D50DFA3001D8576 /* dash_unspent_transaction_unit_test.json */; };
+		AA8FFFDC2D50E079001D8576 /* dash_unverified_unspent_transactions.json in Resources */ = {isa = PBXBuildFile; fileRef = AA8FFFDB2D50E063001D8576 /* dash_unverified_unspent_transactions.json */; };
+		AA8FFFE12D50E175001D8576 /* dash_send_transaction_unit_response.json in Resources */ = {isa = PBXBuildFile; fileRef = AA8FFFDF2D50E13F001D8576 /* dash_send_transaction_unit_response.json */; };
 		AAB01CAD2D3AE44B007D6BF4 /* BitcoinKitTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */; };
 		AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */; };
 		AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */; };
@@ -498,17 +504,16 @@
 		AAC641412D4049DA00619DFE /* RpsRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641402D4049D400619DFE /* RpsRequestBody.swift */; };
 		AAC641452D404AE100619DFE /* KlyTransactionSubmitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */; };
 		AAC641472D404D8400619DFE /* URLSessionSwizzlingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */; };
-		AAC641592D44F81700619DFE /* ERC20WalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */; };
-		AAC6415B2D44FB0100619DFE /* ERC20ApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */; };
-		AAC6415D2D44FD5B00619DFE /* ERC20ApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */; };
 		AAC641492D417B0D00619DFE /* DashLastTransactionStorageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641482D417AF400619DFE /* DashLastTransactionStorageProtocol.swift */; };
 		AAC6414B2D417B5300619DFE /* DashLastTransactionStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6414A2D417B4D00619DFE /* DashLastTransactionStorage.swift */; };
 		AAC6414D2D4180B600619DFE /* DashLastTransactionStorageProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6414C2D4180B200619DFE /* DashLastTransactionStorageProtocolMock.swift */; };
 		AAC6414F2D41829900619DFE /* DashWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6414E2D41829300619DFE /* DashWalletServiceTests.swift */; };
 		AAC641512D42D67B00619DFE /* DashApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641502D42D67700619DFE /* DashApiServiceProtocol.swift */; };
 		AAC641532D42D70100619DFE /* DashApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641522D42D6FB00619DFE /* DashApiServiceProtocolMock.swift */; };
-		AAC641552D42D74800619DFE /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641542D42D74300619DFE /* NodeOrigin+Extensions.swift */; };
 		AAC641572D42F9E200619DFE /* DashWalletServiceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641562D42F9DA00619DFE /* DashWalletServiceIntegrationTests.swift */; };
+		AAC641592D44F81700619DFE /* ERC20WalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */; };
+		AAC6415B2D44FB0100619DFE /* ERC20ApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */; };
+		AAC6415D2D44FD5B00619DFE /* ERC20ApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */; };
 		AAFB3C8B2D31C0DD000CCCE9 /* Actor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8A2D31C0D0000CCCE9 /* Actor+Extensions.swift */; };
 		AAFB3C8D2D31C0EE000CCCE9 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8C2D31C0EA000CCCE9 /* Result+Extensions.swift */; };
 		AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */; };
@@ -1172,6 +1177,12 @@
 		AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
 		AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldRow.swift; sourceTree = "<group>"; };
 		AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsetTextField.swift; sourceTree = "<group>"; };
+		AA8FFFD22D50DC0C001D8576 /* dash_unspent_transaction_intergration_test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = dash_unspent_transaction_intergration_test.json; sourceTree = "<group>"; };
+		AA8FFFD42D50DCE4001D8576 /* dash_send_transation_response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = dash_send_transation_response.json; sourceTree = "<group>"; };
+		AA8FFFD62D50DD07001D8576 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
+		AA8FFFD92D50DFA3001D8576 /* dash_unspent_transaction_unit_test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = dash_unspent_transaction_unit_test.json; sourceTree = "<group>"; };
+		AA8FFFDB2D50E063001D8576 /* dash_unverified_unspent_transactions.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = dash_unverified_unspent_transactions.json; sourceTree = "<group>"; };
+		AA8FFFDF2D50E13F001D8576 /* dash_send_transaction_unit_response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = dash_send_transaction_unit_response.json; sourceTree = "<group>"; };
 		AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinKitTransactionFactory.swift; sourceTree = "<group>"; };
 		AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeWalletServiceTests.swift; sourceTree = "<group>"; };
 		AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeApiServiceProtocol.swift; sourceTree = "<group>"; };
@@ -1187,17 +1198,16 @@
 		AAC641402D4049D400619DFE /* RpsRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RpsRequestBody.swift; sourceTree = "<group>"; };
 		AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyTransactionSubmitModel.swift; sourceTree = "<group>"; };
 		AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlingMock.swift; sourceTree = "<group>"; };
-		AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20WalletServiceTests.swift; sourceTree = "<group>"; };
-		AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocol.swift; sourceTree = "<group>"; };
-		AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocolMock.swift; sourceTree = "<group>"; };
 		AAC641482D417AF400619DFE /* DashLastTransactionStorageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashLastTransactionStorageProtocol.swift; sourceTree = "<group>"; };
 		AAC6414A2D417B4D00619DFE /* DashLastTransactionStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashLastTransactionStorage.swift; sourceTree = "<group>"; };
 		AAC6414C2D4180B200619DFE /* DashLastTransactionStorageProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashLastTransactionStorageProtocolMock.swift; sourceTree = "<group>"; };
 		AAC6414E2D41829300619DFE /* DashWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashWalletServiceTests.swift; sourceTree = "<group>"; };
 		AAC641502D42D67700619DFE /* DashApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashApiServiceProtocol.swift; sourceTree = "<group>"; };
 		AAC641522D42D6FB00619DFE /* DashApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashApiServiceProtocolMock.swift; sourceTree = "<group>"; };
-		AAC641542D42D74300619DFE /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
 		AAC641562D42F9DA00619DFE /* DashWalletServiceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashWalletServiceIntegrationTests.swift; sourceTree = "<group>"; };
+		AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20WalletServiceTests.swift; sourceTree = "<group>"; };
+		AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocol.swift; sourceTree = "<group>"; };
+		AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocolMock.swift; sourceTree = "<group>"; };
 		AAFB3C8A2D31C0D0000CCCE9 /* Actor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Actor+Extensions.swift"; sourceTree = "<group>"; };
 		AAFB3C8C2D31C0EA000CCCE9 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletServiceError+Equatable.swift"; sourceTree = "<group>"; };
@@ -2423,6 +2433,7 @@
 				AA8FFFB52D4975D1001D8576 /* AccountsProviderMock.swift */,
 				AA8FFFB32D497509001D8576 /* AccountServiceMock.swift */,
 				AA8FFFB12D49726B001D8576 /* SecuredStoreMock.swift */,
+				AA8FFFD12D50DBF2001D8576 /* RequestStubs */,
 				AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */,
 				AAC641522D42D6FB00619DFE /* DashApiServiceProtocolMock.swift */,
 				AAC6414C2D4180B200619DFE /* DashLastTransactionStorageProtocolMock.swift */,
@@ -2445,9 +2456,22 @@
 			path = Stubs;
 			sourceTree = "<group>";
 		};
+		AA8FFFD12D50DBF2001D8576 /* RequestStubs */ = {
+			isa = PBXGroup;
+			children = (
+				AA8FFFDF2D50E13F001D8576 /* dash_send_transaction_unit_response.json */,
+				AA8FFFDB2D50E063001D8576 /* dash_unverified_unspent_transactions.json */,
+				AA8FFFD92D50DFA3001D8576 /* dash_unspent_transaction_unit_test.json */,
+				AA8FFFD42D50DCE4001D8576 /* dash_send_transation_response.json */,
+				AA8FFFD22D50DC0C001D8576 /* dash_unspent_transaction_intergration_test.json */,
+			);
+			path = RequestStubs;
+			sourceTree = "<group>";
+		};
 		AAFB3C892D31C0C4000CCCE9 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AA8FFFD62D50DD07001D8576 /* Data+Extensions.swift */,
 				AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */,
 				AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */,
 				AAFB3CA42D3854B7000CCCE9 /* MockURLProtocol.swift */,
@@ -3448,6 +3472,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA8FFFE12D50E175001D8576 /* dash_send_transaction_unit_response.json in Resources */,
+				AA8FFFD82D50DF63001D8576 /* dash_unspent_transaction_intergration_test.json in Resources */,
+				AA8FFFDC2D50E079001D8576 /* dash_unverified_unspent_transactions.json in Resources */,
+				AA8FFFD52D50DCEF001D8576 /* dash_send_transation_response.json in Resources */,
+				AA8FFFDA2D50DFB2001D8576 /* dash_unspent_transaction_unit_test.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4066,6 +4095,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA8FFFD72D50DD0E001D8576 /* Data+Extensions.swift in Sources */,
 				AAFB3C972D31CB72000CCCE9 /* UnspentTransaction+Equatable.swift in Sources */,
 				AAFB3CA92D3860F2000CCCE9 /* EthResponseBody.swift in Sources */,
 				AAC6414F2D41829900619DFE /* DashWalletServiceTests.swift in Sources */,

--- a/Adamant/App/DI/AppAssembly.swift
+++ b/Adamant/App/DI/AppAssembly.swift
@@ -202,6 +202,12 @@ struct AppAssembly: MainThreadAssembly {
             ))
         }.inObjectScope(.container)
         
+        
+        // MARK: DashLastTransactionStorage
+        container.register(DashLastTransactionStorageProtocol.self) { r in
+            DashLastTransactionStorage(securedStore: r.resolve(SecuredStore.self)!)
+        }.inObjectScope(.container)
+        
         // MARK: LskNodeApiService
         container.register(KlyNodeApiService.self) { r in
             KlyNodeApiService(api: .init(

--- a/Adamant/Modules/Wallets/Dash/DashApiService.swift
+++ b/Adamant/Modules/Wallets/Dash/DashApiService.swift
@@ -64,7 +64,7 @@ final class DashApiCore: BlockchainHealthCheckableService, Sendable {
     }
 }
 
-final class DashApiService: ApiServiceProtocol {
+final class DashApiService: DashApiServiceProtocol {
     let api: BlockchainHealthCheckWrapper<DashApiCore>
     
     @MainActor

--- a/Adamant/Modules/Wallets/Dash/DashApiServiceProtocol.swift
+++ b/Adamant/Modules/Wallets/Dash/DashApiServiceProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  DashApiServiceProtocol.swift
+//  Adamant
+//
+//  Created by Christian Benua on 23.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CommonKit
+import Foundation
+
+protocol DashApiServiceProtocol: ApiServiceProtocol {
+    func request<Output>(
+        waitsForConnectivity: Bool,
+        _ request: @Sendable @escaping (APICoreProtocol, NodeOrigin) async -> ApiServiceResult<Output>
+    ) async -> WalletServiceResult<Output>
+}

--- a/Adamant/Modules/Wallets/Dash/DashLastTransactionStorage.swift
+++ b/Adamant/Modules/Wallets/Dash/DashLastTransactionStorage.swift
@@ -1,0 +1,56 @@
+//
+//  DashLastTransactionStorage.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CommonKit
+import Foundation
+
+final class DashLastTransactionStorage: DashLastTransactionStorageProtocol {
+    
+    private let securedStore: SecuredStore
+    
+    init(securedStore: SecuredStore) {
+        self.securedStore = securedStore
+    }
+    
+    func getLastTransactionId() -> String? {
+        guard
+            let hash: String = self.securedStore.get(Constants.transactionIdKey),
+            let timestampString: String = self.securedStore.get(Constants.transactionTimeKey),
+            let timestamp = Double(string: timestampString)
+        else { return nil }
+        
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        let timeAgo = -1 * date.timeIntervalSinceNow
+        
+        if timeAgo > Constants.tenMinutes { // 10m waiting for transaction complete
+            self.securedStore.remove(Constants.transactionTimeKey)
+            self.securedStore.remove(Constants.transactionIdKey)
+            return nil
+        } else {
+            return hash
+        }
+    }
+    
+    func setLastTransactionId(_ id: String?) {
+        if let value = id {
+            let timestamp = Date().timeIntervalSince1970
+            self.securedStore.set("\(timestamp)", for: Constants.transactionTimeKey)
+            self.securedStore.set(value, for: Constants.transactionIdKey)
+        } else {
+            self.securedStore.remove(Constants.transactionTimeKey)
+            self.securedStore.remove(Constants.transactionIdKey)
+        }
+    }
+}
+
+private enum Constants {
+    static let transactionTimeKey = "lastDashTransactionTime"
+    static let transactionIdKey = "lastDashTransactionId"
+    
+    static let tenMinutes: TimeInterval = 10 * 60
+}

--- a/Adamant/Modules/Wallets/Dash/DashLastTransactionStorageProtocol.swift
+++ b/Adamant/Modules/Wallets/Dash/DashLastTransactionStorageProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  DashLastTransactionStorageProtocol.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+protocol DashLastTransactionStorageProtocol: AnyObject {
+    func getLastTransactionId() -> String?
+    func setLastTransactionId(_ id: String?)
+}

--- a/Adamant/Modules/Wallets/Dash/DashWalletService+Send.swift
+++ b/Adamant/Modules/Wallets/Dash/DashWalletService+Send.swift
@@ -71,12 +71,13 @@ extension DashWalletService: WalletServiceTwoStepSend {
         }
         
         // MARK: 4. Create local transaction
-        let transaction = BitcoinKit.Transaction.createNewTransaction(
+        let transaction = transactionFactory.createTransaction(
             toAddress: toAddress,
             amount: rawAmount,
             fee: fee,
             changeAddress: wallet.addressEntity,
             utxos: utxos,
+            lockTime: 0,
             keys: [key]
         )
         return transaction

--- a/Adamant/Modules/Wallets/Dash/DashWalletService.swift
+++ b/Adamant/Modules/Wallets/Dash/DashWalletService.swift
@@ -65,9 +65,10 @@ final class DashWalletService: WalletCoreProtocol, @unchecked Sendable {
     
     // MARK: - Dependencies
     var apiService: AdamantApiServiceProtocol!
-    var dashApiService: DashApiService!
+    var dashApiService: DashApiServiceProtocol!
     var accountService: AccountService!
-    var securedStore: SecuredStore!
+    var lastTransactionStorage: DashLastTransactionStorageProtocol!
+    var transactionFactory: BitcoinKitTransactionFactoryProtocol!
     var dialogService: DialogService!
     var addressConverter: AddressConverter!
     var coreDataStack: CoreDataStack!
@@ -90,32 +91,10 @@ final class DashWalletService: WalletCoreProtocol, @unchecked Sendable {
     
     var lastTransactionId: String? {
         get {
-            guard
-                let hash: String = self.securedStore.get("lastDashTransactionId"),
-                let timestampString: String = self.securedStore.get("lastDashTransactionTime"),
-                let timestamp = Double(string: timestampString)
-            else { return nil }
-            
-            let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
-            let timeAgo = -1 * date.timeIntervalSinceNow
-            
-            if timeAgo > 10 * 60 { // 10m waiting for transaction complete
-                self.securedStore.remove("lastDashTransactionTime")
-                self.securedStore.remove("lastDashTransactionId")
-                return nil
-            } else {
-                return hash
-            }
+            lastTransactionStorage.getLastTransactionId()
         }
         set {
-            if let value = newValue {
-                let timestamp = Date().timeIntervalSince1970
-                self.securedStore.set("\(timestamp)", for: "lastDashTransactionTime")
-                self.securedStore.set(value, for: "lastDashTransactionId")
-            } else {
-                self.securedStore.remove("lastDashTransactionTime")
-                self.securedStore.remove("lastDashTransactionId")
-            }
+            lastTransactionStorage.setLastTransactionId(newValue)
         }
     }
     
@@ -420,7 +399,8 @@ extension DashWalletService: SwinjectDependentService {
     func injectDependencies(from container: Container) {
         accountService = container.resolve(AccountService.self)
         apiService = container.resolve(AdamantApiServiceProtocol.self)
-        securedStore = container.resolve(SecuredStore.self)
+        lastTransactionStorage = container.resolve(DashLastTransactionStorageProtocol.self)
+        transactionFactory = container.resolve(BitcoinKitTransactionFactoryProtocol.self)
         dialogService = container.resolve(DialogService.self)
         addressConverter = container.resolve(AddressConverterFactory.self)?
             .make(network: network)
@@ -617,6 +597,15 @@ extension DashWalletService {
         )
     }
 }
+
+#if DEBUG
+extension DashWalletService {
+    @available(*, deprecated, message: "For testing purposes only")
+    func setWalletForTests(_ wallet: DashWallet?) {
+        self.dashWallet = wallet
+    }
+}
+#endif
 
 // MARK: - PrivateKey generator
 extension DashWalletService: PrivateKeyGenerator {

--- a/AdamantTests/Extensions/Data+Extensions.swift
+++ b/AdamantTests/Extensions/Data+Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  Data+Extensions.swift
+//  Adamant
+//
+//  Created by Christian Benua on 03.02.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+
+private final class BundleTag {}
+
+extension Data {
+    static func readResource(name: String, withExtension extensionName: String?) -> Data? {
+        Bundle(for: BundleTag.self)
+            .url(forResource: name, withExtension: extensionName)
+            .flatMap { try? Data(contentsOf: $0) }
+    }
+}

--- a/AdamantTests/Modules/Wallets/DashWalletServiceIntegrationTests.swift
+++ b/AdamantTests/Modules/Wallets/DashWalletServiceIntegrationTests.swift
@@ -52,7 +52,7 @@ final class DashWalletServiceIntegrationTests: XCTestCase {
         // when 1
         let result = await Result(catchingAsync: {
             try await self.sut.createTransaction(
-                recipient: "Xp6kFbogHMD4QRBDLQdqRp5zUgzmfj1KPn",
+                recipient: Constants.recipient,
                 amount: 0.01,
                 fee: 0.0000001,
                 comment: nil
@@ -74,7 +74,7 @@ final class DashWalletServiceIntegrationTests: XCTestCase {
         let result2 = await Result {
             try await self.sut.sendTransaction(transaction)
         }
-        // then 3
+        // then 2
         XCTAssertNil(result2.error)
         await apiCoreMock.isolated { mock in
             XCTAssertEqual(mock.invokedSendRequestBasicGenericCount, 2)
@@ -108,28 +108,17 @@ private enum Constants {
     
     static let expectedTransactionID = "d4cf3fde45d0e7ba855db9621bdc6da091856011d86f199bebd1937f7b63020a"
     
+    static let recipient = "Xp6kFbogHMD4QRBDLQdqRp5zUgzmfj1KPn"
+    
     static let expectedTransactionHex = "0100000001721f0c2437124acb8a20fea5af60908057b086118b240119adcb39c890b4c3a2010000006a473044022002e19bc62748ca3f34a6e5f1aeab31bb3dc43997792d9551e9b8c51a094abbae02200e3c9bde7c60326ef6984045a81304a9915e8fbce96de01813fe89886ef26453012102cd3dcbdfc1b77e54b3a8f273310806ab56b0c2463c2f1677c7694a89a713e0d0ffffffff0240420f00000000001976a914931ef5cbdad28723ba9596de5da1145ae969a71888acb695a905000000001976a91457f6f900ac7a7e3ccab712326cd7b85638fc15a888ac00000000"
     
-    static let unspentTranscationsData = unspentTransactionsRawJSON.data(using: .utf8)!
-    
-    static let unspentTransactionsRawJSON: String = """
-{
-"result": [{
-    "txid":"a2c3b490c839cbad1901248b1186b057809060afa5fe208acb4a1237240c1f72",
-    "address": "Xp6kFbogHMD4QRBDLQdqRp5zUgzmfj1KPn",
-    "outputIndex": 1,
-    "script": "76a914931ef5cbdad28723ba9596de5da1145ae969a71888ac",
-    "satoshis": 96000000,
-    "height": 2209770
-    }]
-}
-"""
-    
-    static let sendTransactionResponseData = sendTransactionResponseRawJSON.data(using: .utf8)!
-    
-    static let sendTransactionResponseRawJSON: String = """
-{
-  "result": "d4cf3fde45d0e7ba855db9621bdc6da091856011d86f199bebd1937f7b63020a"
-}
-"""
+    static let unspentTranscationsData = Data.readResource(
+        name: "dash_unspent_transaction_intergration_test",
+        withExtension: "json"
+    )!
+
+    static let sendTransactionResponseData = Data.readResource(
+        name: "dash_send_transation_response",
+        withExtension: "json"
+    )!
 }

--- a/AdamantTests/Modules/Wallets/DashWalletServiceIntegrationTests.swift
+++ b/AdamantTests/Modules/Wallets/DashWalletServiceIntegrationTests.swift
@@ -1,0 +1,135 @@
+//
+//  DashWalletServiceIntegrationTests.swift
+//  Adamant
+//
+//  Created by Christian Benua on 24.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import XCTest
+@testable import Adamant
+import Swinject
+import BitcoinKit
+import CommonKit
+
+final class DashWalletServiceIntegrationTests: XCTestCase {
+    
+    private var apiCoreMock: APICoreProtocolMock!
+    private var lastTransactionStorageMock: DashLastTransactionStorageProtocolMock!
+    private var dashApiServiceProtocolMock: DashApiServiceProtocolMock!
+    private var sut: DashWalletService!
+    
+    override func setUp() {
+        super.setUp()
+        apiCoreMock = APICoreProtocolMock()
+        dashApiServiceProtocolMock = DashApiServiceProtocolMock()
+        dashApiServiceProtocolMock.api = DashApiCore(apiCore: apiCoreMock)
+        lastTransactionStorageMock = DashLastTransactionStorageProtocolMock()
+        
+        sut = DashWalletService()
+        sut.lastTransactionStorage = lastTransactionStorageMock
+        sut.addressConverter = AddressConverterFactory().make(network: DashMainnet())
+        sut.dashApiService = dashApiServiceProtocolMock
+        sut.transactionFactory = BitcoinKitTransactionFactory()
+    }
+    
+    override func tearDown() {
+        apiCoreMock = nil
+        dashApiServiceProtocolMock = nil
+        lastTransactionStorageMock = nil
+        sut = nil
+        super.tearDown()
+    }
+    
+    func test_createAndSendTransaction_createsValidTxIdAndHash() async throws {
+        // given
+        sut.setWalletForTests(try makeWallet())
+        let data = Constants.unspentTranscationsData
+        await apiCoreMock.isolated { mock in
+            mock.stubbedSendRequestBasicGenericResult = APIResponseModel(result: .success(data), data: data, code: 200)
+        }
+        
+        // when 1
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: "Xp6kFbogHMD4QRBDLQdqRp5zUgzmfj1KPn",
+                amount: 0.01,
+                fee: 0.0000001,
+                comment: nil
+            )
+        })
+        
+        // then 1
+        let transaction = try XCTUnwrap(result.value)
+        XCTAssertEqual(transaction.serialized().hex, Constants.expectedTransactionHex)
+        XCTAssertEqual(transaction.txID, Constants.expectedTransactionID)
+        
+        // given 2
+        let txData = Constants.sendTransactionResponseData
+        await apiCoreMock.isolated { mock in
+            mock.stubbedSendRequestBasicGenericResult = APIResponseModel(result: .success(txData), data: txData, code: 200)
+        }
+        
+        // when 2
+        let result2 = await Result {
+            try await self.sut.sendTransaction(transaction)
+        }
+        // then 3
+        XCTAssertNil(result2.error)
+        await apiCoreMock.isolated { mock in
+            XCTAssertEqual(mock.invokedSendRequestBasicGenericCount, 2)
+        }
+    }
+}
+
+// MARK: Private
+
+private extension DashWalletServiceIntegrationTests {
+    func makeWallet() throws -> DashWallet {
+        let privateKeyData = Constants.passphrase
+            .data(using: .utf8)!
+            .sha256()
+        let privateKey = PrivateKey(
+            data: privateKeyData,
+            network: DashMainnet(),
+            isPublicKeyCompressed: true
+        )
+        return try DashWallet(
+            unicId: "DASHDASH",
+            privateKey: privateKey,
+            addressConverter: AddressConverterFactory().make(network: DashMainnet())
+        )
+    }
+}
+
+private enum Constants {
+    
+    static let passphrase = "village lunch say patrol glow first hurt shiver name method dolphin dead"
+    
+    static let expectedTransactionID = "d4cf3fde45d0e7ba855db9621bdc6da091856011d86f199bebd1937f7b63020a"
+    
+    static let expectedTransactionHex = "0100000001721f0c2437124acb8a20fea5af60908057b086118b240119adcb39c890b4c3a2010000006a473044022002e19bc62748ca3f34a6e5f1aeab31bb3dc43997792d9551e9b8c51a094abbae02200e3c9bde7c60326ef6984045a81304a9915e8fbce96de01813fe89886ef26453012102cd3dcbdfc1b77e54b3a8f273310806ab56b0c2463c2f1677c7694a89a713e0d0ffffffff0240420f00000000001976a914931ef5cbdad28723ba9596de5da1145ae969a71888acb695a905000000001976a91457f6f900ac7a7e3ccab712326cd7b85638fc15a888ac00000000"
+    
+    static let unspentTranscationsData = unspentTransactionsRawJSON.data(using: .utf8)!
+    
+    static let unspentTransactionsRawJSON: String = """
+{
+"result": [{
+    "txid":"a2c3b490c839cbad1901248b1186b057809060afa5fe208acb4a1237240c1f72",
+    "address": "Xp6kFbogHMD4QRBDLQdqRp5zUgzmfj1KPn",
+    "outputIndex": 1,
+    "script": "76a914931ef5cbdad28723ba9596de5da1145ae969a71888ac",
+    "satoshis": 96000000,
+    "height": 2209770
+    }]
+}
+"""
+    
+    static let sendTransactionResponseData = sendTransactionResponseRawJSON.data(using: .utf8)!
+    
+    static let sendTransactionResponseRawJSON: String = """
+{
+  "result": "d4cf3fde45d0e7ba855db9621bdc6da091856011d86f199bebd1937f7b63020a"
+}
+"""
+}

--- a/AdamantTests/Modules/Wallets/DashWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/DashWalletServiceTests.swift
@@ -111,7 +111,7 @@ final class DashWalletServiceTests: XCTestCase {
     func test_createTransaction_badUnspentTransactionResponseDataThrowsError() async throws {
         // given
         sut.setWalletForTests(try makeWallet())
-        let data = Constants.unspentTranscationsCorruptedData
+        let data = Constants.unspentTransactionsCorruptedData
         await apiCoreMock.isolated { mock in
             mock.stubbedSendRequestBasicGenericResult = APIResponseModel(result: .success(data), data: data, code: 200)
         }
@@ -268,64 +268,23 @@ private enum Constants {
     
     static let lastTransactionId = "lastTransactionId"
     
-    static let getTransactionZeroConfirmationsData = getTransactionZeroConfirmationsJSON.data(using: .utf8)!
-    
     // RPCResponseModel with BTCRawTransaction inside data
-    static let getTransactionZeroConfirmationsJSON = """
-{
-    "id": "some id",
-    "result": {
-      "txid": "some txid",
-      "confirmations": 0,
-      "hash": "some hash",
-      "valueIn": 1,
-      "valueOut": 0.95,
-      "vin": [],
-      "vout": []
-    }
-}
-"""
+    static let getTransactionZeroConfirmationsData = Data.readResource(
+        name: "dash_unverified_unspent_transactions",
+        withExtension: "json"
+    )!
     
-    static let unspentTranscationsData = unspentTranscationsRawJSON.data(using: .utf8)!
+    static let unspentTranscationsData = Data.readResource(
+        name: "dash_unspent_transaction_unit_test",
+        withExtension: "json"
+    )!
     
-    static let unspentTranscationsCorruptedData = Data(unspentTranscationsData.shuffled())
+    static let unspentTransactionsCorruptedData = Data()
     
-    static let unspentTranscationsRawJSON: String = """
-{
-"result": [
-  {
-    "txid": "1",
-    "script": "some script",
-    "address": "some address",
-    "outputIndex": 1,
-    "satoshis": 30,
-    "height": 1,
-    "status": {
-        "confirmed": true
-    }
-  },
-  {
-    "txid": "1",
-    "script": "some script",
-    "address": "some address",
-    "outputIndex": 2,
-    "satoshis": 20,
-    "height": 1,
-    "status": {
-        "confirmed": true
-    }
-  }
-]
-}
-"""
-    
-    static let sendTransactionResponseData = sendTransactionResponseRawJSON.data(using: .utf8)!
-    
-    static let sendTransactionResponseRawJSON: String = """
-{
-  "result": "txid"
-}
-"""
+    static let sendTransactionResponseData = Data.readResource(
+        name: "dash_send_transaction_unit_response",
+        withExtension: "json"
+    )!
     
     static let expectedUnspentTransactions = [
         UnspentTransaction(

--- a/AdamantTests/Modules/Wallets/DashWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/DashWalletServiceTests.swift
@@ -1,0 +1,363 @@
+//
+//  DashWalletServiceTests.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import BitcoinKit
+import CommonKit
+import XCTest
+
+final class DashWalletServiceTests: XCTestCase {
+    
+    private var sut: DashWalletService!
+    private var lastTransactionStorageMock: DashLastTransactionStorageProtocolMock!
+    private var apiServiceMock: DashApiServiceProtocolMock!
+    private var apiCoreMock: APICoreProtocolMock!
+    private var transactionFactoryMock: BitcoinKitTransactionFactoryProtocolMock!
+    
+    override func setUp() {
+        super.setUp()
+        
+        lastTransactionStorageMock = DashLastTransactionStorageProtocolMock()
+        transactionFactoryMock = BitcoinKitTransactionFactoryProtocolMock()
+        transactionFactoryMock.stubbedTransactionFactory = {
+            BitcoinKit.Transaction.createNewTransaction(
+                toAddress: $0,
+                amount: $1,
+                fee: $2,
+                changeAddress: $3,
+                utxos: $4,
+                lockTime: $5,
+                keys: $6
+            )
+        }
+        apiCoreMock = APICoreProtocolMock()
+        apiServiceMock = DashApiServiceProtocolMock()
+        apiServiceMock.api = DashApiCore(apiCore: apiCoreMock)
+        sut = DashWalletService()
+        
+        sut.dashApiService = apiServiceMock
+        sut.lastTransactionStorage = lastTransactionStorageMock
+        sut.addressConverter = makeAddressConverter()
+        sut.transactionFactory = transactionFactoryMock
+    }
+    
+    override func tearDown() {
+        sut = nil
+        apiServiceMock = nil
+        lastTransactionStorageMock = nil
+        apiCoreMock = nil
+        transactionFactoryMock = nil
+        
+        super.tearDown()
+    }
+    
+    func test_createTransaction_throwsErrorWhenHasLastTransactionIdAndNotEnoughConfirmations() async throws {
+        // given
+        lastTransactionStorageMock.stubbedLastTransactionId = Constants.lastTransactionId
+        await apiCoreMock.isolated { mock in
+            mock.stubbedSendRequestBasicResult = APIResponseModel(
+                result: .success(Constants.getTransactionZeroConfirmationsData),
+                data: Constants.getTransactionZeroConfirmationsData,
+                code: 200
+            )
+        }
+        
+        // when
+        let result = await Result {
+            try await self.sut.create(recipient: Constants.invalidDashAddress, amount: 10)
+        }
+        
+        // then
+        switch result.error as? WalletServiceError {
+        case .remoteServiceError?:
+            break
+        default:
+            XCTFail("Expected .remoteServiceError, but got \(result.error) error")
+        }
+    }
+    
+    func test_createTransaction_throwsErrorWhenNoWallet() async throws {
+        // given
+        lastTransactionStorageMock.stubbedLastTransactionId = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.create(recipient: Constants.invalidDashAddress, amount: 10)
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notLogged)
+    }
+    
+    func test_createTransaction_throwsErrorWhenInvalidRecipient() async throws {
+        // given
+        sut.setWalletForTests(try makeWallet())
+        lastTransactionStorageMock.stubbedLastTransactionId = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.create(recipient: Constants.invalidDashAddress, amount: 10)
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+    }
+    
+    func test_createTransaction_badUnspentTransactionResponseDataThrowsError() async throws {
+        // given
+        sut.setWalletForTests(try makeWallet())
+        let data = Constants.unspentTranscationsCorruptedData
+        await apiCoreMock.isolated { mock in
+            mock.stubbedSendRequestBasicGenericResult = APIResponseModel(result: .success(data), data: data, code: 200)
+        }
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.validDashAddress,
+                amount: 30 / DashWalletService.multiplier,
+                fee: 1 / DashWalletService.multiplier,
+                comment: nil)
+        })
+        
+        // then
+        XCTAssertNotNil(result.error)
+    }
+    
+    func test_createTransaction_notEnoughMoneyThrowsError() async throws {
+        // given
+        sut.setWalletForTests(try makeWallet())
+        let data = Constants.unspentTranscationsData
+        await apiCoreMock.isolated { mock in
+            mock.stubbedSendRequestBasicGenericResult = APIResponseModel(result: .success(data), data: data, code: 200)
+        }
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.validDashAddress,
+                amount: 130 / DashWalletService.multiplier,
+                fee: 1 / DashWalletService.multiplier,
+                comment: nil)
+        })
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notEnoughMoney)
+    }
+    
+    func test_createTransaction_enoughMoneyReturnsRealTransaction() async throws {
+        // given
+        sut.setWalletForTests(try makeWallet())
+        let data = Constants.unspentTranscationsData
+        await apiCoreMock.isolated { mock in
+            mock.stubbedSendRequestBasicGenericResult = APIResponseModel(result: .success(data), data: data, code: 200)
+        }
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.validDashAddress,
+                amount: 30 / DashWalletService.multiplier,
+                fee: 1 / DashWalletService.multiplier,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertNil(result.error)
+        XCTAssertEqual(result.value?.version, Constants.expectedTransaction.version)
+        XCTAssertEqual(result.value?.outputs, Constants.expectedTransaction.outputs)
+        XCTAssertEqual(
+            transactionFactoryMock.invokedCreateTransactionParameters?.amount,
+            30
+        )
+        XCTAssertEqual(
+            transactionFactoryMock.invokedCreateTransactionParameters?.fee,
+            1
+        )
+        XCTAssertEqual(
+            transactionFactoryMock.invokedCreateTransactionParameters?.utxos,
+            Constants.expectedUnspentTransactions
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(transactionFactoryMock.invokedCreateTransactionParameters?.toAddress).stringValue,
+            Constants.validDashAddress
+        )
+        
+        XCTAssertEqual(
+            try XCTUnwrap(transactionFactoryMock.invokedCreateTransactionParameters?.changeAddress).stringValue,
+            try makeWallet().address
+        )
+    }
+    
+    func test_createAndSendTransaction_updatesLastTransactionId() async throws {
+        // given
+        sut.setWalletForTests(try makeWallet())
+        let data = Constants.unspentTranscationsData
+        await apiCoreMock.isolated { mock in
+            mock.stubbedSendRequestBasicGenericResult = APIResponseModel(result: .success(data), data: data, code: 200)
+        }
+        
+        // when 1
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.validDashAddress,
+                amount: 30 / DashWalletService.multiplier,
+                fee: 1 / DashWalletService.multiplier,
+                comment: nil
+            )
+        })
+        
+        // then 1
+        XCTAssertNil(result.error)
+        let transaction = try XCTUnwrap(result.value)
+        
+        // given 2
+        await apiCoreMock.isolated { mock in
+            mock.stubbedSendRequestBasicGenericResult = APIResponseModel(
+                result: .success(Constants.sendTransactionResponseData),
+                data: Constants.sendTransactionResponseData,
+                code: 200
+            )
+        }
+        
+        // when 2
+        let result2 = await Result(catchingAsync: {
+            try await self.sut.sendTransaction(transaction)
+        })
+        
+        // then 2
+        XCTAssertNil(result2.error)
+        XCTAssertEqual(lastTransactionStorageMock.invokedSetLastTransactionIdCount, 1)
+        XCTAssertEqual(lastTransactionStorageMock.invokedSetLastTransactionIdParameters, transaction.txID)
+    }
+}
+
+// MARK: Private
+
+private extension DashWalletServiceTests {
+    func makeWallet() throws -> DashWallet {
+        let privateKeyData = Constants.passphrase.data(using: .utf8)!.sha256()
+        let key = PrivateKey(data: privateKeyData, network: DashMainnet(), isPublicKeyCompressed: true)
+        return try DashWallet(
+            unicId: Constants.tokenUnicId,
+            privateKey: key,
+            addressConverter: makeAddressConverter()
+        )
+    }
+    
+    func makeAddressConverter() -> AddressConverter {
+        AddressConverterFactory().make(network: DashMainnet())
+    }
+}
+
+private enum Constants {
+    
+    static let tokenUnicId = "DASHDASH"
+    
+    static let validDashAddress = "Xp6kFbogHMD4QRBDLQdqRp5zUgzmfj1KPn"
+    
+    static let invalidDashAddress = "recipient"
+    
+    static let passphrase = "village lunch say patrol glow first hurt shiver name method dolphin dead"
+    
+    static let lastTransactionId = "lastTransactionId"
+    
+    static let getTransactionZeroConfirmationsData = getTransactionZeroConfirmationsJSON.data(using: .utf8)!
+    
+    // RPCResponseModel with BTCRawTransaction inside data
+    static let getTransactionZeroConfirmationsJSON = """
+{
+    "id": "some id",
+    "result": {
+      "txid": "some txid",
+      "confirmations": 0,
+      "hash": "some hash",
+      "valueIn": 1,
+      "valueOut": 0.95,
+      "vin": [],
+      "vout": []
+    }
+}
+"""
+    
+    static let unspentTranscationsData = unspentTranscationsRawJSON.data(using: .utf8)!
+    
+    static let unspentTranscationsCorruptedData = Data(unspentTranscationsData.shuffled())
+    
+    static let unspentTranscationsRawJSON: String = """
+{
+"result": [
+  {
+    "txid": "1",
+    "script": "some script",
+    "address": "some address",
+    "outputIndex": 1,
+    "satoshis": 30,
+    "height": 1,
+    "status": {
+        "confirmed": true
+    }
+  },
+  {
+    "txid": "1",
+    "script": "some script",
+    "address": "some address",
+    "outputIndex": 2,
+    "satoshis": 20,
+    "height": 1,
+    "status": {
+        "confirmed": true
+    }
+  }
+]
+}
+"""
+    
+    static let sendTransactionResponseData = sendTransactionResponseRawJSON.data(using: .utf8)!
+    
+    static let sendTransactionResponseRawJSON: String = """
+{
+  "result": "txid"
+}
+"""
+    
+    static let expectedUnspentTransactions = [
+        UnspentTransaction(
+            output: TransactionOutput(value: 30, lockingScript: Constants.lockingScript2),
+            outpoint: TransactionOutPoint(hash: Data(), index: 1)
+        ),
+        UnspentTransaction(
+            output: TransactionOutput(value: 20, lockingScript: Constants.lockingScript2),
+            outpoint: TransactionOutPoint(hash: Data(), index: 2)
+        )
+    ]
+    
+    static let expectedTransaction = BitcoinKit.Transaction(
+        version: 1,
+        inputs: [
+            TransactionInput(previousOutput: TransactionOutPoint(hash: Data(), index: 1), signatureScript: Data(), sequence: 4294967295),
+            TransactionInput(previousOutput: TransactionOutPoint(hash: Data(), index: 2), signatureScript: Data(), sequence: 4294967295)
+        ],
+        outputs: [
+            TransactionOutput(
+                value: 30,
+                lockingScript: Constants.lockingScript
+            ),
+            TransactionOutput(
+                value: 19,
+                lockingScript: Constants.lockingScript2
+            )
+        ],
+        lockTime: 0
+    )
+    
+    static let lockingScript = Data([118, 169, 20, 147, 30, 245, 203, 218, 210, 135, 35, 186, 149, 150, 222, 93, 161, 20, 90, 233, 105, 167, 24, 136, 172])
+    
+    static let lockingScript2 = Data([118, 169, 20, 87, 246, 249, 0, 172, 122, 126, 60, 202, 183, 18, 50, 108, 215, 184, 86, 56, 252, 21, 168, 136, 172])
+}

--- a/AdamantTests/Stubs/DashApiServiceProtocolMock.swift
+++ b/AdamantTests/Stubs/DashApiServiceProtocolMock.swift
@@ -1,8 +1,8 @@
 //
-//  BtcApiServiceProtocol.swift
+//  DashApiServiceProtocolMock.swift
 //  Adamant
 //
-//  Created by Christian Benua on 09.01.2025.
+//  Created by Christian Benua on 23.01.2025.
 //  Copyright © 2025 Adamant. All rights reserved.
 //
 
@@ -10,9 +10,8 @@
 import CommonKit
 import Foundation
 
-final class BtcApiServiceProtocolMock: BtcApiServiceProtocol {
-    
-    var api: BtcApiCore!
+final class DashApiServiceProtocolMock: DashApiServiceProtocol {
+    var api: DashApiCore!
     
     func request<Output>(
         waitsForConnectivity: Bool,

--- a/AdamantTests/Stubs/DashLastTransactionStorageProtocolMock.swift
+++ b/AdamantTests/Stubs/DashLastTransactionStorageProtocolMock.swift
@@ -1,0 +1,29 @@
+//
+//  DashLastTransactionStorageProtocolMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 22.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import CommonKit
+
+final class DashLastTransactionStorageProtocolMock: DashLastTransactionStorageProtocol {
+    
+    var stubbedLastTransactionId: String?
+
+    func getLastTransactionId() -> String? {
+        return stubbedLastTransactionId
+    }
+    
+    var invokedSetLastTransactionId: Bool = false
+    var invokedSetLastTransactionIdCount: Int = 0
+    var invokedSetLastTransactionIdParameters: String?
+    
+    func setLastTransactionId(_ id: String?) {
+        invokedSetLastTransactionId = true
+        invokedSetLastTransactionIdCount += 1
+        invokedSetLastTransactionIdParameters = id
+    }
+}

--- a/AdamantTests/Stubs/EthApiServiceProtocolMock.swift
+++ b/AdamantTests/Stubs/EthApiServiceProtocolMock.swift
@@ -22,7 +22,7 @@ final class EthApiServiceProtocolMock: EthApiServiceProtocol {
         _ request: @escaping @Sendable (Web3) async throws -> Output
     ) async -> WalletServiceResult<Output>  {
         await api.performRequest(
-            origin: NodeOrigin(url: URL(string: "http://samplenodeorigin.com")!)
+            origin: .mock
         ) { _ in
             try await request(self.web3)
         }
@@ -34,7 +34,7 @@ final class EthApiServiceProtocolMock: EthApiServiceProtocol {
     ) async -> WalletServiceResult<Output> {
         await request(
             api.apiCore,
-            NodeOrigin(url: URL(string: "http://samplenodeorigin.com")!)
+            .mock
         ).mapError { $0.asWalletServiceError() }
     }
     

--- a/AdamantTests/Stubs/RequestStubs/dash_send_transaction_unit_response.json
+++ b/AdamantTests/Stubs/RequestStubs/dash_send_transaction_unit_response.json
@@ -1,0 +1,3 @@
+{
+    "result": "txid"
+}

--- a/AdamantTests/Stubs/RequestStubs/dash_send_transation_response.json
+++ b/AdamantTests/Stubs/RequestStubs/dash_send_transation_response.json
@@ -1,0 +1,3 @@
+{
+    "result": "d4cf3fde45d0e7ba855db9621bdc6da091856011d86f199bebd1937f7b63020a"
+}

--- a/AdamantTests/Stubs/RequestStubs/dash_unspent_transaction_intergration_test.json
+++ b/AdamantTests/Stubs/RequestStubs/dash_unspent_transaction_intergration_test.json
@@ -1,0 +1,10 @@
+{
+    "result": [{
+        "txid":"a2c3b490c839cbad1901248b1186b057809060afa5fe208acb4a1237240c1f72",
+        "address": "Xp6kFbogHMD4QRBDLQdqRp5zUgzmfj1KPn",
+        "outputIndex": 1,
+        "script": "76a914931ef5cbdad28723ba9596de5da1145ae969a71888ac",
+        "satoshis": 96000000,
+        "height": 2209770
+    }]
+}

--- a/AdamantTests/Stubs/RequestStubs/dash_unspent_transaction_unit_test.json
+++ b/AdamantTests/Stubs/RequestStubs/dash_unspent_transaction_unit_test.json
@@ -1,0 +1,26 @@
+{
+    "result": [
+        {
+            "txid": "1",
+            "script": "some script",
+            "address": "some address",
+            "outputIndex": 1,
+            "satoshis": 30,
+            "height": 1,
+            "status": {
+                "confirmed": true
+            }
+        },
+        {
+            "txid": "1",
+            "script": "some script",
+            "address": "some address",
+            "outputIndex": 2,
+            "satoshis": 20,
+            "height": 1,
+            "status": {
+                "confirmed": true
+            }
+        }
+    ]
+}

--- a/AdamantTests/Stubs/RequestStubs/dash_unverified_unspent_transactions.json
+++ b/AdamantTests/Stubs/RequestStubs/dash_unverified_unspent_transactions.json
@@ -1,0 +1,12 @@
+{
+    "id": "some id",
+    "result": {
+        "txid": "some txid",
+        "confirmations": 0,
+        "hash": "some hash",
+        "valueIn": 1,
+        "valueOut": 0.95,
+        "vin": [],
+        "vout": []
+    }
+}


### PR DESCRIPTION
DashWalletService - is like `BtcWalletService` but with slightly different API contract + logic with lastTransactionId.

For testing logic with lastTransactionId I've made `DashLastTransactionStorageProtocol`. It's used in both unit-tests and integration tests. 

Test where lastTransaction has not enough confirmations is named `test_createTransaction_throwsErrorWhenHasLastTransactionIdAndNotEnoughConfirmations`.

All other cases are almost similar to `BtcWalletService` tests with slightly mock differences