### PR TITLE
[trello.com/c/fzQGYRav]: fix disappearing cursor on amount field on macOS

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -478,6 +478,8 @@
 		AA8FFFBC2D49796A001D8576 /* ChatsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */; };
 		AA8FFFC02D4AC011001D8576 /* AdamantCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */; };
 		AA8FFFC42D4C1174001D8576 /* NativeAdamantCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFC32D4C1168001D8576 /* NativeAdamantCoreTests.swift */; };
+		AA8FFFE32D513681001D8576 /* CustomFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */; };
+		AA8FFFE52D513787001D8576 /* EdgeInsetTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */; };
 		AAB01CAD2D3AE44B007D6BF4 /* BitcoinKitTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */; };
 		AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */; };
 		AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */; };
@@ -1154,6 +1156,8 @@
 		AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsProviderMock.swift; sourceTree = "<group>"; };
 		AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdamantCoreMock.swift; sourceTree = "<group>"; };
 		AA8FFFC32D4C1168001D8576 /* NativeAdamantCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAdamantCoreTests.swift; sourceTree = "<group>"; };
+		AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldRow.swift; sourceTree = "<group>"; };
+		AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsetTextField.swift; sourceTree = "<group>"; };
 		AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinKitTransactionFactory.swift; sourceTree = "<group>"; };
 		AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeWalletServiceTests.swift; sourceTree = "<group>"; };
 		AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogeApiServiceProtocol.swift; sourceTree = "<group>"; };
@@ -2597,6 +2601,8 @@
 		E913C9101FFFAA4B001A83F7 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */,
+				AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */,
 				93775E452A674FA9009061AC /* Markdown+Adamant.swift */,
 				E9061B96207501E40011F104 /* AdamantUserInfoKey.swift */,
 				E94008862114F05B00CD2D67 /* AddressValidationResult.swift */,
@@ -3584,6 +3590,7 @@
 				3A7BD0122AA9BD5A0045AAB0 /* AdamantVibroType.swift in Sources */,
 				9306E0982CF8C67B00A99BA4 /* AdamantSecureField.swift in Sources */,
 				E921597520611A6A0000CA5C /* AdamantReachability.swift in Sources */,
+				AA8FFFE32D513681001D8576 /* CustomFieldRow.swift in Sources */,
 				3A2478AE2BB42967009D89E9 /* ChatDropView.swift in Sources */,
 				E9960B3321F5154300C840A8 /* BaseAccount+CoreDataClass.swift in Sources */,
 				E9FCA1E6218334C00005E83D /* SimpleTransactionDetails.swift in Sources */,
@@ -3622,6 +3629,7 @@
 				3AA388052B67F4DD00125684 /* BtcBlockchainInfoDTO.swift in Sources */,
 				93547BCA29E2262D00B0914B /* WelcomeViewController.swift in Sources */,
 				41047B74294C61D10039E956 /* VisibleWalletsService.swift in Sources */,
+				AA8FFFE52D513787001D8576 /* EdgeInsetTextField.swift in Sources */,
 				3AE0A42A2BC6A64900BF7125 /* FilesNetworkManager.swift in Sources */,
 				648CE3AC229AD2190070A2CC /* DashTransferViewController.swift in Sources */,
 				3A7BD0102AA9BD030045AAB0 /* AdamantVibroService.swift in Sources */,

--- a/Adamant/Helpers/CustomFieldRow.swift
+++ b/Adamant/Helpers/CustomFieldRow.swift
@@ -1,0 +1,370 @@
+import Eureka
+import UIKit
+
+// Copy of _FieldCell from Eureka with generic descendant of UITextField class
+open class CustomFieldCell<T, TextFieldType: UITextField> : Cell<T>, UITextFieldDelegate, TextFieldCell where T: Equatable, T: InputTypeInitiable {
+
+    weak var _textField: TextFieldType!
+    public var textField: UITextField! {
+        _textField
+    }
+    weak var titleLabel: UILabel?
+
+    fileprivate var observingTitleText = false
+    private var awakeFromNibCalled = false
+
+    open var dynamicConstraints = [NSLayoutConstraint]()
+
+    private var calculatedTitlePercentage: CGFloat = 0.7
+
+    public required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+
+        let textField = TextFieldType()
+        self._textField = textField
+        textField.translatesAutoresizingMaskIntoConstraints = false
+
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        setupTitleLabel()
+
+        contentView.addSubview(titleLabel!)
+        contentView.addSubview(textField)
+
+        NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: nil) { [weak self] _ in
+            guard let me = self else { return }
+            guard me.observingTitleText else { return }
+            me.titleLabel?.removeObserver(me, forKeyPath: "text")
+            me.observingTitleText = false
+        }
+        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
+            guard let me = self else { return }
+            guard !me.observingTitleText else { return }
+            me.titleLabel?.addObserver(me, forKeyPath: "text", options: [.new, .old], context: nil)
+            me.observingTitleText = true
+        }
+
+        NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification, object: nil, queue: nil) { [weak self] _ in
+            self?.setupTitleLabel()
+            self?.setNeedsUpdateConstraints()
+        }
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    open override func awakeFromNib() {
+        super.awakeFromNib()
+        awakeFromNibCalled = true
+    }
+
+    deinit {
+        textField?.delegate = nil
+        textField?.removeTarget(self, action: nil, for: .allEvents)
+        guard !awakeFromNibCalled else { return }
+        if observingTitleText {
+            titleLabel?.removeObserver(self, forKeyPath: "text")
+        }
+        imageView?.removeObserver(self, forKeyPath: "image")
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIContentSizeCategory.didChangeNotification, object: nil)
+    }
+
+    open override func setup() {
+        super.setup()
+        selectionStyle = .none
+
+        if !awakeFromNibCalled {
+            titleLabel?.addObserver(self, forKeyPath: "text", options: [.new, .old], context: nil)
+            observingTitleText = true
+            imageView?.addObserver(self, forKeyPath: "image", options: [.new, .old], context: nil)
+        }
+        textField.addTarget(self, action: #selector(CustomFieldCell.textFieldDidChange(_:)), for: .editingChanged)
+
+        if let titleLabel = titleLabel {
+            // Make sure the title takes over most of the empty space so that the text field starts editing at the back.
+            let priority = UILayoutPriority(rawValue: titleLabel.contentHuggingPriority(for: .horizontal).rawValue + 1)
+            textField.setContentHuggingPriority(priority, for: .horizontal)
+        }
+    }
+
+    open override func update() {
+        super.update()
+        detailTextLabel?.text = nil
+
+        if !awakeFromNibCalled {
+            if let title = row.title {
+                switch row.cellStyle {
+                case .subtitle:
+                    textField.textAlignment = .left
+                    textField.clearButtonMode = .whileEditing
+                default:
+                    textField.textAlignment = title.isEmpty ? .left : .right
+                    textField.clearButtonMode = title.isEmpty ? .whileEditing : .never
+                }
+            } else {
+                textField.textAlignment = .left
+                textField.clearButtonMode = .whileEditing
+            }
+        } else {
+            textLabel?.text = nil
+            titleLabel?.text = row.title
+            if #available(iOS 13.0, *) {
+                titleLabel?.textColor = row.isDisabled ? .tertiaryLabel : .label
+            } else {
+                titleLabel?.textColor = row.isDisabled ? .gray : .black
+            }
+        }
+        textField.delegate = self
+        textField.text = row.displayValueFor?(row.value)
+        textField.isEnabled = !row.isDisabled
+        if #available(iOS 13.0, *) {
+            textField.textColor = row.isDisabled ? .tertiaryLabel : .label
+        } else {
+            textField.textColor = row.isDisabled ? .gray : .black
+        }
+        textField.font = .preferredFont(forTextStyle: .body)
+        if let placeholder = (row as? FieldRowConformance)?.placeholder {
+            if let color = (row as? FieldRowConformance)?.placeholderColor {
+                textField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [.foregroundColor: color])
+            } else {
+                textField.placeholder = (row as? FieldRowConformance)?.placeholder
+            }
+        }
+        if row.isHighlighted {
+            titleLabel?.textColor = tintColor
+        }
+    }
+
+    open override func cellCanBecomeFirstResponder() -> Bool {
+        return !row.isDisabled && textField?.canBecomeFirstResponder == true
+    }
+
+    open override func cellBecomeFirstResponder(withDirection: Direction) -> Bool {
+        return textField.becomeFirstResponder()
+    }
+
+    open override func cellResignFirstResponder() -> Bool {
+        return textField.resignFirstResponder()
+    }
+
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        let obj = object as AnyObject?
+        
+        if let keyPathValue = keyPath, let changeType = change?[NSKeyValueChangeKey.kindKey],
+           ((obj === titleLabel && keyPathValue == "text") || (obj === imageView && keyPathValue == "image")) &&
+            (changeType as? NSNumber)?.uintValue == NSKeyValueChange.setting.rawValue {
+            setNeedsUpdateConstraints()
+            updateConstraintsIfNeeded()
+        }
+    }
+
+    // MARK: Helpers
+
+    open func customConstraints() {
+
+        guard !awakeFromNibCalled else { return }
+        contentView.removeConstraints(dynamicConstraints)
+        dynamicConstraints = []
+
+        switch row.cellStyle {
+        case .subtitle:
+            var views: [String: AnyObject] =  ["textField": textField]
+
+            if let titleLabel = titleLabel, let text = titleLabel.text, !text.isEmpty {
+                views["titleLabel"] = titleLabel
+                dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|-[titleLabel]-3-[textField]-|",
+                                                                     options: .alignAllLeading, metrics: nil, views: views)
+                titleLabel.setContentHuggingPriority(
+                    UILayoutPriority(textField.contentHuggingPriority(for: .vertical).rawValue + 1), for: .vertical)
+                dynamicConstraints.append(NSLayoutConstraint(item: titleLabel, attribute: .centerX, relatedBy: .equal, toItem: textField, attribute: .centerX, multiplier: 1, constant: 0))
+            } else {
+                dynamicConstraints.append(NSLayoutConstraint(item: textField!, attribute: .centerY, relatedBy: .equal, toItem: contentView, attribute: .centerY, multiplier: 1, constant: 0))
+            }
+
+            if let imageView = imageView, let _ = imageView.image {
+                views["imageView"] = imageView
+                if let titleLabel = titleLabel, let text = titleLabel.text, !text.isEmpty {
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:[imageView]-(15)-[titleLabel]-|", options: [], metrics: nil, views: views)
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:[imageView]-(15)-[textField]-|", options: [], metrics: nil, views: views)
+                } else {
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:[imageView]-(15)-[textField]-|", options: [], metrics: nil, views: views)
+                }
+            } else {
+                if let titleLabel = titleLabel, let text = titleLabel.text, !text.isEmpty {
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-[titleLabel]-|", options: [], metrics: nil, views: views)
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-[textField]-|", options: [], metrics: nil, views: views)
+                } else {
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-[textField]-|", options: .alignAllLeft, metrics: nil, views: views)
+                }
+            }
+
+        default:
+            var views: [String: AnyObject] =  ["textField": textField]
+            dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|-[textField]-|", options: .alignAllLastBaseline, metrics: nil, views: views)
+            
+            if let titleLabel = titleLabel, let text = titleLabel.text, !text.isEmpty {
+                views["titleLabel"] = titleLabel
+                dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|-[titleLabel]-|", options: .alignAllLastBaseline, metrics: nil, views: views)
+                dynamicConstraints.append(NSLayoutConstraint(item: titleLabel, attribute: .centerY, relatedBy: .equal, toItem: textField, attribute: .centerY, multiplier: 1, constant: 0))
+            }
+
+            if let imageView = imageView, let _ = imageView.image {
+                views["imageView"] = imageView
+                if let titleLabel = titleLabel, let text = titleLabel.text, !text.isEmpty {
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:[imageView]-(15)-[titleLabel]-[textField]-|", options: [], metrics: nil, views: views)
+                    dynamicConstraints.append(NSLayoutConstraint(item: titleLabel,
+                                                                 attribute: .width,
+                                                                 relatedBy: (row as? FieldRowConformance)?.titlePercentage != nil ? .equal : .lessThanOrEqual,
+                                                                 toItem: contentView,
+                                                                 attribute: .width,
+                                                                 multiplier: calculatedTitlePercentage,
+                                                                 constant: 0.0))
+                } else {
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:[imageView]-(15)-[textField]-|", options: [], metrics: nil, views: views)
+                }
+            } else {
+                if let titleLabel = titleLabel, let text = titleLabel.text, !text.isEmpty {
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-[titleLabel]-[textField]-|", options: [], metrics: nil, views: views)
+                    dynamicConstraints.append(NSLayoutConstraint(item: titleLabel,
+                                                                 attribute: .width,
+                                                                 relatedBy: (row as? FieldRowConformance)?.titlePercentage != nil ? .equal : .lessThanOrEqual,
+                                                                 toItem: contentView,
+                                                                 attribute: .width,
+                                                                 multiplier: calculatedTitlePercentage,
+                                                                 constant: 0.0))
+                } else {
+                    dynamicConstraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-[textField]-|", options: .alignAllLeft, metrics: nil, views: views)
+                }
+            }
+        }
+        contentView.addConstraints(dynamicConstraints)
+    }
+
+    open override func updateConstraints() {
+        customConstraints()
+        super.updateConstraints()
+    }
+
+    @objc open func textFieldDidChange(_ textField: UITextField) {
+ 
+        guard textField.markedTextRange == nil else { return }
+        
+        guard let textValue = textField.text else {
+            row.value = nil
+            return
+        }
+        guard let fieldRow = row as? FieldRowConformance, let formatter = fieldRow.formatter else {
+            row.value = textValue.isEmpty ? nil : (T.init(string: textValue) ?? row.value)
+            return
+        }
+        if fieldRow.useFormatterDuringInput {
+            let unsafePointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+            defer {
+                unsafePointer.deallocate()
+            }
+            let value: AutoreleasingUnsafeMutablePointer<AnyObject?> = AutoreleasingUnsafeMutablePointer<AnyObject?>.init(unsafePointer)
+            let errorDesc: AutoreleasingUnsafeMutablePointer<NSString?>? = nil
+            if formatter.getObjectValue(value, for: textValue, errorDescription: errorDesc) {
+                row.value = value.pointee as? T
+                guard var selStartPos = textField.selectedTextRange?.start else { return }
+                let oldVal = textField.text
+                textField.text = row.displayValueFor?(row.value)
+                selStartPos = (formatter as? FormatterProtocol)?.getNewPosition(forPosition: selStartPos, inTextInput: textField, oldValue: oldVal, newValue: textField.text) ?? selStartPos
+                textField.selectedTextRange = textField.textRange(from: selStartPos, to: selStartPos)
+                return
+            }
+        } else {
+            let unsafePointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
+            defer {
+                unsafePointer.deallocate()
+            }
+            let value: AutoreleasingUnsafeMutablePointer<AnyObject?> = AutoreleasingUnsafeMutablePointer<AnyObject?>.init(unsafePointer)
+            let errorDesc: AutoreleasingUnsafeMutablePointer<NSString?>? = nil
+            if formatter.getObjectValue(value, for: textValue, errorDescription: errorDesc) {
+                row.value = value.pointee as? T
+            } else {
+                row.value = textValue.isEmpty ? nil : (T.init(string: textValue) ?? row.value)
+            }
+        }
+    }
+
+    // MARK: Helpers
+
+    private func setupTitleLabel() {
+        titleLabel = self.textLabel
+        titleLabel?.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel?.setContentHuggingPriority(UILayoutPriority(rawValue: 500), for: .horizontal)
+        titleLabel?.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 1000), for: .horizontal)
+    }
+
+    private func displayValue(useFormatter: Bool) -> String? {
+        guard let v = row.value else { return nil }
+        if let formatter = (row as? FormatterConformance)?.formatter, useFormatter {
+            return textField?.isFirstResponder == true ? formatter.editingString(for: v) : formatter.string(for: v)
+        }
+        return String(describing: v)
+    }
+
+    // MARK: TextFieldDelegate
+
+    open func textFieldDidBeginEditing(_ textField: UITextField) {
+        formViewController()?.beginEditing(of: self)
+        formViewController()?.textInputDidBeginEditing(textField, cell: self)
+        if let fieldRowConformance = row as? FormatterConformance, let _ = fieldRowConformance.formatter, fieldRowConformance.useFormatterOnDidBeginEditing ?? fieldRowConformance.useFormatterDuringInput {
+            textField.text = displayValue(useFormatter: true)
+        } else {
+            textField.text = displayValue(useFormatter: false)
+        }
+    }
+
+    open func textFieldDidEndEditing(_ textField: UITextField) {
+        formViewController()?.endEditing(of: self)
+        formViewController()?.textInputDidEndEditing(textField, cell: self)
+        textFieldDidChange(textField)
+        textField.text = displayValue(useFormatter: (row as? FormatterConformance)?.formatter != nil)
+    }
+
+    open func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        return formViewController()?.textInputShouldReturn(textField, cell: self) ?? true
+    }
+
+    open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        return formViewController()?.textInput(textField, shouldChangeCharactersInRange:range, replacementString:string, cell: self) ?? true
+    }
+
+    open func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        return formViewController()?.textInputShouldBeginEditing(textField, cell: self) ?? true
+    }
+
+    open func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        return formViewController()?.textInputShouldClear(textField, cell: self) ?? true
+    }
+
+    open func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        return formViewController()?.textInputShouldEndEditing(textField, cell: self) ?? true
+    }
+
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let row = (row as? FieldRowConformance) else { return }
+        defer {
+            // As titleLabel is the textLabel, iOS may re-layout without updating constraints, for example:
+            // swiping, showing alert or actionsheet from the same section.
+            // thus we need forcing update to use customConstraints()
+            setNeedsUpdateConstraints()
+            updateConstraintsIfNeeded()
+        }
+        guard let titlePercentage = row.titlePercentage else  { return }
+        var targetTitleWidth = bounds.size.width * titlePercentage
+        if let imageView = imageView, let _ = imageView.image, let titleLabel = titleLabel {
+            var extraWidthToSubtract = titleLabel.frame.minX - imageView.frame.minX // Left-to-right interface layout
+            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+                extraWidthToSubtract = imageView.frame.maxX - titleLabel.frame.maxX
+            }
+            targetTitleWidth -= extraWidthToSubtract
+        }
+        calculatedTitlePercentage = targetTitleWidth / contentView.bounds.size.width
+    }
+}

--- a/Adamant/Helpers/EdgeInsetTextField.swift
+++ b/Adamant/Helpers/EdgeInsetTextField.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+final class EdgeInsetTextField: UITextField {
+    var caretInset: CGFloat = .zero
+    
+    public override func caretRect(for position: UITextPosition) -> CGRect {
+        super.caretRect(for: position).offsetBy(dx: -caretInset, dy: 0)
+    }
+}

--- a/Adamant/Helpers/SafeDecimalRow.swift
+++ b/Adamant/Helpers/SafeDecimalRow.swift
@@ -27,7 +27,7 @@ class _SafeDecimalRow: FieldRow<SafeDecimalCell> {
     }
 }
 
-final class SafeDecimalCell: _FieldCell<Double>, CellType {
+final class SafeDecimalCell: CustomFieldCell<Double, EdgeInsetTextField>, CellType {
     required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
     }
@@ -40,5 +40,13 @@ final class SafeDecimalCell: _FieldCell<Double>, CellType {
         super.setup()
         textField.autocorrectionType = .no
         textField.setPopupKeyboardType(.decimalPad)
+    }
+}
+
+extension CustomFieldCell {
+    /// Sets hugging priorities to make text field to take as much space as possible
+    func adjustHuggingPriority() {
+        textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        titleLabel?.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
 }

--- a/Adamant/Modules/Wallets/TransferViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/TransferViewControllerBase.swift
@@ -1101,6 +1101,11 @@ extension TransferViewControllerBase {
                 row.tag = BaseRows.amount.tag
                 row.formatter = self?.balanceFormatter
                 
+                if isMacOS {
+                    row.cell._textField.caretInset = 1
+                    row.cell.adjustHuggingPriority()
+                }
+
                 if let amount = self?.amount {
                     row.value = amount.doubleValue
                 }


### PR DESCRIPTION
Idea 1: cursor is disappearing because UITextField shrink and becomes too narrow
Solution 1: adjust content hugging priority
Result 1: does not work

Idea 2: cursor is not actually disappearing, it just layouts incorrectly
Solution 2: adjust result `caretRect(for:)` in UITextField subclass
Result 2: does not work

Idea 3: combine both idea 1 and idea 2:
Result 3: works fine!

To do so I had to create almost a copy of `_FieldCell` class from Eureka, but with generic `T: UITextField` type along with `EdgeInsetTextField` that adjust caret size with given inset.

And make `SafeDecimalCell` a child of `CustomFieldCell<Double, EdgeInsetTextField>`.

https://github.com/user-attachments/assets/04f32259-5911-4ed1-bc06-a322a8cc1dd4

