### PR TITLE
[trello.com/c/WmyCJE1a] Settet donate as an non system wallet

### DIFF
--- a/CommonKit/Sources/CommonKit/Helpers/AdamantContacts.swift
+++ b/CommonKit/Sources/CommonKit/Helpers/AdamantContacts.swift
@@ -49,9 +49,9 @@ public enum AdamantContacts: CaseIterable {
     
     public var isSystem: Bool {
         switch self {
-        case .adamantExchange, .betOnBitcoin, .adelina:
+        case .adamantExchange, .betOnBitcoin, .adelina, .donate:
             return false
-        case .adamantWelcomeWallet, .adamantSupport, .adamantIco, .adamantBountyWallet, .adamantNewBountyWallet, .donate, .pwaBountyBot:
+        case .adamantWelcomeWallet, .adamantSupport, .adamantIco, .adamantBountyWallet, .adamantNewBountyWallet, .pwaBountyBot:
             return true
         }
     }


### PR DESCRIPTION
I've changed .donate Contact to non system, because of some of this logic should be store in blockchain like it's renamed representation