### PR TITLE
[trello.com/c/qGUKq5jZ] Sending ADM from chat: Do not display name for unnamed contacts

### DIFF
--- a/Adamant/Modules/Wallets/TransferViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/TransferViewControllerBase.swift
@@ -818,11 +818,10 @@ class TransferViewControllerBase: FormViewController {
             }
         }
         
-        let recipient: String
-        if let recipientName = recipientName {
+        var recipient: String = recipientAddress
+        
+        if let recipientName, recipientName != recipientAddress {
             recipient = "\(recipientName) \(recipientAddress)"
-        } else {
-            recipient = recipientAddress
         }
         
         let formattedAmount = balanceFormatter.string(from: amount as NSDecimalNumber)!


### PR DESCRIPTION
Added a check that the display of name+address only occurs if name and address are not equal. Since by default name is the address of adamant wallet, this check can work only when transferring in adamant network, as stated in the task.