### PR TITLE
[trello.com/c/DZ8C5tVP]: AdmWalletService tests

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -469,6 +469,14 @@
 		AA33BEB92D3044760083E59C /* BtcApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */; };
 		AA8FFFCA2D4E6435001D8576 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AA8FFFC92D4E6435001D8576 /* CryptoSwift */; };
 		AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */; };
+		AA8FFFB02D497175001D8576 /* AdmWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFAF2D49716D001D8576 /* AdmWalletServiceTests.swift */; };
+		AA8FFFB22D49726F001D8576 /* SecuredStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFB12D49726B001D8576 /* SecuredStoreMock.swift */; };
+		AA8FFFB42D497510001D8576 /* AccountServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFB32D497509001D8576 /* AccountServiceMock.swift */; };
+		AA8FFFB62D4975D3001D8576 /* AccountsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFB52D4975D1001D8576 /* AccountsProviderMock.swift */; };
+		AA8FFFB82D497772001D8576 /* AdamantApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFB72D49776F001D8576 /* AdamantApiServiceProtocolMock.swift */; };
+		AA8FFFBA2D4978D7001D8576 /* ChatTransactionServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFB92D4978D5001D8576 /* ChatTransactionServiceMock.swift */; };
+		AA8FFFBC2D49796A001D8576 /* ChatsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */; };
+		AA8FFFC02D4AC011001D8576 /* AdamantCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */; };
 		AAB01CAD2D3AE44B007D6BF4 /* BitcoinKitTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */; };
 		AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */; };
 		AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */; };
@@ -1136,6 +1144,14 @@
 		AA33BEB52D303DB60083E59C /* APICoreProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICoreProtocolMock.swift; sourceTree = "<group>"; };
 		AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BtcApiServiceProtocolMock.swift; sourceTree = "<group>"; };
 		AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
+		AA8FFFAF2D49716D001D8576 /* AdmWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdmWalletServiceTests.swift; sourceTree = "<group>"; };
+		AA8FFFB12D49726B001D8576 /* SecuredStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuredStoreMock.swift; sourceTree = "<group>"; };
+		AA8FFFB32D497509001D8576 /* AccountServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountServiceMock.swift; sourceTree = "<group>"; };
+		AA8FFFB52D4975D1001D8576 /* AccountsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsProviderMock.swift; sourceTree = "<group>"; };
+		AA8FFFB72D49776F001D8576 /* AdamantApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdamantApiServiceProtocolMock.swift; sourceTree = "<group>"; };
+		AA8FFFB92D4978D5001D8576 /* ChatTransactionServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTransactionServiceMock.swift; sourceTree = "<group>"; };
+		AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsProviderMock.swift; sourceTree = "<group>"; };
+		AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdamantCoreMock.swift; sourceTree = "<group>"; };
 		AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinKitTransactionFactory.swift; sourceTree = "<group>"; };
 		AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeWalletServiceTests.swift; sourceTree = "<group>"; };
 		AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeApiServiceProtocol.swift; sourceTree = "<group>"; };
@@ -2351,6 +2367,7 @@
 		AA33BEB02D303C470083E59C /* Wallets */ = {
 			isa = PBXGroup;
 			children = (
+				AA8FFFAF2D49716D001D8576 /* AdmWalletServiceTests.swift */,
 				AAC641342D40324D00619DFE /* KlyWalletServiceTests.swift */,
 				AAC641322D3ED1B200619DFE /* DogeWalletServiceIntegrationTests.swift */,
 				AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */,
@@ -2365,6 +2382,13 @@
 		AA33BEB32D303CA30083E59C /* Stubs */ = {
 			isa = PBXGroup;
 			children = (
+				AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */,
+				AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */,
+				AA8FFFB92D4978D5001D8576 /* ChatTransactionServiceMock.swift */,
+				AA8FFFB72D49776F001D8576 /* AdamantApiServiceProtocolMock.swift */,
+				AA8FFFB52D4975D1001D8576 /* AccountsProviderMock.swift */,
+				AA8FFFB32D497509001D8576 /* AccountServiceMock.swift */,
+				AA8FFFB12D49726B001D8576 /* SecuredStoreMock.swift */,
 				AAC6415C2D44FD5400619DFE /* ERC20ApiServiceProtocolMock.swift */,
 				AAC641442D404ADA00619DFE /* KlyTransactionSubmitModel.swift */,
 				AAC641402D4049D400619DFE /* RpsRequestBody.swift */,
@@ -3996,9 +4020,11 @@
 				AAFB3C972D31CB72000CCCE9 /* UnspentTransaction+Equatable.swift in Sources */,
 				AAFB3CA92D3860F2000CCCE9 /* EthResponseBody.swift in Sources */,
 				AAFB3C9D2D383F7D000CCCE9 /* EthApiServiceProtocolMock.swift in Sources */,
+				AA8FFFBC2D49796A001D8576 /* ChatsProviderMock.swift in Sources */,
 				AAFB3C992D357E1D000CCCE9 /* BtcWalletServiceIntegrationTests.swift in Sources */,
 				AAFB3C9F2D3843E0000CCCE9 /* Web3ProviderMock.swift in Sources */,
 				AAC6415D2D44FD5B00619DFE /* ERC20ApiServiceProtocolMock.swift in Sources */,
+				AA8FFFC02D4AC011001D8576 /* AdamantCoreMock.swift in Sources */,
 				AAC6413F2D40466B00619DFE /* KlyNodeApiServiceProtocolMock.swift in Sources */,
 				AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */,
 				AAFB3CA72D385BBE000CCCE9 /* EthRequestBody.swift in Sources */,
@@ -4007,9 +4033,11 @@
 				AAC641352D40325400619DFE /* KlyWalletServiceTests.swift in Sources */,
 				AAC641412D4049DA00619DFE /* RpsRequestBody.swift in Sources */,
 				AAC641592D44F81700619DFE /* ERC20WalletServiceTests.swift in Sources */,
+				AA8FFFB62D4975D3001D8576 /* AccountsProviderMock.swift in Sources */,
 				AAFB3C9B2D383BB1000CCCE9 /* EthWalletServiceTests.swift in Sources */,
 				AAC641332D3ED1BB00619DFE /* DogeWalletServiceIntegrationTests.swift in Sources */,
 				AAC641472D404D8400619DFE /* URLSessionSwizzlingMock.swift in Sources */,
+				AA8FFFB42D497510001D8576 /* AccountServiceMock.swift in Sources */,
 				AAC6413B2D403C3300619DFE /* KlyTransactionFactoryProtocolMock.swift in Sources */,
 				AA33BEB22D303C730083E59C /* BtcWalletServiceTests.swift in Sources */,
 				AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */,
@@ -4017,10 +4045,14 @@
 				AAFB3C8D2D31C0EE000CCCE9 /* Result+Extensions.swift in Sources */,
 				AAB01CB32D3AF0B4007D6BF4 /* DogeApiServiceProtocolMock.swift in Sources */,
 				AA33BEB62D303E240083E59C /* APICoreProtocolMock.swift in Sources */,
+				AA8FFFB22D49726F001D8576 /* SecuredStoreMock.swift in Sources */,
 				AAFB3C912D31C14A000CCCE9 /* BitcoinKitTransaction+Equatable.swift in Sources */,
+				AA8FFFBA2D4978D7001D8576 /* ChatTransactionServiceMock.swift in Sources */,
 				AAC641452D404AE100619DFE /* KlyTransactionSubmitModel.swift in Sources */,
+				AA8FFFB02D497175001D8576 /* AdmWalletServiceTests.swift in Sources */,
 				AAFB3C8B2D31C0DD000CCCE9 /* Actor+Extensions.swift in Sources */,
 				AAFB3CA32D384F52000CCCE9 /* IEthMock.swift in Sources */,
+				AA8FFFB82D497772001D8576 /* AdamantApiServiceProtocolMock.swift in Sources */,
 				AAFB3C952D31C58B000CCCE9 /* BitcoinKitTransactionFactoryProtocolMock.swift in Sources */,
 				AAFB3CA12D384AF7000CCCE9 /* IncreaseFeeServiceMock.swift in Sources */,
 				AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */,

--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		AA8FFFBA2D4978D7001D8576 /* ChatTransactionServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFB92D4978D5001D8576 /* ChatTransactionServiceMock.swift */; };
 		AA8FFFBC2D49796A001D8576 /* ChatsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */; };
 		AA8FFFC02D4AC011001D8576 /* AdamantCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */; };
+		AA8FFFC42D4C1174001D8576 /* NativeAdamantCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFC32D4C1168001D8576 /* NativeAdamantCoreTests.swift */; };
 		AAB01CAD2D3AE44B007D6BF4 /* BitcoinKitTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */; };
 		AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */; };
 		AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */; };
@@ -1152,6 +1153,7 @@
 		AA8FFFB92D4978D5001D8576 /* ChatTransactionServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTransactionServiceMock.swift; sourceTree = "<group>"; };
 		AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsProviderMock.swift; sourceTree = "<group>"; };
 		AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdamantCoreMock.swift; sourceTree = "<group>"; };
+		AA8FFFC32D4C1168001D8576 /* NativeAdamantCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAdamantCoreTests.swift; sourceTree = "<group>"; };
 		AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinKitTransactionFactory.swift; sourceTree = "<group>"; };
 		AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeWalletServiceTests.swift; sourceTree = "<group>"; };
 		AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeApiServiceProtocol.swift; sourceTree = "<group>"; };
@@ -2367,6 +2369,7 @@
 		AA33BEB02D303C470083E59C /* Wallets */ = {
 			isa = PBXGroup;
 			children = (
+				AA8FFFC32D4C1168001D8576 /* NativeAdamantCoreTests.swift */,
 				AA8FFFAF2D49716D001D8576 /* AdmWalletServiceTests.swift */,
 				AAC641342D40324D00619DFE /* KlyWalletServiceTests.swift */,
 				AAC641322D3ED1B200619DFE /* DogeWalletServiceIntegrationTests.swift */,
@@ -4027,6 +4030,7 @@
 				AA8FFFC02D4AC011001D8576 /* AdamantCoreMock.swift in Sources */,
 				AAC6413F2D40466B00619DFE /* KlyNodeApiServiceProtocolMock.swift in Sources */,
 				AAFB3C8F2D31C119000CCCE9 /* WalletServiceError+Equatable.swift in Sources */,
+				AA8FFFC42D4C1174001D8576 /* NativeAdamantCoreTests.swift in Sources */,
 				AAFB3CA72D385BBE000CCCE9 /* EthRequestBody.swift in Sources */,
 				AA33BEB92D3044760083E59C /* BtcApiServiceProtocolMock.swift in Sources */,
 				AAFB3CA52D3854BB000CCCE9 /* MockURLProtocol.swift in Sources */,

--- a/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
@@ -321,6 +321,252 @@ final class AdmWalletServiceTests: XCTestCase {
         XCTAssertEqual(transaction.chatRoom?.objectID, room.objectID)
     }
     
+    // AdmWalletService have different logic for just sending money and sending money with comments
+    
+    func test_sendJustMoney_isNotLoggedInThrowsError() async throws {
+        // given
+        accountService.account = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: "",
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notLogged)
+    }
+    
+    func test_sendJustMoney_noKeyPairThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: "",
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notLogged)
+    }
+    
+    func test_sendJustMoney_notEnoughMoneyThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: 20,
+                comments: "",
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notEnoughMoney)
+    }
+    
+    func test_sendJustMoney_invalidRecipientThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .failure(AccountsProviderError.invalidAddress(address: ""))
+        }
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: "",
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+    }
+    
+    func test_sendJustMoney_invalidRecipientQueriesDummyAndThrowsErrorWhenFails() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .failure(AccountsProviderError.notFound(address: ""))
+            accountsProviderMock.stubbedGetDummyAccountResult = .failure(AccountsProviderDummyAccountError.invalidAddress(address: ""))
+        }
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: "",
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+        await MainActor.run {
+            XCTAssertEqual(accountsProviderMock.invokedGetAccountCount, 1)
+            XCTAssertEqual(accountsProviderMock.invokedGetDummyAccountCount, 1)
+        }
+    }
+    
+    func test_sendJustMoney_correctRecipientBadMessageEncodeThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(account)
+        }
+        adamantCoreMock.stubbedEncodeMessageResult = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: "",
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(adamantCoreMock.invokedEncodeMessageCount, 0)
+        switch result.error as? WalletServiceError {
+        case .internalError:
+            break
+        default:
+            XCTFail("Expected '.internalError', but got \(String(describing: result.error))")
+        }
+    }
+    
+    func test_sendJustMoney_signTransactionFailureThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(account)
+        }
+        adamantCoreMock.stubbedEncodeMessageResult = ("message", "nonce")
+        adamantCoreMock.stubbedSignResult = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: "",
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(adamantCoreMock.invokedSignCount, 1)
+        let signParameters = try XCTUnwrap(adamantCoreMock.invokedSignParameters)
+        XCTAssertEqual(signParameters.senderId, Constants.accountAddress)
+        XCTAssertEqual(signParameters.keypair.publicKey, accountService.keypair?.publicKey)
+        XCTAssertEqual(signParameters.keypair.privateKey, accountService.keypair?.privateKey)
+        
+        XCTAssertEqual(signParameters.transaction.type, .send)
+        XCTAssertEqual(signParameters.transaction.amount, Constants.sendAmount)
+        XCTAssertEqual(signParameters.transaction.recipientId, Constants.recipientAddress)
+        
+        switch result.error as? WalletServiceError {
+        case .internalError:
+            break
+        default:
+            XCTFail("Expected '.internalError', but got \(String(describing: result.error))")
+        }
+    }
+    
+    func test_sendJustMoney_sendTransactionFailureThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(account)
+        }
+        adamantCoreMock.stubbedEncodeMessageResult = ("message", "nonce")
+        adamantCoreMock.stubbedSignResult = "signature"
+        admApiServiceMock.stubbedSendMessageTransactionResult = .failure(.accountNotFound)
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(admApiServiceMock.invokedSendMessageTransactionCount, 1)
+        XCTAssertEqual(admApiServiceMock.invokedSendMessageTransactionParameters?.amount, Constants.sendAmount)
+        XCTAssertEqual(admApiServiceMock.invokedSendMessageTransactionParameters?.recipientId, Constants.recipientAddress)
+        XCTAssertEqual(admApiServiceMock.invokedSendMessageTransactionParameters?.senderId, Constants.accountAddress)
+        
+        let transactions: [TransferTransaction] = try stack.container.viewContext.fetch(TransferTransaction.fetchRequest())
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions.first?.statusEnum, .failed)
+        
+        switch result.error as? WalletServiceError {
+        case .remoteServiceError:
+            break
+        default:
+            XCTFail("Expected '.remoteServiceError', but got \(String(describing: result.error))")
+        }
+    }
+    
+    func test_sendJustMoney_sendTransactionSuccess() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(account)
+        }
+        adamantCoreMock.stubbedEncodeMessageResult = ("message", "nonce")
+        adamantCoreMock.stubbedSignResult = "signature"
+        admApiServiceMock.stubbedSendMessageTransactionResult = .success(1234)
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        let transaction = try XCTUnwrap(result.value as? TransferTransaction)
+        XCTAssertEqual(transaction.transactionId, "1234")
+        XCTAssertEqual(transaction.statusEnum, .pending)
+        XCTAssertEqual(transaction.chatRoom?.objectID, room.objectID)
+    }
+    
     private func makeAccount() -> AdamantAccount {
         return AdamantAccount(
             address: Constants.accountAddress,

--- a/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
@@ -1,0 +1,378 @@
+//
+//  AdmWalletServiceTests.swift
+//  Adamant
+//
+//  Created by Christian Benua on 28.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import XCTest
+@testable import Adamant
+import CommonKit
+
+final class AdmWalletServiceTests: XCTestCase {
+    
+    var sut: AdmWalletService!
+    var transafersProvider: AdamantTransfersProvider!
+    var accountService: AccountServiceMock!
+    var accountsProviderMock: AccountsProviderMock!
+    var admApiServiceMock: AdamantApiServiceProtocolMock!
+    var chatProviderMock: ChatsProviderMock!
+    var stack: InMemoryCoreDataStack!
+    var adamantCoreMock: AdamantCoreMock!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        
+        accountService = AccountServiceMock()
+        accountsProviderMock = await AccountsProviderMock()
+        admApiServiceMock = AdamantApiServiceProtocolMock()
+        chatProviderMock = ChatsProviderMock()
+        adamantCoreMock = AdamantCoreMock()
+        stack = try InMemoryCoreDataStack(modelUrl: AdamantResources.coreDataModel)
+        transafersProvider = AdamantTransfersProvider(
+            apiService: admApiServiceMock,
+            stack: stack,
+            adamantCore: adamantCoreMock,
+            accountService: accountService,
+            accountsProvider: accountsProviderMock,
+            securedStore: SecuredStoreMock(),
+            transactionService: ChatTransactionServiceMock(),
+            chatsProvider: chatProviderMock
+        )
+        sut = AdmWalletService()
+        sut.transfersProvider = transafersProvider
+    }
+    
+    override func tearDown() async throws {
+        sut = nil
+        transafersProvider = nil
+        accountService = nil
+        accountsProviderMock = nil
+        admApiServiceMock = nil
+        chatProviderMock = nil
+        stack = nil
+        adamantCoreMock = nil
+        
+        try await super.tearDown()
+    }
+    
+    func test_sendMoney_isNotLoggedInThrowsError() async throws {
+        // given
+        accountService.account = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notLogged)
+    }
+    
+    func test_sendMoney_noKeyPairThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notLogged)
+    }
+    
+    func test_sendMoney_notEnoughMoneyThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: 20,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .notEnoughMoney)
+    }
+    
+    func test_sendMoney_invalidRecipientThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .failure(AccountsProviderError.notFound(address: ""))
+        }
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+    }
+    
+    func test_sendMoney_invalidRecipientPublicKeyThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(createCoreDataAccount())
+        }
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+    }
+    
+    func test_sendMoney_emptyRecipientChatroomThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(createCoreDataAccount(publicKey: "public key"))
+        }
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(result.error as? WalletServiceError, .accountNotFound)
+    }
+    
+    func test_sendMoney_correctRecipientBadMessageEncodeThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(account)
+        }
+        adamantCoreMock.stubbedEncodeMessageResult = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(adamantCoreMock.invokedEncodeMessageCount, 1)
+        XCTAssertEqual(adamantCoreMock.invokedEncodeMessageParameters?.message, Constants.comment)
+        XCTAssertEqual(adamantCoreMock.invokedEncodeMessageParameters?.privateKey, accountService.keypair?.privateKey)
+        XCTAssertEqual(adamantCoreMock.invokedEncodeMessageParameters?.recipientPublicKey, Constants.recipientPublicKeyAddress)
+        switch result.error as? WalletServiceError {
+        case .internalError:
+            break
+        default:
+            XCTFail("Expected '.internalError', but got \(String(describing: result.error))")
+        }
+    }
+    
+    func test_sendMoney_signTransactionFailureThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(account)
+        }
+        adamantCoreMock.stubbedEncodeMessageResult = ("message", "nonce")
+        adamantCoreMock.stubbedSignResult = nil
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(adamantCoreMock.invokedSignCount, 1)
+        let signParameters = try XCTUnwrap(adamantCoreMock.invokedSignParameters)
+        XCTAssertEqual(signParameters.senderId, Constants.accountAddress)
+        XCTAssertEqual(signParameters.keypair.publicKey, accountService.keypair?.publicKey)
+        XCTAssertEqual(signParameters.keypair.privateKey, accountService.keypair?.privateKey)
+        
+        XCTAssertEqual(signParameters.transaction.type, .chatMessage)
+        XCTAssertEqual(signParameters.transaction.amount, Constants.sendAmount)
+        XCTAssertEqual(signParameters.transaction.recipientId, Constants.recipientAddress)
+        
+        switch result.error as? WalletServiceError {
+        case .internalError:
+            break
+        default:
+            XCTFail("Expected '.internalError', but got \(String(describing: result.error))")
+        }
+    }
+    
+    func test_sendMoney_sendTransactionFailureThrowsError() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(account)
+        }
+        adamantCoreMock.stubbedEncodeMessageResult = ("message", "nonce")
+        adamantCoreMock.stubbedSignResult = "signature"
+        admApiServiceMock.stubbedSendMessageTransactionResult = .failure(.accountNotFound)
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then
+        XCTAssertEqual(admApiServiceMock.invokedSendMessageTransactionCount, 1)
+        XCTAssertEqual(admApiServiceMock.invokedSendMessageTransactionParameters?.amount, Constants.sendAmount)
+        XCTAssertEqual(admApiServiceMock.invokedSendMessageTransactionParameters?.recipientId, Constants.recipientAddress)
+        XCTAssertEqual(admApiServiceMock.invokedSendMessageTransactionParameters?.senderId, Constants.accountAddress)
+        
+        let transactions: [TransferTransaction] = try stack.container.viewContext.fetch(TransferTransaction.fetchRequest())
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions.first?.statusEnum, .failed)
+                
+        switch result.error as? WalletServiceError {
+        case .remoteServiceError:
+            break
+        default:
+            XCTFail("Expected '.remoteServiceError', but got \(String(describing: result.error))")
+        }
+    }
+    
+    func test_sendMoney_sendTransactionSuccess() async throws {
+        // given
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
+        await MainActor.run {
+            accountsProviderMock.stubbedGetAccountResult = .success(account)
+        }
+        adamantCoreMock.stubbedEncodeMessageResult = ("message", "nonce")
+        adamantCoreMock.stubbedSignResult = "signature"
+        admApiServiceMock.stubbedSendMessageTransactionResult = .success(1234)
+        
+        // when
+        let result = await Result {
+            try await self.sut.sendMoney(
+                recipient: Constants.recipientAddress,
+                amount: Constants.sendAmount,
+                comments: Constants.comment,
+                replyToMessageId: nil
+            )
+        }
+        
+        // then        
+        let transaction = try XCTUnwrap(result.value as? TransferTransaction)
+        XCTAssertEqual(transaction.transactionId, "1234")
+        XCTAssertEqual(transaction.statusEnum, .pending)
+        XCTAssertEqual(transaction.chatRoom?.objectID, room.objectID)
+    }
+    
+    private func makeAccount() -> AdamantAccount {
+        return AdamantAccount(
+            address: Constants.accountAddress,
+            unconfirmedBalance: Constants.unconfirmedBalance,
+            balance: Constants.balance,
+            publicKey: nil,
+            unconfirmedSignature: 0,
+            secondSignature: 0,
+            secondPublicKey: nil,
+            multisignatures: nil,
+            uMultisignatures: nil,
+            isDummy: false
+        )
+    }
+    
+    private func setupCoreDataEntities(accountPublicKey: String? = nil) -> (Chatroom, CoreDataAccount) {
+        let account = createCoreDataAccount(publicKey: accountPublicKey)
+        let room = createChatroom()
+        account.chatroom = room
+        
+        return (room, account)
+    }
+    
+    private func createCoreDataAccount(publicKey: String? = nil) -> CoreDataAccount {
+        let account = CoreDataAccount(context: stack.container.viewContext)
+        
+        account.address = Constants.recipientAddress
+        account.publicKey = publicKey
+        
+        return account
+    }
+    
+    private func createChatroom() -> Chatroom {
+        let room = Chatroom(context: stack.container.viewContext)
+        
+        return room
+    }
+    
+    private func makeKeypair(passphrase: String) -> Keypair? {
+        NativeAdamantCore().createKeypairFor(passphrase: passphrase)
+    }
+}
+
+private enum Constants {
+    static let passphrase = "village lunch say patrol glow first hurt shiver name method dolphin dead"
+    
+    static let accountAddress = "adamant address"
+    static let recipientAddress = "recipient address"
+    static let recipientPublicKeyAddress = "public key"
+    static let unconfirmedBalance: Decimal = 10
+    static let balance: Decimal = 8
+    static let sendAmount: Decimal = 5
+    
+    static let comment = "comment"
+}

--- a/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
@@ -566,8 +566,10 @@ final class AdmWalletServiceTests: XCTestCase {
         XCTAssertEqual(transaction.statusEnum, .pending)
         XCTAssertEqual(transaction.chatRoom?.objectID, room.objectID)
     }
-    
-    private func makeAccount() -> AdamantAccount {
+}
+
+private extension AdmWalletServiceTests {
+    func makeAccount() -> AdamantAccount {
         return AdamantAccount(
             address: Constants.accountAddress,
             unconfirmedBalance: Constants.unconfirmedBalance,
@@ -582,7 +584,7 @@ final class AdmWalletServiceTests: XCTestCase {
         )
     }
     
-    private func setupCoreDataEntities(accountPublicKey: String? = nil) -> (Chatroom, CoreDataAccount) {
+    func setupCoreDataEntities(accountPublicKey: String? = nil) -> (Chatroom, CoreDataAccount) {
         let account = createCoreDataAccount(publicKey: accountPublicKey)
         let room = createChatroom()
         account.chatroom = room
@@ -590,7 +592,7 @@ final class AdmWalletServiceTests: XCTestCase {
         return (room, account)
     }
     
-    private func createCoreDataAccount(publicKey: String? = nil) -> CoreDataAccount {
+    func createCoreDataAccount(publicKey: String? = nil) -> CoreDataAccount {
         let account = CoreDataAccount(context: stack.container.viewContext)
         
         account.address = Constants.recipientAddress
@@ -599,13 +601,13 @@ final class AdmWalletServiceTests: XCTestCase {
         return account
     }
     
-    private func createChatroom() -> Chatroom {
+    func createChatroom() -> Chatroom {
         let room = Chatroom(context: stack.container.viewContext)
         
         return room
     }
     
-    private func makeKeypair(passphrase: String) -> Keypair? {
+    func makeKeypair(passphrase: String) -> Keypair? {
         NativeAdamantCore().createKeypairFor(passphrase: passphrase)
     }
 }

--- a/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
@@ -608,7 +608,7 @@ private extension AdmWalletServiceTests {
     }
     
     func makeKeypair(passphrase: String) -> Keypair? {
-        NativeAdamantCore().createKeypairFor(passphrase: passphrase)
+        NativeAdamantCore().createKeypairFor(passphrase: passphrase, password: "")
     }
 }
 

--- a/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
+++ b/AdamantTests/Modules/Wallets/AdmWalletServiceTests.swift
@@ -13,7 +13,7 @@ import CommonKit
 final class AdmWalletServiceTests: XCTestCase {
     
     var sut: AdmWalletService!
-    var transafersProvider: AdamantTransfersProvider!
+    var transfersProvider: AdamantTransfersProvider!
     var accountService: AccountServiceMock!
     var accountsProviderMock: AccountsProviderMock!
     var admApiServiceMock: AdamantApiServiceProtocolMock!
@@ -30,7 +30,7 @@ final class AdmWalletServiceTests: XCTestCase {
         chatProviderMock = ChatsProviderMock()
         adamantCoreMock = AdamantCoreMock()
         stack = try InMemoryCoreDataStack(modelUrl: AdamantResources.coreDataModel)
-        transafersProvider = AdamantTransfersProvider(
+        transfersProvider = AdamantTransfersProvider(
             apiService: admApiServiceMock,
             stack: stack,
             adamantCore: adamantCoreMock,
@@ -41,12 +41,12 @@ final class AdmWalletServiceTests: XCTestCase {
             chatsProvider: chatProviderMock
         )
         sut = AdmWalletService()
-        sut.transfersProvider = transafersProvider
+        sut.transfersProvider = transfersProvider
     }
     
     override func tearDown() async throws {
         sut = nil
-        transafersProvider = nil
+        transfersProvider = nil
         accountService = nil
         accountsProviderMock = nil
         admApiServiceMock = nil
@@ -96,8 +96,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendMoney_notEnoughMoneyThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         
         // when
         let result = await Result {
@@ -115,8 +114,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendMoney_invalidRecipientThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .failure(AccountsProviderError.notFound(address: ""))
         }
@@ -137,8 +135,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendMoney_invalidRecipientPublicKeyThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(createCoreDataAccount())
         }
@@ -159,8 +156,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendMoney_emptyRecipientChatroomThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(createCoreDataAccount(publicKey: "public key"))
         }
@@ -181,8 +177,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendMoney_correctRecipientBadMessageEncodeThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(account)
@@ -214,8 +209,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendMoney_signTransactionFailureThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(account)
@@ -254,8 +248,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendMoney_sendTransactionFailureThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(account)
@@ -294,8 +287,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendMoney_sendTransactionSuccess() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(account)
@@ -362,8 +354,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendJustMoney_notEnoughMoneyThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         
         // when
         let result = await Result {
@@ -381,8 +372,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendJustMoney_invalidRecipientThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .failure(AccountsProviderError.invalidAddress(address: ""))
         }
@@ -403,8 +393,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendJustMoney_invalidRecipientQueriesDummyAndThrowsErrorWhenFails() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .failure(AccountsProviderError.notFound(address: ""))
             accountsProviderMock.stubbedGetDummyAccountResult = .failure(AccountsProviderDummyAccountError.invalidAddress(address: ""))
@@ -430,8 +419,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendJustMoney_correctRecipientBadMessageEncodeThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(account)
@@ -460,8 +448,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendJustMoney_signTransactionFailureThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(account)
@@ -500,8 +487,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendJustMoney_sendTransactionFailureThrowsError() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(account)
@@ -540,8 +526,7 @@ final class AdmWalletServiceTests: XCTestCase {
     
     func test_sendJustMoney_sendTransactionSuccess() async throws {
         // given
-        accountService.account = makeAccount()
-        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
+        setupAccountService()
         let (room, account) = setupCoreDataEntities(accountPublicKey: Constants.recipientPublicKeyAddress)
         await MainActor.run {
             accountsProviderMock.stubbedGetAccountResult = .success(account)
@@ -582,6 +567,11 @@ private extension AdmWalletServiceTests {
             uMultisignatures: nil,
             isDummy: false
         )
+    }
+    
+    func setupAccountService() {
+        accountService.account = makeAccount()
+        accountService.keypair = makeKeypair(passphrase: Constants.passphrase)
     }
     
     func setupCoreDataEntities(accountPublicKey: String? = nil) -> (Chatroom, CoreDataAccount) {

--- a/AdamantTests/Modules/Wallets/NativeAdamantCoreTests.swift
+++ b/AdamantTests/Modules/Wallets/NativeAdamantCoreTests.swift
@@ -1,0 +1,66 @@
+//
+//  NativeAdamantCoreTests.swift
+//  Adamant
+//
+//  Created by Christian Benua on 30.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import XCTest
+import CommonKit
+
+final class NativeAdamantCoreTests: XCTestCase {
+    func test_encodeMessage() throws {
+        let (encryptedMessage, nonce) = try XCTUnwrap(NativeAdamantCore().encodeMessage(
+            Constants.message,
+            recipientPublicKey: Constants.publicKey,
+            privateKey: Constants.privateKey
+        ))
+        
+        let message = NativeAdamantCore().decodeMessage(
+            rawMessage: encryptedMessage,
+            rawNonce: nonce,
+            senderPublicKey: Constants.publicKey,
+            privateKey: Constants.privateKey
+        )
+        
+        XCTAssertEqual(message, Constants.message)
+    }
+    
+    func test_sign() {
+        let signature = NativeAdamantCore().sign(
+            transaction: Constants.transaction,
+            senderId: Constants.senderPublicKey,
+            keypair: Keypair(publicKey: Constants.senderPublicKey, privateKey: Constants.privateKey)
+        )
+        
+        XCTAssertEqual(signature, Constants.expectedSignature)
+    }
+}
+
+private enum Constants {
+    static let privateKey = "c2b4df1562b93e5e37bef8551d430a21736da9b021cad8e3eec54cfca05b8db2fdfa0ad06afc6445c8d2c63078cba7f6d079ee0367e764cf286f42ab955a4d67"
+    static let publicKey = "1ed651ec1c686c23249dadb2cb656edd5f8e7d35076815d8a81c395c3eed1a85"
+    static let message = "Sample encode message for testing"
+    
+    static let expectedSignature = "328870db4ae22f0b74c829a32ae16ed3191d6dbfb13077f2ec0b35ee005270d13ff0f615de7d9a5486c4f7a66d41c99e814a7e7d2a8611d140476573266e2503"
+    
+    static let transaction = NormalizedTransaction(
+        type: .chatMessage,
+        amount: 0,
+        senderPublicKey: "fdfa0ad06afc6445c8d2c63078cba7f6d079ee0367e764cf286f42ab955a4d67",
+        requesterPublicKey: nil,
+        date: Date(timeIntervalSince1970: 1738267672),
+        recipientId: "U3716604363012166999",
+        asset: TransactionAsset(
+            chat: ChatAsset(
+                message: "1507aaf7fdf4bdea3cf4e4df3d2476962be70102e2cac0961c25c1642713e2e14a0c8bf02e7f",
+                ownMessage: "c488a53dff457feb4e46d83ae26c3821b9aa10d06a727eb5",
+                type: .message
+            )
+        )
+    )
+    
+    static let senderId = "U12686887375123482464"
+    static let senderPublicKey = "fdfa0ad06afc6445c8d2c63078cba7f6d079ee0367e764cf286f42ab955a4d67"
+}

--- a/AdamantTests/Modules/Wallets/NativeAdamantCoreTests.swift
+++ b/AdamantTests/Modules/Wallets/NativeAdamantCoreTests.swift
@@ -48,7 +48,7 @@ private enum Constants {
     static let transaction = NormalizedTransaction(
         type: .chatMessage,
         amount: 0,
-        senderPublicKey: "fdfa0ad06afc6445c8d2c63078cba7f6d079ee0367e764cf286f42ab955a4d67",
+        senderPublicKey: Constants.senderPublicKey,
         requesterPublicKey: nil,
         date: Date(timeIntervalSince1970: 1738267672),
         recipientId: "U3716604363012166999",

--- a/AdamantTests/Stubs/AccountServiceMock.swift
+++ b/AdamantTests/Stubs/AccountServiceMock.swift
@@ -1,0 +1,61 @@
+//
+//  AccountServiceMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 28.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import CommonKit
+
+final class AccountServiceMock: AccountService {
+    var state: AccountServiceState = .loggedIn
+    
+    var isBalanceExpired: Bool = false
+    var hasStayInAccount: Bool = false
+    var useBiometry: Bool = false
+    
+    var account: AdamantAccount?
+    var keypair: Keypair?
+    
+    func update() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func loginWith(passphrase: String) async throws -> AccountServiceResult {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func loginWithStoredAccount() async throws -> AccountServiceResult {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func logout() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func reloadWallets() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func setStayLoggedIn(pin: String, completion: @escaping @Sendable (AccountServiceResult) -> Void) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func dropSavedAccount() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func validatePin(_ pin: String) -> Bool {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func updateUseBiometry(_ newValue: Bool) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/AccountServiceMock.swift
+++ b/AdamantTests/Stubs/AccountServiceMock.swift
@@ -27,10 +27,6 @@ final class AccountServiceMock: AccountService {
         fatalError("\(#file).\(#function) is not implemented")
     }
     
-    func loginWith(passphrase: String) async throws -> AccountServiceResult {
-        fatalError("\(#file).\(#function) is not implemented")
-    }
-    
     func loginWith(passphrase: String, password: String) async throws -> AccountServiceResult {
         fatalError("\(#file).\(#function) is not implemented")
     }

--- a/AdamantTests/Stubs/AccountServiceMock.swift
+++ b/AdamantTests/Stubs/AccountServiceMock.swift
@@ -31,6 +31,10 @@ final class AccountServiceMock: AccountService {
         fatalError("\(#file).\(#function) is not implemented")
     }
     
+    func loginWith(passphrase: String, password: String) async throws -> AccountServiceResult {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
     func loginWithStoredAccount() async throws -> AccountServiceResult {
         fatalError("\(#file).\(#function) is not implemented")
     }

--- a/AdamantTests/Stubs/AccountsProviderMock.swift
+++ b/AdamantTests/Stubs/AccountsProviderMock.swift
@@ -1,0 +1,45 @@
+//
+//  AccountsProviderMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 28.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+
+final class AccountsProviderMock: AccountsProvider {
+    
+    var invokedGetAccount = false
+    var invokedGetAccountCount = 0
+    var invokedGetAccountParameters: String?
+    var stubbedGetAccountResult: Result<CoreDataAccount, Error>!
+    
+    func getAccount(byAddress address: String) async throws -> CoreDataAccount {
+        invokedGetAccount = true
+        invokedGetAccountCount += 1
+        invokedGetAccountParameters = address
+        return try stubbedGetAccountResult.get()
+    }
+    
+    var invokedGetAccountPublicKey = false
+    var invokedGetAccountPublicKeyCount = 0
+    var invokedGetAccountPublicKeyParameters: (address: String, publicKey: String)?
+    var stubbedGetAccountPublicKeyResult: CoreDataAccount!
+    
+    func getAccount(byAddress address: String, publicKey: String) async throws -> CoreDataAccount {
+        invokedGetAccountPublicKey = true
+        invokedGetAccountPublicKeyCount += 1
+        invokedGetAccountPublicKeyParameters = (address, publicKey)
+        
+        return stubbedGetAccountPublicKeyResult
+    }
+    
+    func hasAccount(address: String) async -> Bool {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getDummyAccount(for address: String) async throws -> DummyAccount {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/AccountsProviderMock.swift
+++ b/AdamantTests/Stubs/AccountsProviderMock.swift
@@ -35,11 +35,20 @@ final class AccountsProviderMock: AccountsProvider {
         return stubbedGetAccountPublicKeyResult
     }
     
-    func hasAccount(address: String) async -> Bool {
-        fatalError("\(#file).\(#function) is not implemented")
-    }
+    var invokedGetDummyAccount = false
+    var invokedGetDummyAccountCount = 0
+    var invokedGetDummyAccountParameters: String?
+    var stubbedGetDummyAccountResult: Result<DummyAccount, Error>!
     
     func getDummyAccount(for address: String) async throws -> DummyAccount {
+        invokedGetDummyAccount = true
+        invokedGetDummyAccountCount += 1
+        invokedGetDummyAccountParameters = address
+        
+        return try stubbedGetDummyAccountResult.get()
+    }
+    
+    func hasAccount(address: String) async -> Bool {
         fatalError("\(#file).\(#function) is not implemented")
     }
 }

--- a/AdamantTests/Stubs/AdamantApiServiceProtocolMock.swift
+++ b/AdamantTests/Stubs/AdamantApiServiceProtocolMock.swift
@@ -1,0 +1,131 @@
+//
+//  AdamantApiServiceProtocolMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 28.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CommonKit
+import Foundation
+
+final class AdamantApiServiceProtocolMock: AdamantApiServiceProtocol {
+    
+    var invokedTransferFunds: Bool = false
+    var invokedTransferFundsCount: Int = 0
+    var stubbedTransferFundsResult: ApiServiceResult<UInt64>!
+
+    func transferFunds(transaction: UnregisteredTransaction) async -> ApiServiceResult<UInt64> {
+        invokedTransferFunds = true
+        invokedTransferFundsCount += 1
+        
+        return stubbedTransferFundsResult
+    }
+    
+    var invokedSendMessageTransaction: Bool = false
+    var invokedSendMessageTransactionCount: Int = 0
+    var invokedSendMessageTransactionParameters: UnregisteredTransaction?
+    var stubbedSendMessageTransactionResult: ApiServiceResult<UInt64>!
+    
+    func sendMessageTransaction(transaction: UnregisteredTransaction) async -> ApiServiceResult<UInt64> {
+        invokedSendMessageTransaction = true
+        invokedSendMessageTransactionCount += 1
+        invokedSendMessageTransactionParameters = transaction
+        
+        return stubbedSendMessageTransactionResult
+    }
+    
+    // Not implemented methods
+    
+    func getAccount(byPassphrase passphrase: String) async -> ApiServiceResult<AdamantAccount> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getAccount(byPublicKey publicKey: String) async -> ApiServiceResult<AdamantAccount> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getAccount(byAddress address: String) async -> ApiServiceResult<AdamantAccount> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getPublicKey(byAddress address: String) async -> ApiServiceResult<String> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getTransaction(id: UInt64) async -> ApiServiceResult<Transaction> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getTransaction(id: UInt64, withAsset: Bool) async -> ApiServiceResult<Transaction> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getTransactions(forAccount: String, type: TransactionType, fromHeight: Int64?, offset: Int?, limit: Int?, waitsForConnectivity: Bool) async -> ApiServiceResult<[Transaction]> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getTransactions(forAccount account: String, type: TransactionType, fromHeight: Int64?, offset: Int?, limit: Int?, orderByTime: Bool?, waitsForConnectivity: Bool) async -> ApiServiceResult<[Transaction]> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getChatRooms(address: String, offset: Int?, waitsForConnectivity: Bool) async -> ApiServiceResult<ChatRooms> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getChatMessages(address: String, addressRecipient: String, offset: Int?, limit: Int?) async -> ApiServiceResult<ChatRooms> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func transferFunds(sender: String, recipient: String, amount: Decimal, keypair: Keypair, date: Date) async -> ApiServiceResult<UInt64> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func store(_ model: KVSValueModel, date: Date) async -> ApiServiceResult<UInt64> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func get(key: String, sender: String) async -> ApiServiceResult<String?> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getMessageTransactions(address: String, height: Int64?, offset: Int?, waitsForConnectivity: Bool) async -> ApiServiceResult<[Transaction]> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func sendTransaction(path: String, transaction: UnregisteredTransaction) async -> ApiServiceResult<UInt64> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getDelegates(limit: Int) async -> ApiServiceResult<[Delegate]> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getDelegatesWithVotes(for address: String, limit: Int) async -> ApiServiceResult<[Delegate]> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getForgedByAccount(publicKey: String) async -> ApiServiceResult<DelegateForgeDetails> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getForgingTime(for delegate: Delegate) async -> ApiServiceResult<Int> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func voteForDelegates(from address: String, keypair: Keypair, votes: [DelegateVote], date: Date) async -> ApiServiceResult<Bool> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var nodesInfo: NodesListInfo {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var nodesInfoPublisher: AnyObservable<NodesListInfo> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func healthCheck() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/AdamantCoreMock.swift
+++ b/AdamantTests/Stubs/AdamantCoreMock.swift
@@ -12,12 +12,12 @@ import CommonKit
 final class AdamantCoreMock: AdamantCore {
     
     // MARK: - Keys
-
-    func createHashFor(passphrase: String) -> String? {
+    
+    func createSeedFor(passphrase: String, password: String) -> [UInt8]? {
         fatalError("\(#file).\(#function) is not implemented")
     }
     
-    func createKeypairFor(passphrase: String) -> Keypair? {
+    func createKeypairFor(passphrase: String, password: String) -> CommonKit.Keypair? {
         fatalError("\(#file).\(#function) is not implemented")
     }
     

--- a/AdamantTests/Stubs/AdamantCoreMock.swift
+++ b/AdamantTests/Stubs/AdamantCoreMock.swift
@@ -1,0 +1,71 @@
+//
+//  AdamantCoreMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 29.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+import CommonKit
+
+final class AdamantCoreMock: AdamantCore {
+    
+    // MARK: - Keys
+
+    func createHashFor(passphrase: String) -> String? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func createKeypairFor(passphrase: String) -> Keypair? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    // MARK: - Signing transactions
+    
+    var invokedSign: Bool = false
+    var invokedSignCount: Int = 0
+    var invokedSignParameters: (transaction: SignableTransaction, senderId: String, keypair: Keypair)?
+    var stubbedSignResult: String?
+    
+    func sign(transaction: SignableTransaction, senderId: String, keypair: Keypair) -> String? {
+        invokedSign = true
+        invokedSignCount += 1
+        invokedSignParameters = (transaction, senderId, keypair)
+        return stubbedSignResult
+    }
+    
+    // MARK: - Encoding messages
+    
+    var invokedEncodeMessage: Bool = false
+    var invokedEncodeMessageCount: Int = 0
+    var invokedEncodeMessageParameters: (message: String, recipientPublicKey: String, privateKey: String)?
+    var stubbedEncodeMessageResult: (message: String, nonce: String)?
+    
+    func encodeMessage(_ message: String, recipientPublicKey: String, privateKey: String) -> (message: String, nonce: String)? {
+        invokedEncodeMessage = true
+        invokedEncodeMessageCount += 1
+        invokedEncodeMessageParameters = (message, recipientPublicKey, privateKey)
+        return stubbedEncodeMessageResult
+    }
+    
+    func decodeMessage(rawMessage: String, rawNonce: String, senderPublicKey: String, privateKey: String) -> String? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func encodeValue(_ value: [String : Any], privateKey: String) -> (message: String, nonce: String)? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func decodeValue(rawMessage: String, rawNonce: String, privateKey: String) -> String? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func encodeData(_ data: Data, recipientPublicKey publicKey: String, privateKey privateKeyHex: String) -> (data: Data, nonce: String)? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func decodeData(_ data: Data, rawNonce: String, senderPublicKey senderKeyHex: String, privateKey privateKeyHex: String) -> Data? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/ChatTransactionServiceMock.swift
+++ b/AdamantTests/Stubs/ChatTransactionServiceMock.swift
@@ -1,0 +1,29 @@
+//
+//  ChatTransactionServiceMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 28.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import CoreData
+import CommonKit
+
+final actor ChatTransactionServiceMock: ChatTransactionService {
+    func addOperations(_ op: Operation) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func chatTransaction(from transaction: Transaction, isOutgoing: Bool, publicKey: String, privateKey: String, partner: BaseAccount, removedMessages: [String], context: NSManagedObjectContext) -> ChatTransaction? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getTransfer(id: String, context: NSManagedObjectContext) -> TransferTransaction? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func transferTransaction(from transaction: Transaction, isOut: Bool, partner: BaseAccount?, context: NSManagedObjectContext) -> TransferTransaction {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/ChatsProviderMock.swift
+++ b/AdamantTests/Stubs/ChatsProviderMock.swift
@@ -162,11 +162,11 @@ final actor ChatsProviderMock: ChatsProvider {
         fatalError("\(#file).\(#function) is not implemented")
     }
     
-    var state: State {
+    var state: DataProviderState {
         fatalError("\(#file).\(#function) is not implemented")
     }
     
-    var stateObserver: AnyObservable<State> {
+    var stateObserver: AnyObservable<DataProviderState> {
         fatalError("\(#file).\(#function) is not implemented")
     }
     

--- a/AdamantTests/Stubs/ChatsProviderMock.swift
+++ b/AdamantTests/Stubs/ChatsProviderMock.swift
@@ -1,0 +1,180 @@
+//
+//  ChatsProviderMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 28.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+@testable import Adamant
+import CommonKit
+import CoreData
+
+final actor ChatsProviderMock: ChatsProvider {
+    var receivedLastHeight: Int64?
+    
+    var readedLastHeight: Int64?
+    
+    var isInitiallySynced: Bool = false
+    
+    var blockList: [String] = []
+    
+    var roomsMaxCount: Int?
+    
+    var roomsLoadedCount: Int?
+    
+    var chatMaxMessages: [String: Int] = [:]
+    
+    var chatLoadedMessages: [String : Int] = [:]
+    
+    var invokedAddUnconfirmed: Bool = false
+    var invokedAddUnconfirmedCount: Int = 0
+    var invokedAddUnconfirmedParameters: (transactionId: UInt64, objectId: NSManagedObjectID)?
+    
+    func addUnconfirmed(transactionId: UInt64, managedObjectId: NSManagedObjectID) {
+        invokedAddUnconfirmed = true
+        invokedAddUnconfirmedCount += 1
+        invokedAddUnconfirmedParameters = (transactionId, managedObjectId)
+    }
+    
+    // Unimplemented
+    
+    var chatLoadingStatusPublisher: AnyObservable<[String: ChatRoomLoadingStatus]> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getChatroom(for adm: String) -> Chatroom? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getChatroomsController() -> NSFetchedResultsController<Chatroom> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getChatController(for chatroom: Chatroom) -> NSFetchedResultsController<ChatTransaction> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getChatRooms(offset: Int?) async {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getChatMessages(with addressRecipient: String, offset: Int?) async {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func isChatLoading(with addressRecipient: String) -> Bool {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func isChatLoaded(with addressRecipient: String) -> Bool {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func loadTransactionsUntilFound(_ transactionId: String, recipient: String) async throws {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getUnreadMessagesController() -> NSFetchedResultsController<ChatTransaction> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func update(notifyState: Bool) async -> ChatsProviderResult? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func sendMessage(_ message: AdamantMessage, recipientId: String) async throws -> ChatTransaction {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func sendMessage(_ message: AdamantMessage, recipientId: String, from chatroom: Chatroom?) async throws -> ChatTransaction {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func retrySendMessage(_ message: ChatTransaction) async throws {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func sendFileMessageLocally(_ message: AdamantMessage, recipientId: String, from chatroom: Chatroom?) async throws -> String {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func sendFileMessage(_ message: AdamantMessage, recipientId: String, transactionLocalyId: String, from chatroom: Chatroom?) async throws -> ChatTransaction {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func updateTxMessageContent(txId: String, richMessage: any RichMessage) throws {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func setTxMessageStatus(txId: String, status: MessageStatus) throws {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func cancelMessage(_ message: ChatTransaction) async throws {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func isMessageDeleted(id: String) -> Bool {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func validateMessage(_ message: AdamantMessage) -> ValidateMessageResult {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func blockChat(with address: String) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func removeMessage(with id: String) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func markChatAsRead(chatroom: Chatroom) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    @MainActor
+    func removeChatPositon(for address: String) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    @MainActor
+    func setChatPositon(for address: String, position: Double?) {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    @MainActor
+    func getChatPositon(for address: String) -> Double? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func fakeReceived(message: AdamantMessage, senderId: String, date: Date, unread: Bool, silent: Bool, showsChatroom: Bool) async throws -> ChatTransaction {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func getMessages(containing text: String, in chatroom: Chatroom?) -> [MessageTransaction]? {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func isTransactionUnique(_ transaction: RichMessageTransaction) -> Bool {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var state: State {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    var stateObserver: AnyObservable<State> {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func reload() async {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+    
+    func reset() {
+        fatalError("\(#file).\(#function) is not implemented")
+    }
+}

--- a/AdamantTests/Stubs/SecuredStoreMock.swift
+++ b/AdamantTests/Stubs/SecuredStoreMock.swift
@@ -1,0 +1,43 @@
+//
+//  SecuredStoreMock.swift
+//  Adamant
+//
+//  Created by Christian Benua on 28.01.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CommonKit
+
+final class SecuredStoreMock: SecuredStore {
+    var invokedGet: Bool = false
+    var invokedGetCount: Int = 0
+    var invokedGetParameters: String?
+    var stubbedGetResult: Any?
+    
+    func get<T: Decodable>(_ key: String) -> T? {
+        invokedGet = true
+        invokedGetCount += 1
+        invokedGetParameters = key
+        return stubbedGetResult as? T
+    }
+    
+    var invokedSet: Bool = false
+    var invokedSetCount: Int = 0
+    var invokedSetParameters: (value: Any?, key: String)?
+    
+    func set<T: Encodable>(_ value: T, for key: String) {
+        invokedSet = true
+        invokedSetCount += 1
+        invokedSetParameters = (value, key)
+    }
+    
+    var invokedRemove: Bool = false
+    var invokedRemoveCount: Int = 0
+    var invokedRemoveParameters: String?
+    
+    func remove(_ key: String) {
+        invokedRemove = true
+        invokedRemoveCount += 1
+        invokedRemoveParameters = key
+    }
+}

--- a/LiskKit/Sources/Crypto/ED25519/Ed25519fe.swift
+++ b/LiskKit/Sources/Crypto/ED25519/Ed25519fe.swift
@@ -607,8 +607,8 @@ struct fe: CustomDebugStringConvertible {
     static func fe25519_mul(_ r: inout fe, _ x: fe, _ y: fe) {
         var t = [UInt32](repeating: 0, count: 63)
         var i = 0
-        var j = 0
         while i < 32 {
+            var j = 0
             while j < 32 {
                 t[i+j] += x.v[i] * y.v[j]
                 j += 1


### PR DESCRIPTION
Added AdmWalletService tests.

Inside AdmWalletService there are two separate ways of sending crypto: with message and without message.

First case tests starts with `test_sendMoney`, second case tests starts with `test_sendJustMoney`.

I've handled most of the errors thrown by `sendMoney` method.

For testing CoreData I've used `InMemoryCoreDataStack`.

For testing sending transaction - `AdamantApiServiceProtocolMock`.