### PR TITLE
[trello.com/c/LC02sdnW]: optimize hexBytes calculation

### DIFF
--- a/CommonKit/Sources/CommonKit/Core/NativeAdamantCore.swift
+++ b/CommonKit/Sources/CommonKit/Core/NativeAdamantCore.swift
@@ -215,12 +215,22 @@ public final class NativeAdamantCore: AdamantCore {
 
 public extension String {
     func hexBytes() -> [UInt8] {
-        return (0..<count/2).reduce([]) { res, i in
-            let indexStart = index(startIndex, offsetBy: i * 2)
-            let indexEnd = index(indexStart, offsetBy: 2)
-            let substring = self[indexStart..<indexEnd]
-            return res + [UInt8(substring, radix: 16) ?? 0]
+        let utf8CString = self.utf8CString
+        let length = utf8CString.count - 1 // utf8CString includes a null terminator
+        
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(length / 2)
+        
+        for i in stride(from: 0, to: length, by: 2) {
+            if let highValue = hexCharToUInt8(utf8CString[i]),
+               let lowValue = hexCharToUInt8(utf8CString[i + 1]) {
+                bytes.append((highValue << 4) | lowValue)
+            } else {
+                bytes.append(0)
+            }
         }
+        
+        return bytes
     }
     
     static func random(length: Int = 32, alphabet: String = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") -> String {
@@ -229,6 +239,21 @@ public extension String {
             let index = alphabet.index(alphabet.startIndex, offsetBy: Int(arc4random_uniform(upperBound)))
             return alphabet[index]
         })
+    }
+}
+
+private extension String {
+    func hexCharToUInt8(_ char: CChar) -> UInt8? {
+        switch char {
+        case 48...57:   // '0'-'9'
+            return UInt8(char - 48)
+        case 65...70:   // 'A'-'F'
+            return UInt8(char - 55)
+        case 97...102:  // 'a'-'f'
+            return UInt8(char - 87)
+        default:
+            return nil
+        }
     }
 }
 

--- a/LiskKit/Sources/Crypto/Crypto.swift
+++ b/LiskKit/Sources/Crypto/Crypto.swift
@@ -224,19 +224,40 @@ extension KeyPair {
 extension String {
 
     internal func hexBytes() -> [UInt8] {
-        return (0..<count/2).reduce([]) { res, i in
-            let indexStart = index(startIndex, offsetBy: i * 2)
-            let indexEnd = index(indexStart, offsetBy: 2)
-            let substring = self[indexStart..<indexEnd]
-            return res + [UInt8(substring, radix: 16) ?? 0]
+        let utf8CString = self.utf8CString
+        let length = utf8CString.count - 1 // utf8CString includes a null terminator
+        
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(length / 2)
+        
+        for i in stride(from: 0, to: length, by: 2) {
+            if let highValue = hexCharToUInt8(utf8CString[i]),
+               let lowValue = hexCharToUInt8(utf8CString[i + 1]) {
+                bytes.append((highValue << 4) | lowValue)
+            } else {
+                bytes.append(0)
+            }
         }
+        
+        return bytes
     }
+    
     internal func allHexBytes() -> [UInt8] {
-        return (0..<count/2).reduce([]) { res, i in
-            let indexStart = index(startIndex, offsetBy: i * 2)
-            let indexEnd = index(indexStart, offsetBy: 2)
-            let substring = self[indexStart..<indexEnd]
-            return res + [UInt8(substring, radix: 16) ?? 0]
+        hexBytes()
+    }
+}
+
+private extension String {
+    func hexCharToUInt8(_ char: CChar) -> UInt8? {
+        switch char {
+        case 48...57:   // '0'-'9'
+            return UInt8(char - 48)
+        case 65...70:   // 'A'-'F'
+            return UInt8(char - 55)
+        case 97...102:  // 'a'-'f'
+            return UInt8(char - 87)
+        default:
+            return nil
         }
     }
 }


### PR DESCRIPTION
Before: 900+ ms on main thread, 1.12 total (release build)
After: 0 ms (even not shown in Xcode Instruments Time Profiler)

Problem 1:
```
 let indexStart = index(startIndex, offsetBy: i * 2) // O(n) complexity
 let indexEnd = index(indexStart, offsetBy: 2)
```

So the whole operation is O(n^2):

```
return (0..<count/2).reduce([]) { res, i in // O(n)
let indexStart = index(startIndex, offsetBy: i * 2) // O(n)
```

Moreover, then it requires to create substring:

```
let substring = self[indexStart..<indexEnd]
return res + [UInt8(substring, radix: 16) ?? 0]
```

So I simplified it using simple loop and `hexCharToUInt8` to convert each symbol to `UInt4` (but inside `UInt8`) and then join them in single `UInt8` using `bytes.append((highValue << 4) | lowValue)`

<img width="615" alt="Before" src="https://github.com/user-attachments/assets/9b72ae74-9107-4d00-b89e-322a79ca6ba5" />


<img width="878" alt="After" src="https://github.com/user-attachments/assets/b393cbb6-124c-4104-af71-dbf1f6457ccc" />
