### PR TITLE
[trello.com/c/pwKrXiiC] Update the logic of reading messages.

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -465,8 +465,8 @@
 		AA33BEB62D303E240083E59C /* APICoreProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB52D303DB60083E59C /* APICoreProtocolMock.swift */; };
 		AA33BEB72D3041A30083E59C /* AddressConverterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB42D303CBD0083E59C /* AddressConverterMock.swift */; };
 		AA33BEB92D3044760083E59C /* BtcApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */; };
-		AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */; };
 		AA8FFFCA2D4E6435001D8576 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AA8FFFC92D4E6435001D8576 /* CryptoSwift */; };
+		AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */; };
 		AAB01CAD2D3AE44B007D6BF4 /* BitcoinKitTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */; };
 		AAB01CAF2D3AECED007D6BF4 /* DogeWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAE2D3AECE6007D6BF4 /* DogeWalletServiceTests.swift */; };
 		AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CB02D3AF015007D6BF4 /* DogeApiServiceProtocol.swift */; };

--- a/Adamant/Adamant.xcdatamodeld/Adamant.xcdatamodel/contents
+++ b/Adamant/Adamant.xcdatamodeld/Adamant.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22225" systemVersion="23B81" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24D60" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="BaseAccount" representedClassName="BaseAccount" isAbstract="YES" syncable="YES">
         <attribute name="address" attributeType="String"/>
         <attribute name="avatar" optional="YES" attributeType="String"/>
@@ -66,6 +66,7 @@
         <attribute name="isMarkdown" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="message" attributeType="String"/>
         <attribute name="reactionsData" optional="YES" attributeType="Transformable"/>
+        <relationship name="richMessageTransactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="RichMessageTransaction" inverseName="messageTransaction" inverseEntity="RichMessageTransaction"/>
     </entity>
     <entity name="RichMessageTransaction" representedClassName="RichMessageTransaction" parentEntity="ChatTransaction" syncable="YES">
         <attribute name="additionalType" optional="YES" attributeType="Integer 32" defaultValueString="2" usesScalarValueType="YES"/>
@@ -76,11 +77,14 @@
         <attribute name="richTransferHash" optional="YES" attributeType="String"/>
         <attribute name="richType" attributeType="String"/>
         <attribute name="transferStatusRaw" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" customClassName="RichTransferStatus"/>
+        <relationship name="messageTransaction" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MessageTransaction" inverseName="richMessageTransactions" inverseEntity="MessageTransaction"/>
+        <relationship name="transferTransaction" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TransferTransaction" inverseName="richMessageTransactions" inverseEntity="TransferTransaction"/>
     </entity>
     <entity name="TransferTransaction" representedClassName="TransferTransaction" parentEntity="ChatTransaction" syncable="YES">
         <attribute name="comment" optional="YES" attributeType="String"/>
         <attribute name="decodedReplyMessage" optional="YES" attributeType="String"/>
         <attribute name="reactionsData" optional="YES" attributeType="Transformable"/>
         <attribute name="replyToId" optional="YES" attributeType="String"/>
+        <relationship name="richMessageTransactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="RichMessageTransaction" inverseName="transferTransaction" inverseEntity="RichMessageTransaction"/>
     </entity>
 </model>

--- a/Adamant/Models/CoreData/MessageTransaction+CoreDataProperties.swift
+++ b/Adamant/Models/CoreData/MessageTransaction+CoreDataProperties.swift
@@ -19,6 +19,7 @@ extension MessageTransaction {
     @NSManaged public var isMarkdown: Bool
     @NSManaged public var message: String?
     @NSManaged public var reactionsData: Data?
+    @NSManaged public var richMessageTransactions: Set<RichMessageTransaction>?
     
     var reactions: Set<Reaction>? {
         get {
@@ -38,5 +39,8 @@ extension MessageTransaction {
             let data = try? PropertyListEncoder().encode(value)
             reactionsData = data
         }
+    }
+    func addToRichMessageTransactions(_ transaction: RichMessageTransaction) {
+        self.mutableSetValue(forKey: "richMessageTransactions").add(transaction)
     }
 }

--- a/Adamant/Models/CoreData/RichMessageTransaction+CoreDataProperties.swift
+++ b/Adamant/Models/CoreData/RichMessageTransaction+CoreDataProperties.swift
@@ -23,6 +23,8 @@ extension RichMessageTransaction {
     @NSManaged public var richType: String?
     @NSManaged public var transferStatusRaw: NSNumber?
     @NSManaged public var additionalType: RichAdditionalType
+    @NSManaged public var messageTransaction: MessageTransaction?
+    @NSManaged public var transferTransaction: TransferTransaction?
     
     func isTransferReply() -> Bool {
         return richContent?[RichContentKeys.reply.replyMessage] is [String: String]

--- a/Adamant/Models/CoreData/TransferTransaction+CoreDataProperties.swift
+++ b/Adamant/Models/CoreData/TransferTransaction+CoreDataProperties.swift
@@ -20,6 +20,7 @@ extension TransferTransaction {
     @NSManaged public var replyToId: String?
     @NSManaged public var decodedReplyMessage: String?
     @NSManaged public var reactionsData: Data?
+    @NSManaged public var richMessageTransactions: Set<RichMessageTransaction>?
     
     var reactions: Set<Reaction>? {
         get {
@@ -61,5 +62,8 @@ extension TransferTransaction: AdamantTransactionDetails {
     var chatRoom: Chatroom? {
         let partner = partner as? CoreDataAccount
         return partner?.chatroom
+    }
+    func addToRichMessageTransactions(_ transaction: RichMessageTransaction) {
+        self.mutableSetValue(forKey: "richMessageTransactions").add(transaction)
     }
 }

--- a/Adamant/Modules/Chat/ViewModel/ChatMessageFactory.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatMessageFactory.swift
@@ -113,7 +113,8 @@ struct ChatMessageFactory: Sendable {
             ).map { .init(string: $0) },
             dateHeader: makeDateHeader(sentDate: sentDate),
             topSpinnerOn: topSpinnerOn, 
-            dateHeaderIsHidden: !dateHeaderOn
+            dateHeaderIsHidden: !dateHeaderOn,
+            isUnread: checkTransactionForUnreadReaction(transaction: transaction)
         )
     }
 }
@@ -540,6 +541,21 @@ private extension ChatMessageFactory {
                 .foregroundColor: UIColor.adamant.secondary
             ]
         ))
+    }
+    func checkTransactionForUnreadReaction(transaction: ChatTransaction) -> Bool {
+        if let messageTransaction = transaction as? MessageTransaction,
+           let richTransactions = messageTransaction.richMessageTransactions,
+           !richTransactions.isEmpty {
+            return richTransactions.contains { $0.isUnread }
+        }
+        
+        if let transferTransaction = transaction as? TransferTransaction,
+           let richTransactions = transferTransaction.richMessageTransactions,
+           !richTransactions.isEmpty {
+            return richTransactions.contains { $0.isUnread }
+        }
+        
+        return transaction.isUnread
     }
 }
 

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -88,7 +88,6 @@ final class ChatViewModel: NSObject {
     let didTapAdmSend = ObservableSender<AdamantAddress>()
     let didTapAdmNodesList = ObservableSender<Void>()
     let closeScreen = ObservableSender<Void>()
-    let updateChatRead = ObservableSender<Void>()
     let commitVibro = ObservableSender<Void>()
     let layoutIfNeeded = ObservableSender<Void>()
     let presentKeyboard = ObservableSender<Void>()
@@ -105,6 +104,7 @@ final class ChatViewModel: NSObject {
     @ObservableValue private(set) var isHeaderLoading = false
     @ObservableValue private(set) var fullscreenLoading = false
     @ObservableValue private(set) var messages = [ChatMessage]()
+    @ObservableValue private(set) var unReadMesaggesIndexes: [Int]?
     @ObservableValue private(set) var isAttachmentButtonAvailable = false
     @ObservableValue private(set) var isSendingAvailable = false
     @ObservableValue private(set) var fee = ""
@@ -207,6 +207,7 @@ final class ChatViewModel: NSObject {
     ) {
         assert(self.chatroom == nil, "Can't setup several times")
         self.chatroom = chatroom
+        self.chatroom?.updateLastTransaction()
         self.messageIdToShow = messageIdToShow
         controller = chatsProvider.getChatController(for: chatroom)
         controller?.delegate = self
@@ -400,18 +401,15 @@ final class ChatViewModel: NSObject {
         guard let address = chatroom?.partner?.address else { return }
         chatsProvider.setChatPositon(for: address, position: offset.map { Double.init($0) })
     }
-    
-    func entireChatWasRead() {
+    func messageWasRead(index: Int) {
+        guard _messages.wrappedValue.indices.contains(index) else { return }
+        guard let chatroom else { return }
+
+        let message = _messages.wrappedValue[index]
         Task {
-            guard
-                let chatroom = chatroom,
-                chatroom.hasUnreadMessages == true || chatroom.lastTransaction?.isUnread == true
-            else { return }
-            
-            await chatsProvider.markChatAsRead(chatroom: chatroom)
+            await chatsProvider.markMessageAsRead(chatroom: chatroom, message: message.messageId)
         }
     }
-    
     func hideMessage(id: String) {
         Task {
             guard let transaction = chatTransactions.first(where: { $0.chatMessageId == id })
@@ -1095,6 +1093,18 @@ private extension ChatViewModel {
             .sink { [weak self] _ in self?.inputTextUpdated() }
             .store(in: &subscriptions)
         
+        $messages
+            .map { messages in
+                messages.enumerated()
+                    .filter { $0.element.isUnread }
+                    .map { $0.offset }
+            }
+            .removeDuplicates()
+            .sink { [weak self] unreadIndexes in
+                self?.unReadMesaggesIndexes = unreadIndexes
+            }
+            .store(in: &subscriptions)
+        
         chatFileService.updateFileFields
             .receive(on: DispatchQueue.main)
             .sink { [weak self] data in
@@ -1245,12 +1255,6 @@ private extension ChatViewModel {
                 resetLoadingProperty: resetLoadingProperty,
                 expirationTimestamp: expirationTimestamp
             )
-            
-            // The 'makeMessages' method doesn't include reactions.
-            // If the message count is different from the number of transactions, update the chat read status if necessary.
-            if messages.count != chatTransactions.count {
-                updateChatRead.send()
-            }
         }
     }
     

--- a/Adamant/Modules/Chat/ViewModel/Models/ChatMessage.swift
+++ b/Adamant/Modules/Chat/ViewModel/Models/ChatMessage.swift
@@ -21,6 +21,7 @@ struct ChatMessage: Identifiable, Equatable, Sendable {
     let dateHeader: ComparableAttributedString?
     let topSpinnerOn: Bool
     let dateHeaderIsHidden: Bool
+    var isUnread: Bool
     
     static var `default`: Self {
         Self(
@@ -33,7 +34,8 @@ struct ChatMessage: Identifiable, Equatable, Sendable {
             bottomString: nil,
             dateHeader: nil,
             topSpinnerOn: false,
-            dateHeaderIsHidden: true
+            dateHeaderIsHidden: true,
+            isUnread: true
         )
     }
 }

--- a/Adamant/Modules/ChatsList/ChatListViewController.swift
+++ b/Adamant/Modules/ChatsList/ChatListViewController.swift
@@ -70,6 +70,11 @@ final class ChatListViewController: KeyboardObservingViewController {
     var searchController: UISearchController?
     
     private var transactionsRequiringBalanceUpdate: [String] = []
+    private lazy var chatsManuallyMarkedAsUnread: Set<Int> = Set() {
+        didSet {
+            setBadgeValue(unreadController?.fetchedObjects?.count)
+        }
+    }
     
     let defaultAvatar = UIImage.asset(named: "avatar-chat-placeholder") ?? .init()
     
@@ -286,6 +291,7 @@ final class ChatListViewController: KeyboardObservingViewController {
             .sink { @MainActor [weak self] _ in
                 self?.initFetchedRequestControllers(provider: nil)
                 self?.areMessagesLoaded = false
+                self?.chatsManuallyMarkedAsUnread = Set()
             }
             .store(in: &subscriptions)
         
@@ -560,6 +566,7 @@ extension ChatListViewController: UITableViewDelegate, UITableViewDataSource {
         if let chatroom = chatsController?.fetchedObjects?[safe: nIndexPath.row] {
             let vc = chatViewController(for: chatroom)
             vc.hidesBottomBarWhenPushed = true
+            chatsManuallyMarkedAsUnread.remove(indexPath.row)
             
             if let split = self.splitViewController {
                 let chat = UINavigationController(rootViewController:vc)
@@ -681,7 +688,7 @@ extension ChatListViewController {
         cell.hasUnreadMessages = chatroom.hasUnreadMessages
 
         if let lastTransaction = chatroom.lastTransaction {
-            cell.hasUnreadMessages = lastTransaction.isUnread
+            cell.hasUnreadMessages = chatroom.hasUnreadMessages
             cell.lastMessageLabel.attributedText = shortDescription(for: lastTransaction)
         } else {
             cell.lastMessageLabel.text = nil
@@ -904,15 +911,21 @@ extension ChatListViewController {
                 message: text?.string,
                 image: image
             ) { [weak self] in
-                self?.presentChatroom(chatroom)
+                self?.presentChatroom(chatroom, with: self?.messageId(transaction: transaction))
             }
         }
     }
-    
+    private func messageId(transaction: ChatTransaction) -> String? {
+        if let transaction = transaction as? RichMessageTransaction {
+            return transaction.messageTransaction?.transactionId
+        } else {
+            return transaction.transactionId
+        }
+    }
     @MainActor
-    func presentChatroom(_ chatroom: Chatroom, with message: MessageTransaction? = nil) {
+    func presentChatroom(_ chatroom: Chatroom, with message: String? = nil) {
         // MARK: 1. Create and config ViewController
-        let vc = chatViewController(for: chatroom, with: message?.transactionId)
+        let vc = chatViewController(for: chatroom, with: message)
         
         if let split = self.splitViewController, UIScreen.main.traitCollection.userInterfaceIdiom == .pad {
             let chat = UINavigationController(rootViewController:vc)
@@ -1097,7 +1110,7 @@ extension ChatListViewController {
         
         var actions: [UIContextualAction] = []
       
-        let markAsRead = makeMarkAsReadContextualAction(for: chatroom)
+        let markAsRead = makeMarkAsReadContextualAction(for: chatroom, index: indexPath.row)
         actions.append(markAsRead)
         
         return UISwipeActionsConfiguration(actions: actions)
@@ -1150,15 +1163,17 @@ extension ChatListViewController {
         return block
     }
     
-    private func makeMarkAsReadContextualAction(for chatroom: Chatroom) -> UIContextualAction {
+    private func makeMarkAsReadContextualAction(for chatroom: Chatroom, index: Int) -> UIContextualAction {
         let markAsRead = UIContextualAction(
             style: .normal,
             title: "👀"
         ) { (_, _, completionHandler) in
             if chatroom.hasUnread {
                 chatroom.markAsReaded()
+                self.chatsManuallyMarkedAsUnread.remove(index)
             } else {
                 chatroom.markAsUnread()
+                self.chatsManuallyMarkedAsUnread.insert(index)
             }
             try? chatroom.managedObjectContext?.save()
             completionHandler(true)
@@ -1347,9 +1362,11 @@ extension ChatListViewController {
             item = tabBarItem
         }
         
-        if let value = value, value > 0 {
-            item.badgeValue = String(value)
-            notificationsService.setBadge(number: value)
+        let adjustedValue = (value ?? 0) + chatsManuallyMarkedAsUnread.count
+
+        if adjustedValue > 0 {
+            item.badgeValue = String(adjustedValue)
+            notificationsService.setBadge(number: adjustedValue)
         } else {
             item.badgeValue = nil
             notificationsService.setBadge(number: nil)
@@ -1474,7 +1491,7 @@ extension ChatListViewController: UISearchBarDelegate, UISearchResultsUpdating, 
                 tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
             }
             
-            presenter.presentChatroom(chatroom, with: message)
+            presenter.presentChatroom(chatroom, with: message.transactionId)
         }
     }
     

--- a/Adamant/ServiceProtocols/DataProviders/ChatsProvider.swift
+++ b/Adamant/ServiceProtocols/DataProviders/ChatsProvider.swift
@@ -285,6 +285,7 @@ protocol ChatsProvider: DataProvider, Actor {
     func blockChat(with address: String)
     func removeMessage(with id: String)
     func markChatAsRead(chatroom: Chatroom)
+    func markMessageAsRead(chatroom: Chatroom, message: String)
     
     @MainActor func removeChatPositon(for address: String)
     @MainActor func setChatPositon(for address: String, position: Double?)

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -1948,7 +1948,13 @@ extension AdamantChatsProvider {
             }
         }
     }
-    
+    func markMessageAsRead(chatroom: Chatroom, message: String) {
+        chatroom.managedObjectContext?.perform { [weak self] in
+            guard let self else { return }
+            chatroom.markMessageAsReaded(chatMessageId: message, stack: self.stack)
+            try? chatroom.managedObjectContext?.save()
+        }
+    }
     func markChatAsRead(chatroom: Chatroom) {
         chatroom.managedObjectContext?.perform {
             chatroom.markAsReaded()

--- a/Adamant/Services/DataProviders/InMemoryCoreDataStack.swift
+++ b/Adamant/Services/DataProviders/InMemoryCoreDataStack.swift
@@ -20,6 +20,8 @@ final class InMemoryCoreDataStack: CoreDataStack {
         
         let description = NSPersistentStoreDescription()
         description.type = NSInMemoryStoreType
+        description.shouldMigrateStoreAutomatically = true
+        description.shouldInferMappingModelAutomatically = true
         
         container = NSPersistentContainer(name: "Adamant", managedObjectModel: model)
         container.persistentStoreDescriptions = [description]

--- a/Adamant/Services/RichTransactionReactService/AdamantRichTransactionReactService.swift
+++ b/Adamant/Services/RichTransactionReactService/AdamantRichTransactionReactService.swift
@@ -122,8 +122,20 @@ private extension AdamantRichTransactionReactService {
         
         switch baseTransaction {
         case let trs as MessageTransaction:
+            if let context = trs.managedObjectContext {
+                let transactionInContext = context.object(with: transaction.objectID) as? RichMessageTransaction
+                transactionInContext?.messageTransaction = trs
+                trs.addToRichMessageTransactions(transactionInContext!)
+                try? context.save()
+            }
             update(transaction: trs)
         case let trs as TransferTransaction:
+            if let context = trs.managedObjectContext {
+                let transactionInContext = context.object(with: transaction.objectID) as? RichMessageTransaction
+                transactionInContext?.transferTransaction = trs
+                trs.addToRichMessageTransactions(transactionInContext!)
+                try? context.save()
+            }
             update(transaction: trs)
         case let trs as RichMessageTransaction:
             update(transaction: trs)


### PR DESCRIPTION
the current code is here: https://github.com/Adamant-im/adamant-iOS/pull/705
the following changes have been added:
1. All unnecessary functions responsible for and implementing full reading of the chatroom have been removed
2. Now chats that are manually marked as unread will not make the last chat transaction unread, this prevents potential bugs
3. Now messages in the chat view model have an unread parameter, which allows you to track which messages on the screen are unread
4. Relationships between transactions and reactions, between messages and reactions have been added to the database. This allows you to add unread reaction to message in the view model and work with the reading flow.
5. Now when you click on the alert notification about an incoming message, the chat opens and scrolls to this message