### PR TITLE
[trello.com/c/GYGMhcdI]: Reset button red highlight fix

### DIFF
--- a/Adamant/Modules/CoinsNodesList/View/CoinsNodesListView.swift
+++ b/Adamant/Modules/CoinsNodesList/View/CoinsNodesListView.swift
@@ -26,7 +26,7 @@ struct CoinsNodesListView: View {
             isPresented: $viewModel.state.isAlertShown
         ) {
             Button(String.adamant.alert.cancel, role: .cancel) {}
-            Button(String.adamant.coinsNodesList.reset) { viewModel.reset() }
+            Button(String.adamant.coinsNodesList.reset, role: .destructive) { viewModel.reset() }
         }
         .navigationTitle(String.adamant.coinsNodesList.title)
     }


### PR DESCRIPTION
Used `.destructive` role from [Apple docs](https://developer.apple.com/documentation/swiftui/buttonrole)

<img src="https://github.com/user-attachments/assets/7f1c9f6f-2455-4ab7-9b51-78b6534298e2" width="200" />
<img src="https://github.com/user-attachments/assets/6b62c04b-adf6-40aa-8449-ea5f8d277066" width="200" />
