### PR TITLE
[trello.com/c/1C0Wu6wt]: debug login flow speed up in CryptoSwift and LiskKit

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -446,10 +446,6 @@
 		A5C99E0E262C9E3A00F7B1B7 /* Reachability in Frameworks */ = {isa = PBXBuildFile; productRef = A5C99E0D262C9E3A00F7B1B7 /* Reachability */; };
 		A5D87BA3262CA01D00DC28F0 /* ProcedureKit in Frameworks */ = {isa = PBXBuildFile; productRef = A5D87BA2262CA01D00DC28F0 /* ProcedureKit */; };
 		A5DBBABD262C7221004AC028 /* Clibsodium in Frameworks */ = {isa = PBXBuildFile; productRef = A5DBBABC262C7221004AC028 /* Clibsodium */; };
-		A5DBBADC262C729B004AC028 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A5DBBADB262C729B004AC028 /* CryptoSwift */; };
-		A5DBBAE3262C72B0004AC028 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A5DBBAE2262C72B0004AC028 /* CryptoSwift */; };
-		A5DBBAE5262C72B7004AC028 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A5DBBAE4262C72B7004AC028 /* CryptoSwift */; };
-		A5DBBAE7262C72BD004AC028 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A5DBBAE6262C72BD004AC028 /* CryptoSwift */; };
 		A5DBBAEE262C72EF004AC028 /* BitcoinKit in Frameworks */ = {isa = PBXBuildFile; productRef = A5DBBAED262C72EF004AC028 /* BitcoinKit */; };
 		A5DBBAF0262C72EF004AC028 /* LiskKit in Frameworks */ = {isa = PBXBuildFile; productRef = A5DBBAEF262C72EF004AC028 /* LiskKit */; };
 		A5E04224282A830B0076CD13 /* BtcTransactionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B5736C2201E196005DC968 /* BtcTransactionsViewController.swift */; };
@@ -466,6 +462,7 @@
 		AA33BEB72D3041A30083E59C /* AddressConverterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB42D303CBD0083E59C /* AddressConverterMock.swift */; };
 		AA33BEB92D3044760083E59C /* BtcApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */; };
 		AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */; };
+		AA8FFFCA2D4E6435001D8576 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AA8FFFC92D4E6435001D8576 /* CryptoSwift */; };
 		AAB01CAD2D3AE44B007D6BF4 /* BitcoinKitTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */; };
 		AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */; };
 		AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */; };
@@ -1371,7 +1368,6 @@
 			files = (
 				E9079A7D229DEF9C0022CA0D /* UserNotificationsUI.framework in Frameworks */,
 				E9079A7C229DEF9C0022CA0D /* UserNotifications.framework in Frameworks */,
-				A5DBBAE7262C72BD004AC028 /* CryptoSwift in Frameworks */,
 				A5F929B8262C858F00C3E60A /* MarkdownKit in Frameworks */,
 				A5241B77262DEDEF009FA43E /* Clibsodium in Frameworks */,
 				937751A92A68B3400054BD65 /* CommonKit in Frameworks */,
@@ -1401,10 +1397,10 @@
 				A5DBBABD262C7221004AC028 /* Clibsodium in Frameworks */,
 				938F7D582955C1DA001915CA /* MessageKit in Frameworks */,
 				A530B0D82842110D003F0210 /* (null) in Frameworks */,
-				A5DBBADC262C729B004AC028 /* CryptoSwift in Frameworks */,
 				4177E5E12A52DA7100C089FE /* AdvancedContextMenuKit in Frameworks */,
 				A5D87BA3262CA01D00DC28F0 /* ProcedureKit in Frameworks */,
 				A5C99E0E262C9E3A00F7B1B7 /* Reachability in Frameworks */,
+				AA8FFFCA2D4E6435001D8576 /* CryptoSwift in Frameworks */,
 				A5DBBAF0262C72EF004AC028 /* LiskKit in Frameworks */,
 				93FA403629401BFC00D20DB6 /* PopupKit in Frameworks */,
 				4184F1712A33044E00D7B8B9 /* FirebaseCrashlytics in Frameworks */,
@@ -1420,7 +1416,6 @@
 			files = (
 				E957E12F229B10F80019732A /* UserNotificationsUI.framework in Frameworks */,
 				E957E12E229B10F80019732A /* UserNotifications.framework in Frameworks */,
-				A5DBBAE5262C72B7004AC028 /* CryptoSwift in Frameworks */,
 				A5F929B6262C858700C3E60A /* MarkdownKit in Frameworks */,
 				A5241B70262DEDE1009FA43E /* Clibsodium in Frameworks */,
 				937751A72A68B33A0054BD65 /* CommonKit in Frameworks */,
@@ -1436,7 +1431,6 @@
 				937751A52A68B3320054BD65 /* CommonKit in Frameworks */,
 				A57282D1262C94DA00C96FA8 /* DateToolsSwift in Frameworks */,
 				A5F929AF262C857D00C3E60A /* MarkdownKit in Frameworks */,
-				A5DBBAE3262C72B0004AC028 /* CryptoSwift in Frameworks */,
 				A5241B7E262DEDFE009FA43E /* Clibsodium in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2996,7 +2990,6 @@
 			);
 			name = MessageNotificationContentExtension;
 			packageProductDependencies = (
-				A5DBBAE6262C72BD004AC028 /* CryptoSwift */,
 				A5F929B7262C858F00C3E60A /* MarkdownKit */,
 				A57282D4262C94E500C96FA8 /* DateToolsSwift */,
 				A5241B76262DEDEF009FA43E /* Clibsodium */,
@@ -3032,7 +3025,6 @@
 			packageProductDependencies = (
 				A5785ADE262C63580001BC66 /* web3swift */,
 				A5DBBABC262C7221004AC028 /* Clibsodium */,
-				A5DBBADB262C729B004AC028 /* CryptoSwift */,
 				A5DBBAED262C72EF004AC028 /* BitcoinKit */,
 				A5DBBAEF262C72EF004AC028 /* LiskKit */,
 				A50AEB03262C815200B37C22 /* EFQRCode */,
@@ -3055,6 +3047,7 @@
 				3AC76E3C2AB09118008042C4 /* ElegantEmojiPicker */,
 				3A075C9D2B98A3B100714E3B /* FilesPickerKit */,
 				3A833C3F2B99CDA000238F6A /* FilesStorageKit */,
+				AA8FFFC92D4E6435001D8576 /* CryptoSwift */,
 			);
 			productName = Adamant;
 			productReference = E913C8EE1FFFA51D001A83F7 /* Adamant.app */;
@@ -3074,7 +3067,6 @@
 			);
 			name = TransferNotificationContentExtension;
 			packageProductDependencies = (
-				A5DBBAE4262C72B7004AC028 /* CryptoSwift */,
 				A5F929B5262C858700C3E60A /* MarkdownKit */,
 				A57282D2262C94DF00C96FA8 /* DateToolsSwift */,
 				A5241B6F262DEDE1009FA43E /* Clibsodium */,
@@ -3099,7 +3091,6 @@
 			);
 			name = NotificationServiceExtension;
 			packageProductDependencies = (
-				A5DBBAE2262C72B0004AC028 /* CryptoSwift */,
 				A5F929AE262C857D00C3E60A /* MarkdownKit */,
 				A57282D0262C94DA00C96FA8 /* DateToolsSwift */,
 				A5241B7D262DEDFE009FA43E /* Clibsodium */,
@@ -3203,7 +3194,6 @@
 			packageReferences = (
 				A5785ADD262C63580001BC66 /* XCRemoteSwiftPackageReference "web3swift" */,
 				A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium" */,
-				A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
 				A50AEB02262C815200B37C22 /* XCRemoteSwiftPackageReference "EFQRCode" */,
 				A50AEB0A262C81E300B37C22 /* XCRemoteSwiftPackageReference "QRCodeReader.swift" */,
 				A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit" */,
@@ -3219,6 +3209,7 @@
 				938F7D562955C1DA001915CA /* XCRemoteSwiftPackageReference "MessageKit" */,
 				4184F16F2A33044E00D7B8B9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				3AC76E3B2AB09118008042C4 /* XCRemoteSwiftPackageReference "Elegant-Emoji-Picker" */,
+				AA8FFFC82D4E6435001D8576 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
 			);
 			productRefGroup = E913C8EF1FFFA51D001A83F7 /* Products */;
 			projectDirPath = "";
@@ -4670,14 +4661,6 @@
 				minimumVersion = 0.9.1;
 			};
 		};
-		A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/krzyzanowskim/CryptoSwift.git";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.5.0;
-			};
-		};
 		A5F0A049262C9CA90009672A /* XCRemoteSwiftPackageReference "Swinject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Swinject/Swinject.git";
@@ -4692,6 +4675,14 @@
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 1.7.0;
+			};
+		};
+		AA8FFFC82D4E6435001D8576 /* XCRemoteSwiftPackageReference "CryptoSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ChrisBenua/CryptoSwift";
+			requirement = {
+				kind = revision;
+				revision = f0ea2cac7983c4a808cade78743b391726ecc0ea;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -4844,26 +4835,6 @@
 			package = A5DBBABB262C7221004AC028 /* XCRemoteSwiftPackageReference "swift-sodium" */;
 			productName = Clibsodium;
 		};
-		A5DBBADB262C729B004AC028 /* CryptoSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
-			productName = CryptoSwift;
-		};
-		A5DBBAE2262C72B0004AC028 /* CryptoSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
-			productName = CryptoSwift;
-		};
-		A5DBBAE4262C72B7004AC028 /* CryptoSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
-			productName = CryptoSwift;
-		};
-		A5DBBAE6262C72BD004AC028 /* CryptoSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A5DBBADA262C729B004AC028 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
-			productName = CryptoSwift;
-		};
 		A5DBBAED262C72EF004AC028 /* BitcoinKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BitcoinKit;
@@ -4896,6 +4867,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A5F92992262C855A00C3E60A /* XCRemoteSwiftPackageReference "MarkdownKit" */;
 			productName = MarkdownKit;
+		};
+		AA8FFFC92D4E6435001D8576 /* CryptoSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA8FFFC82D4E6435001D8576 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
+			productName = CryptoSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/Adamant.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Adamant.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -39,11 +39,11 @@
       },
       {
         "package": "CryptoSwift",
-        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "repositoryURL": "https://github.com/ChrisBenua/CryptoSwift",
         "state": {
           "branch": null,
-          "revision": "039f56c5d7960f277087a0be51f5eb04ed0ec073",
-          "version": "1.5.1"
+          "revision": "f0ea2cac7983c4a808cade78743b391726ecc0ea",
+          "version": null
         }
       },
       {

--- a/LiskKit/Sources/Crypto/ED25519/Ed25519fe.swift
+++ b/LiskKit/Sources/Crypto/ED25519/Ed25519fe.swift
@@ -446,18 +446,23 @@ struct fe: CustomDebugStringConvertible {
     static func reduce_mul(_ r: inout fe) {
         var t: UInt32
         var s: UInt32
-        for _ in 0..<2 {
+        var i = 0
+        while i < 2 {
             // use q = 2^(31*8)*(2^7) - 19
             t = r.v[31] >> 7
             r.v[31] &= 0x7f
             t = times19(t)
             r.v[0] += t
             // move up
-            for i in 0..<31 {
-                s = r.v[i] >> 8
-                r.v[i+1] += s
-                r.v[i] &= 0xff
+            var j = 0
+            while j < 31 {
+                s = r.v[j] >> 8
+                r.v[j+1] += s
+                r.v[j] &= 0xff
+                j += 1
             }
+
+            i += 1
         }
     }
 
@@ -569,8 +574,10 @@ struct fe: CustomDebugStringConvertible {
 
     /// r = x + y
     static func fe25519_add(_ r: inout fe, _ x: fe, _ y: fe) {
-        for i in 0..<32 {
+        var i = 0
+        while i<32 {
             r.v[i] = x.v[i] + y.v[i]
+            i += 1
         }
         fe.reduce_add_sub(&r)
     }
@@ -587,28 +594,36 @@ struct fe: CustomDebugStringConvertible {
         // t = 2 * q + x
         var t = [UInt32](repeating: 0, count: 32)
         t[0] = x.v[0] + 0x1da    // LSB
-        for i in 1..<31 { t[i] = x.v[i] + 0x1fe }
+        var i = 1
+        while i < 31 { t[i] = x.v[i] + 0x1fe; i += 1 }
         t[31] = x.v[31] + 0xfe    // MSB
         // r = t - y
-        for i in 0..<32 { r.v[i] = t[i] - y.v[i] }
+        i = 0
+        while i < 32 { r.v[i] = t[i] - y.v[i]; i += 1 }
         fe.reduce_add_sub(&r)
     }
 
     /// r = x * y
     static func fe25519_mul(_ r: inout fe, _ x: fe, _ y: fe) {
         var t = [UInt32](repeating: 0, count: 63)
-
-        for i in 0..<32 {
-            for j in 0..<32 {
+        var i = 0
+        var j = 0
+        while i < 32 {
+            while j < 32 {
                 t[i+j] += x.v[i] * y.v[j]
+                j += 1
             }
+            i += 1
         }
 
         // 2q = 2^256 - 2*19
         // so 2^256 = 2*19
-        for i in 32..<63 {
+        i = 32
+        while i < 63 {
             r.v[i-32] = t[i-32] + fe.times38(t[i])
+            i += 1
         }
+
         r.v[31] = t[31] /* result now in r[0]...r[31] */
 
         fe.reduce_mul(&r)


### PR DESCRIPTION
Replaced for-in range loops inside CryptoSwift and LiskKit. Changes inside CryptoSwift drastically improved BIP32/39 keystore creation for generating private/public keys before initialization.

Optimized `Scrypt.salsa20_8_typed(_:)`, `Scrypt.blockXor(_:_:_:)`, `HMAC.authenticate(_:)`, `PKCS5.PBKDF2.calculateBlock(_:blockNum:)`, `SHA2.process32(block:currentHash:)`, `SHA3.θ(_:)` and more

Also used much faster `UInt/Int(trunactingIfNeeded:)` than regular `UInt/Int()` constructor in DEBUG-builds.

Spend some time Profiling the app, I will open more PRs later.