### PR TITLE
[trello.com/c/YrmN2oiR]: ERC20WalletService tests

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 		AA33BEB62D303E240083E59C /* APICoreProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB52D303DB60083E59C /* APICoreProtocolMock.swift */; };
 		AA33BEB72D3041A30083E59C /* AddressConverterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB42D303CBD0083E59C /* AddressConverterMock.swift */; };
 		AA33BEB92D3044760083E59C /* BtcApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */; };
+		AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */; };
 		AAB01CAD2D3AE44B007D6BF4 /* BitcoinKitTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */; };
 		AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */; };
 		AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */; };
@@ -480,7 +481,6 @@
 		AAC641412D4049DA00619DFE /* RpsRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641402D4049D400619DFE /* RpsRequestBody.swift */; };
 		AAC641452D404AE100619DFE /* KlyTransactionSubmitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */; };
 		AAC641472D404D8400619DFE /* URLSessionSwizzlingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */; };
-		AAC641552D42D74800619DFE /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641542D42D74300619DFE /* NodeOrigin+Extensions.swift */; };
 		AAC641592D44F81700619DFE /* ERC20WalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */; };
 		AAC6415B2D44FB0100619DFE /* ERC20ApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */; };
 		AAC6415D2D44FD5B00619DFE /* ERC20ApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */; };
@@ -1128,6 +1128,7 @@
 		AA33BEB42D303CBD0083E59C /* AddressConverterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressConverterMock.swift; sourceTree = "<group>"; };
 		AA33BEB52D303DB60083E59C /* APICoreProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICoreProtocolMock.swift; sourceTree = "<group>"; };
 		AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BtcApiServiceProtocolMock.swift; sourceTree = "<group>"; };
+		AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
 		AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinKitTransactionFactory.swift; sourceTree = "<group>"; };
 		AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeWalletServiceTests.swift; sourceTree = "<group>"; };
 		AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeApiServiceProtocol.swift; sourceTree = "<group>"; };
@@ -1143,7 +1144,6 @@
 		AAC641402D4049D400619DFE /* RpsRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RpsRequestBody.swift; sourceTree = "<group>"; };
 		AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyTransactionSubmitModel.swift; sourceTree = "<group>"; };
 		AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlingMock.swift; sourceTree = "<group>"; };
-		AAC641542D42D74300619DFE /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
 		AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20WalletServiceTests.swift; sourceTree = "<group>"; };
 		AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocol.swift; sourceTree = "<group>"; };
 		AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocolMock.swift; sourceTree = "<group>"; };
@@ -2359,6 +2359,7 @@
 		AAFB3C892D31C0C4000CCCE9 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */,
 				AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */,
 				AAFB3CA42D3854B7000CCCE9 /* MockURLProtocol.swift */,
 				AAFB3C962D31CB6B000CCCE9 /* UnspentTransaction+Equatable.swift */,
@@ -3991,6 +3992,7 @@
 				AAFB3CA32D384F52000CCCE9 /* IEthMock.swift in Sources */,
 				AAFB3C952D31C58B000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift in Sources */,
 				AAFB3CA12D384AF7000CCCE9 /* IncreaseFeeServiceMock.swift in Sources */,
+				AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -480,6 +480,10 @@
 		AAC641412D4049DA00619DFE /* RpsRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641402D4049D400619DFE /* RpsRequestBody.swift */; };
 		AAC641452D404AE100619DFE /* KlyTransactionSubmitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */; };
 		AAC641472D404D8400619DFE /* URLSessionSwizzlingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */; };
+		AAC641552D42D74800619DFE /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641542D42D74300619DFE /* NodeOrigin+Extensions.swift */; };
+		AAC641592D44F81700619DFE /* ERC20WalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */; };
+		AAC6415B2D44FB0100619DFE /* ERC20ApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */; };
+		AAC6415D2D44FD5B00619DFE /* ERC20ApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */; };
 		AAFB3C8B2D31C0DD000CCCE9 /* Actor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8A2D31C0D0000CCCE9 /* Actor+Extensions.swift */; };
 		AAFB3C8D2D31C0EE000CCCE9 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8C2D31C0EA000CCCE9 /* Result+Extensions.swift */; };
 		AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */; };
@@ -1139,6 +1143,10 @@
 		AAC641402D4049D400619DFE /* RpsRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RpsRequestBody.swift; sourceTree = "<group>"; };
 		AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlyTransactionSubmitModel.swift; sourceTree = "<group>"; };
 		AAC641462D404D7000619DFE /* URLSessionSwizzlingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlingMock.swift; sourceTree = "<group>"; };
+		AAC641542D42D74300619DFE /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
+		AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20WalletServiceTests.swift; sourceTree = "<group>"; };
+		AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocol.swift; sourceTree = "<group>"; };
+		AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC20ApiServiceProtocolMock.swift; sourceTree = "<group>"; };
 		AAFB3C8A2D31C0D0000CCCE9 /* Actor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Actor+Extensions.swift"; sourceTree = "<group>"; };
 		AAFB3C8C2D31C0EA000CCCE9 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		AAFB3C8E2D31C110000CCCE9 /* WalletServiceError+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletServiceError+Equatable.swift"; sourceTree = "<group>"; };
@@ -1753,6 +1761,7 @@
 		6449BA5D235CA0930033B936 /* ERC20 */ = {
 			isa = PBXGroup;
 			children = (
+				AAC6415A2D44FAFB00619DFE /* ERC20ApiServiceProtocol.swift */,
 				6449BA66235CA0930033B936 /* ERC20WalletFactory.swift */,
 				6449BA60235CA0930033B936 /* ERC20Wallet.swift */,
 				6449BA5E235CA0930033B936 /* ERC20WalletService.swift */,
@@ -2316,6 +2325,7 @@
 				AAC641342D40324D00619DFE /* KlyWalletServiceTests.swift */,
 				AAC641322D3ED1B200619DFE /* DogeWalletServiceIntegrationTests.swift */,
 				AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */,
+				AAC641582D44F81000619DFE /* ERC20WalletServiceTests.swift */,
 				AAFB3C9A2D383BA9000CCCE9 /* EthWalletServiceTests.swift */,
 				AAFB3C982D357E16000CCCE9 /* BtcWalletServiceIntegrationTests.swift */,
 				AA33BEB12D303C5F0083E59C /* BtcWalletServiceTests.swift */,
@@ -2326,6 +2336,7 @@
 		AA33BEB32D303CA30083E59C /* Stubs */ = {
 			isa = PBXGroup;
 			children = (
+				AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */,
 				AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */,
 				AAC641402D4049D400619DFE /* RpsRequestBody.swift */,
 				AAC6413E2D40464600619DFE /* KlyNodeApiServiceProtocolMock.swift */,
@@ -3839,6 +3850,7 @@
 				934FD9B42C78514E00336841 /* InfoServiceApiCore.swift in Sources */,
 				3AF53F8D2B3DCFA300B30312 /* NodeGroup+Constants.swift in Sources */,
 				411743002A39B1D2008CD98A /* ContributeFactory.swift in Sources */,
+				AAC6415B2D44FB0100619DFE /* ERC20ApiServiceProtocol.swift in Sources */,
 				93A2A8662CB4A1EE00DBC75E /* UnsafeSendableExtensions.swift in Sources */,
 				A5E04224282A830B0076CD13 /* BtcTransactionsViewController.swift in Sources */,
 				645938942378395E00A2BE7C /* EulaViewController.swift in Sources */,
@@ -3954,6 +3966,7 @@
 				AAFB3C9D2D383F7D000CCCE9 /* EthApiServiceProtocolMock.swift in Sources */,
 				AAFB3C992D357E1D000CCCE9 /* BtcWalletServiceIntegrationTests.swift in Sources */,
 				AAFB3C9F2D3843E0000CCCE9 /* Web3ProviderMock.swift in Sources */,
+				AAC6415D2D44FD5B00619DFE /* ERC20ApiServiceProtocolMock.swift in Sources */,
 				AAC6413F2D40466B00619DFE /* KlyNodeApiServiceProtocolMock.swift in Sources */,
 				AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */,
 				AAFB3CA72D385BBE000CCCE9 /* EthRequestBody.swift in Sources */,
@@ -3961,6 +3974,7 @@
 				AAFB3CA52D3854BB000CCCE9 /* MockURLProtocol.swift in Sources */,
 				AAC641352D40325400619DFE /* KlyWalletServiceTests.swift in Sources */,
 				AAC641412D4049DA00619DFE /* RpsRequestBody.swift in Sources */,
+				AAC641592D44F81700619DFE /* ERC20WalletServiceTests.swift in Sources */,
 				AAFB3C9B2D383BB1000CCCE9 /* EthWalletServiceTests.swift in Sources */,
 				AAC641332D3ED1BB00619DFE /* DogeWalletServiceIntegrationTests.swift in Sources */,
 				AAC641472D404D8400619DFE /* URLSessionSwizzlingMock.swift in Sources */,

--- a/Adamant/Modules/Wallets/ERC20/ERC20ApiService.swift
+++ b/Adamant/Modules/Wallets/ERC20/ERC20ApiService.swift
@@ -10,7 +10,7 @@ import web3swift
 @preconcurrency import Web3Core
 import CommonKit
 
-final class ERC20ApiService: EthApiService, @unchecked Sendable {
+final class ERC20ApiService: EthApiService, ERC20ApiServiceProtocol, @unchecked Sendable {
     func requestERC20<Output>(
         token: ERC20Token,
         _ body: @Sendable @escaping (ERC20) async throws -> Output

--- a/Adamant/Modules/Wallets/ERC20/ERC20ApiServiceProtocol.swift
+++ b/Adamant/Modules/Wallets/ERC20/ERC20ApiServiceProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  ERC20ApiServiceProtocol.swift
+//  Adamant
+//
+//  Created by Christian Benua on 25.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import web3swift
+@preconcurrency import Web3Core
+import CommonKit
+
+protocol ERC20ApiServiceProtocol: EthApiServiceProtocol {
+    
+    var keystoreManager: KeystoreManager? { get async }
+    
+    func requestERC20<Output>(
+        token: ERC20Token,
+        _ body: @Sendable @escaping (ERC20) async throws -> Output
+    ) async -> WalletServiceResult<Output>
+}

--- a/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
+++ b/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
@@ -111,7 +111,7 @@ final class ERC20WalletService: WalletCoreProtocol, @unchecked Sendable {
     // MARK: - Dependencies
     weak var accountService: AccountService?
     var apiService: AdamantApiServiceProtocol!
-    var erc20ApiService: ERC20ApiService!
+    var erc20ApiService: ERC20ApiServiceProtocol!
     var dialogService: DialogService!
     var increaseFeeService: IncreaseFeeService!
     var vibroService: VibroService!
@@ -558,6 +558,15 @@ extension ERC20WalletService {
         return result
     }
 }
+
+#if DEBUG
+extension ERC20WalletService {
+    @available(*, deprecated, message: "For testing purposes only")
+    func setWalletForTests(_ wallet: EthWallet?) {
+        self.ethWallet = wallet
+    }
+}
+#endif
 
 extension ERC20WalletService {
     func getTransactionsHistory(

--- a/AdamantTests/Extensions/NodeOrigin+Extensions.swift
+++ b/AdamantTests/Extensions/NodeOrigin+Extensions.swift
@@ -1,0 +1,14 @@
+//
+//  NodeOrigin+Extensions.swift
+//  Adamant
+//
+//  Created by Christian Benua on 23.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CommonKit
+import Foundation
+
+extension NodeOrigin {
+    static let mock = NodeOrigin(url: URL(string: "http://samplenodeorigin.com")!)
+}

--- a/AdamantTests/Modules/Wallets/ERC20WalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/ERC20WalletServiceTests.swift
@@ -159,8 +159,12 @@ final class ERC20WalletServiceTests: XCTestCase {
         XCTAssertEqual(transaction.gasPrice, BigUInt(clamping: 11).toWei())
         XCTAssertEqual(transaction.hashForSignature(), Constants.expectedHashForSignature)
     }
-    
-    private func makeDecimalsMock(_ onCall: @escaping () -> Void) {
+}
+
+// MARK: Private
+
+private extension ERC20WalletServiceTests {
+    func makeDecimalsMock(_ onCall: @escaping () -> Void) {
         let prevHandler = MockURLProtocol.requestHandler
         MockURLProtocol.requestHandler = MockURLProtocol.combineHandlers(
             prevHandler
@@ -178,7 +182,7 @@ final class ERC20WalletServiceTests: XCTestCase {
         }
     }
     
-    private func makeTransactionsCountMock() {
+    func makeTransactionsCountMock() {
         let prevHandler = MockURLProtocol.requestHandler
         MockURLProtocol.requestHandler = MockURLProtocol.combineHandlers(
             prevHandler
@@ -195,7 +199,7 @@ final class ERC20WalletServiceTests: XCTestCase {
         }
     }
     
-    private func makeResponseAndMockData<T: Codable>(
+    func makeResponseAndMockData<T: Codable>(
         url: URL,
         ethResponse: EthAPIResponse<T>
     ) throws -> (HTTPURLResponse, Data) {
@@ -210,7 +214,7 @@ final class ERC20WalletServiceTests: XCTestCase {
         return (response, mockData)
     }
     
-    private func makeSession() -> URLSession {
+    func makeSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
         return URLSession(configuration: config)

--- a/AdamantTests/Modules/Wallets/ERC20WalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/ERC20WalletServiceTests.swift
@@ -1,0 +1,258 @@
+//
+//  ERC20WalletServiceTests.swift
+//  Adamant
+//
+//  Created by Christian Benua on 25.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import BigInt
+@testable import CommonKit
+import Web3Core
+@testable import web3swift
+import XCTest
+
+final class ERC20WalletServiceTests: XCTestCase {
+    private var sut: ERC20WalletService!
+    private var erc20ApiMock: ERC20ApiServiceProtocolMock!
+    private var apiCoreProtocolMock: APICoreProtocolMock!
+    private var web3ProviderMock: Web3ProviderMock!
+    private var increaseFeeServiceMock: IncreaseFeeServiceMock!
+    private var ethMock: IEthMock!
+    private var web3: Web3!
+    private var session: URLSession!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        
+        let keystore = try XCTUnwrap(try BIP32Keystore(
+            mnemonics: Constants.passphrase,
+            password: EthWalletService.walletPassword,
+            mnemonicsPassword: "",
+            language: .english,
+            prefixPath: EthWalletService.walletPath)
+        )
+        let ethAddress = try XCTUnwrap(keystore.addresses?.first)
+        
+        let eWallet = EthWallet(
+            unicId: Constants.tokenUnicID,
+            address: ethAddress.address,
+            ethAddress: ethAddress,
+            keystore: keystore
+        )
+        web3ProviderMock = Web3ProviderMock()
+        web3 = Web3(provider: web3ProviderMock)
+        ethMock = IEthMock()
+        web3.ethInstance = ethMock
+        ethMock._provider = web3ProviderMock
+        apiCoreProtocolMock = APICoreProtocolMock()
+        let ethApi = EthApiCore(apiCore: apiCoreProtocolMock)
+        erc20ApiMock = ERC20ApiServiceProtocolMock()
+        erc20ApiMock.api = ethApi
+        erc20ApiMock.keystoreManager = .init([keystore])
+        erc20ApiMock.contractAddress = try XCTUnwrap(EthereumAddress(from: Constants.token.contractAddress))
+        erc20ApiMock.web3 = web3
+        session = makeSession()
+        web3ProviderMock.session = session
+        increaseFeeServiceMock = IncreaseFeeServiceMock()
+
+        sut = ERC20WalletService(token: Constants.token)
+        sut.setWalletForTests(eWallet)
+        sut.increaseFeeService = increaseFeeServiceMock
+        sut.erc20ApiService = erc20ApiMock
+    }
+    
+    override func tearDown() async throws {
+        sut = nil
+        erc20ApiMock = nil
+        apiCoreProtocolMock = nil
+        web3ProviderMock = nil
+        ethMock = nil
+        web3 = nil
+        session = nil
+        increaseFeeServiceMock = nil
+        try await super.tearDown()
+    }
+    
+    func test_createTransaction_noWalletThrowsError() async throws {
+        // given
+        sut.setWalletForTests(nil)
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: "recipient",
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notLogged)
+    }
+    
+    func test_createTransaction_invalidRecipientAddressThrowsError() async throws {
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.invalidEthAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+    }
+    
+    func test_createTransaction_noKeystoreThrowsError() async throws {
+        // given
+        erc20ApiMock.keystoreManager = nil
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.toEthAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        switch result.error as? WalletServiceError {
+        case .internalError:
+            break
+        default:
+            XCTFail("Expected '.internalError', but got \(String(describing: result.error))")
+        }
+    }
+    
+    func test_createTransaction_correctFields() async throws {
+        // given
+        makeTransactionsCountMock()
+        var calledMakeDecimals = false
+        makeDecimalsMock {
+            calledMakeDecimals = true
+        }
+        
+        // when
+        let result = await Result(catchingAsync: {
+            try await self.sut.createTransaction(
+                recipient: Constants.toEthAddress,
+                amount: 10,
+                fee: 0.1,
+                comment: nil
+            )
+        })
+        
+        // then
+        XCTAssertTrue(calledMakeDecimals)
+        XCTAssertNil(result.error)
+        let transaction = try XCTUnwrap(result.value)
+        XCTAssertEqual(transaction.from?.address, Constants.validEthAddress)
+        XCTAssertEqual(transaction.to.address.lowercased(), Constants.token.contractAddress.lowercased())
+        XCTAssertEqual(transaction.nonce, BigUInt(exactly: Constants.nonce))
+        XCTAssertEqual(transaction.gasPrice, BigUInt(clamping: 11).toWei())
+        XCTAssertEqual(transaction.hashForSignature(), Constants.expectedHashForSignature)
+    }
+    
+    private func makeDecimalsMock(_ onCall: @escaping () -> Void) {
+        let prevHandler = MockURLProtocol.requestHandler
+        MockURLProtocol.requestHandler = MockURLProtocol.combineHandlers(
+            prevHandler
+        ) { request in
+            guard let stream = request.httpBodyStream else { return nil }
+            
+            let ethBody = try JSONDecoder().decode(EthRequestBody.self, from: Data(reading: stream))
+            guard ethBody.method == Constants.ethCallMethod else { return nil }
+            onCall()
+            XCTAssertEqual((ethBody.params[0] as? [String: Any])?["to"] as? String, Constants.token.contractAddress.lowercased())
+            return try self.makeResponseAndMockData(
+                url: request.url!,
+                ethResponse: EthAPIResponse(result: Constants.decimalsMethodResponse)
+            )
+        }
+    }
+    
+    private func makeTransactionsCountMock() {
+        let prevHandler = MockURLProtocol.requestHandler
+        MockURLProtocol.requestHandler = MockURLProtocol.combineHandlers(
+            prevHandler
+        ) { request in
+            guard let stream = request.httpBodyStream else { return nil }
+            
+            let ethBody = try JSONDecoder().decode(EthRequestBody.self, from: Data(reading: stream))
+            guard ethBody.method == Constants.transactionCountResponseMethod else { return nil }
+            
+            return try self.makeResponseAndMockData(
+                url: request.url!,
+                ethResponse: EthAPIResponse(result: "\(Constants.nonce)")
+            )
+        }
+    }
+    
+    private func makeResponseAndMockData<T: Codable>(
+        url: URL,
+        ethResponse: EthAPIResponse<T>
+    ) throws -> (HTTPURLResponse, Data) {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        
+        let mockData = try JSONEncoder().encode(ethResponse)
+        return (response, mockData)
+    }
+    
+    private func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+private enum Constants {
+    
+    static let passphrase = "village lunch say patrol glow first hurt shiver name method dolphin sample"
+    
+    static let tokenUnicID = "ERC20\(token.symbol)\(token.contractAddress)"
+    
+    static let token = ERC20Token(
+        symbol: "BNB",
+        name: "Binance Coin",
+        contractAddress: "0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+        decimals: 18,
+        naturalUnits: 18,
+        defaultVisibility: false,
+        defaultOrdinalLevel: nil,
+        reliabilityGasPricePercent: 10,
+        reliabilityGasLimitPercent: 10,
+        defaultGasPriceGwei: 10,
+        defaultGasLimit: 58000,
+        warningGasPriceGwei: 25,
+        transferDecimals: 6
+    )
+    
+    static let toEthAddress = "0xabfDF505fFd5587D9E7707dFB47F45AF1f03E275"
+    static let invalidEthAddress = "0xBA5CE20aE344CDBd6eAA01ffdDF1976d35Be14"
+    static let validEthAddress = "0xBA5CE20aE344CDBd6eAA01ffdDF1976d35Be142d"
+    
+    static let transactionCountResponseMethod = "eth_getTransactionCount"
+    static let decimalsMethod = "decimals"
+    static let ethCallMethod = "eth_call"
+    static let nonce = 2
+    static let decimalsMethodResponse = "0x0000000000000000000000000000000000000000000000000000000000000006"
+    
+    static let expectedHashForSignature = Data([
+        19, 32, 58, 56, 131, 178, 156, 49, 149,
+        112, 90, 80, 243, 4, 152, 101, 158, 186,
+        191, 16, 58, 253, 186, 73, 77, 9, 179,
+        26, 213, 185, 77, 201
+    ])
+}

--- a/AdamantTests/Stubs/ERC20ApiServiceProtocolMock.swift
+++ b/AdamantTests/Stubs/ERC20ApiServiceProtocolMock.swift
@@ -1,0 +1,70 @@
+//
+//  ERC20ApiServiceProtocolMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 25.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import CommonKit
+import Foundation
+import web3swift
+@preconcurrency import Web3Core
+
+final class ERC20ApiServiceProtocolMock: ERC20ApiServiceProtocol {
+    
+    var keystoreManager: KeystoreManager?
+    var api: EthApiCore!
+    var web3: Web3!
+    var contractAddress: EthereumAddress!
+    
+    func requestERC20<Output>(
+        token: ERC20Token,
+        _ body: @escaping @Sendable (ERC20) async throws -> Output
+    ) async -> WalletServiceResult<Output> {
+        await api.performRequest(
+            origin: .mock
+        ) { _ in
+            let erc20 = ERC20(web3: self.web3, provider: self.web3.provider, address: self.contractAddress)
+            return try await body(erc20)
+        }
+    }
+    
+    func requestWeb3<Output>(
+        waitsForConnectivity: Bool,
+        _ request: @escaping @Sendable (Web3) async throws -> Output
+    ) async -> WalletServiceResult<Output>  {
+        await api.performRequest(
+            origin: .mock
+        ) { _ in
+            try await request(self.web3)
+        }
+    }
+    
+    func requestApiCore<Output>(
+        waitsForConnectivity: Bool,
+        _ request: @escaping @Sendable (APICoreProtocol, NodeOrigin) async -> ApiServiceResult<Output>
+    ) async -> WalletServiceResult<Output> {
+        await request(
+            api.apiCore,
+            .mock
+        ).mapError { $0.asWalletServiceError() }
+    }
+    
+    func setKeystoreManager(_ keystoreManager: KeystoreManager) async {
+        await api.setKeystoreManager(keystoreManager)
+    }
+    
+    var nodesInfo: CommonKit.NodesListInfo {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var nodesInfoPublisher: CommonKit.AnyObservable<CommonKit.NodesListInfo> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func healthCheck() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/IEthMock.swift
+++ b/AdamantTests/Stubs/IEthMock.swift
@@ -25,8 +25,14 @@ final class IEthMock: IEth {
     
     var ethDefault: EthDefault = EthDefault()
     
+    var invokedCallTransaction: Bool = false
+    var invokedCallTransactionParameters: CodableTransaction?
+    
     func callTransaction(_ transaction: CodableTransaction) async throws -> Data {
-        fatalError("\(#file).\(#function) is not implemented")
+        invokedCallTransaction = true
+        invokedCallTransactionParameters = transaction
+        
+        return try await ethDefault.callTransaction(transaction)
     }
     
     func send(_ transaction: CodableTransaction) async throws -> TransactionSendingResult {


### PR DESCRIPTION
Implemented `ERC20WalletService` tests.

Main logic is the same as in `EthWalletService` tests, but there are specific cases where I spent most of time trying to figure out.

For example, to get `multiplier` for current token, API call is used. I mock it using `makeDecimalsMock` and its response looks like `0x0000000000000000000000000000000000000000000000000000000000000006`.

Additionally `ERC20ApiServiceProtocolMock` was needed to proxy all URL calls through custom `Web3Provider` with out custom `URLSession`