### PR TITLE
[trello.com/c/EB2cbIld] Bug: Coin selection in the wallet list

### DIFF
--- a/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
+++ b/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
@@ -97,10 +97,10 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
     }
     
     private func addObservers() {
-        wallets
-            .map { NotificationCenter.default.publisher(for: $0.walletUpdatedNotification, object: $0) }
-            .publisher
-            .flatMap { $0 }
+        wallets.publisher
+            .flatMap { wallet in
+                NotificationCenter.default.publisher(for: wallet.walletUpdatedNotification, object: wallet)
+            }
             .receive(on: DispatchQueue.main)
             .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
+++ b/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
@@ -97,7 +97,7 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
     }
     
     private func addObservers() {
-        let publisher = wallets
+        wallets
             .map { NotificationCenter.default.publisher(for: $0.walletUpdatedNotification, object: $0) }
             .publisher
             .flatMap { $0 }
@@ -106,8 +106,7 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
             .sink { [weak self] _ in
                 self?.tableView.reloadData()
             }
-        
-        subscriptions.insert(publisher)
+            .store(in: &subscriptions)
         
         NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,

--- a/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
+++ b/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import SnapKit
 import CommonKit
+import Combine
 
 // MARK: - Localization
 extension String.adamant {
@@ -67,7 +68,7 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
     private var filteredWallets: [WalletCoreProtocol]?
     private var wallets: [WalletCoreProtocol] = []
     private var previousAppState: UIApplication.State?
-    
+    private var subscriptions = Set<AnyCancellable>()
     // MARK: - Lifecycle
     
     init(visibleWalletsService: VisibleWalletsService, accountService: AccountService) {
@@ -79,7 +80,9 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         loadWallets()
@@ -94,20 +97,17 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
     }
     
     private func addObservers() {
-        for wallet in wallets {
-            let notification = wallet.walletUpdatedNotification
-            
-            NotificationCenter.default.addObserver(
-                forName: notification,
-                object: wallet,
-                queue: OperationQueue.main
-            ) { [weak self] _ in
-                MainActor.assumeIsolatedSafe {
-                    guard let self = self else { return }
-                    self.tableView.reloadData()
-                }
+        let publisher = wallets
+            .map { NotificationCenter.default.publisher(for: $0.walletUpdatedNotification, object: $0) }
+            .publisher
+            .flatMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.tableView.reloadData()
             }
-        }
+        
+        subscriptions.insert(publisher)
         
         NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,


### PR DESCRIPTION
It seems the bug occurred due to an extra table update that came through the observer, sometimes observer have like 30 notification in like 0.5 seconds, and reloadData() perform 30 in this time. So now I add debounce 1 sec for update to not let notification spam reloadData().