### PR TITLE
[trello.com/c/2weLtL2D]: handling keyboard input on login screen and on new chat screen

### DIFF
--- a/Adamant/Modules/ChatsList/NewChatViewController.swift
+++ b/Adamant/Modules/ChatsList/NewChatViewController.swift
@@ -247,7 +247,7 @@ final class NewChatViewController: FormViewController {
     
     // MARK: - IBActions
     
-    @IBAction func done(_ sender: Any) {
+    @IBAction func done() {
         guard let row: TextRow = form.rowBy(tag: Rows.addressField.tag), let nums = row.value, nums.count > 0 else {
             dialogService.showToastMessage(String.adamant.newChat.specifyValidAddressMessage)
             return
@@ -348,6 +348,36 @@ final class NewChatViewController: FormViewController {
         default:
             return false
         }
+    }
+    
+    // MARK: - FormViewController
+    
+    override func textInputShouldReturn<T>(_ textInput: UITextInput, cell: Cell<T>) -> Bool {
+        let result = super.textInputShouldReturn(textInput, cell: cell)
+        if cell.row.tag == Rows.addressField.tag {
+            done()
+        }
+        
+        return result
+    }
+}
+
+// MARK: - Hardware keyboard handling
+
+extension NewChatViewController {
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+    
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        for press in presses {
+            guard let key = press.key else { continue }
+            if key.keyCode == UIKeyboardHIDUsage.keyboardReturnOrEnter {
+                return done()
+            }
+        }
+        
+        super.pressesBegan(presses, with: event)
     }
 }
 

--- a/Adamant/Modules/Login/LoginViewController.swift
+++ b/Adamant/Modules/Login/LoginViewController.swift
@@ -526,6 +526,27 @@ extension LoginViewController: ButtonsStripeViewDelegate {
     }
 }
 
+// MARK: - Hardware keyboard handling
+
+extension LoginViewController {
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        for press in presses {
+            guard let key = press.key else { continue }
+            if key.keyCode == UIKeyboardHIDUsage.keyboardReturnOrEnter {
+                if let passphrase = (form.rowBy(tag: Rows.passphrase.tag) as? PasswordRow)?.value {
+                    return loginWith(passphrase: passphrase)
+                }
+            }
+        }
+
+        super.pressesBegan(presses, with: event)
+    }
+}
+
 // MARK: UITextField + extensions
 
 private extension UITextField {


### PR DESCRIPTION
All handling is done using `func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?)` and `canBecomeFirstResponder`.

Additional handling of enter key while typing in `UITextField` is done in `override func textInputShouldReturn<T>(_ textInput: UITextInput, cell: Cell<T>) -> Bool`