### PR TITLE
[trello.com/c/7YVA2NTe]: cancel file uploading

### DIFF
--- a/Adamant/Modules/Chat/View/Managers/ChatAction.swift
+++ b/Adamant/Modules/Chat/View/Managers/ChatAction.swift
@@ -21,6 +21,7 @@ enum ChatAction {
     case react(id: String, emoji: String)
     case presentMenu(arg: ChatContextMenuArguments)
     case openFile(messageId: String, file: ChatFile)
+    case cancelUploading(messageId: String, file: ChatFile)
     case autoDownloadContentIfNeeded(messageId: String, files: [ChatFile])
     case forceDownloadAllFiles(messageId: String, files: [ChatFile])
 }

--- a/Adamant/Modules/Chat/View/Managers/ChatDataSourceManager.swift
+++ b/Adamant/Modules/Chat/View/Managers/ChatDataSourceManager.swift
@@ -201,6 +201,8 @@ private extension ChatDataSourceManager {
             viewModel.copyTextInPartAction(text)
         case let .openFile(messageId, file):
             viewModel.openFile(messageId: messageId, file: file)
+        case let .cancelUploading(messageId, file):
+            viewModel.cancelFileUploading(messageId: messageId, file: file)
         case let .autoDownloadContentIfNeeded(messageId, files):
             viewModel.autoDownloadContentIfNeeded(
                 messageId: messageId,

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/ChatFileContainerView/FileListContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/ChatFileContainerView/FileListContainerView.swift
@@ -83,12 +83,18 @@ private extension FileListContainerView {
                 txStatus: model.txStatus
             )
             view?.buttonActionHandler = { [weak self, file, model] in
-                self?.actionHandler(
-                    .openFile(
-                        messageId: model.messageId,
-                        file: file
+                if file.isBusy, file.isUploading {
+                    self?.actionHandler(
+                        .cancelUploading(messageId: model.messageId, file: file)
                     )
-                )
+                } else {
+                    self?.actionHandler(
+                        .openFile(
+                            messageId: model.messageId,
+                            file: file
+                        )
+                    )
+                }
             }
         }
     }

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/MediaContainerView/MediaContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/MediaContainerView/MediaContainerView.swift
@@ -131,12 +131,18 @@ private extension MediaContainerView {
                         txStatus: model.txStatus
                     )
                     mediaView.buttonActionHandler = { [weak self, file, model] in
-                        self?.actionHandler(
+                        let action: ChatAction = if file.isBusy, file.isUploading {
+                            .cancelUploading(
+                                messageId: model.messageId,
+                                file: file
+                            )
+                        } else {
                             .openFile(
                                 messageId: model.messageId,
                                 file: file
                             )
-                        )
+                        }
+                        self?.actionHandler(action)
                     }
 
                     if let resolution = file.file.resolution,

--- a/Adamant/Modules/Chat/ViewModel/ChatFileService.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatFileService.swift
@@ -24,11 +24,13 @@ private struct FileMessage {
     var files: [FileUpload]
     var message: String?
     var txId: String?
+    var adamantMessage: AdamantMessage?
 }
 
 @MainActor
 final class ChatFileService: ChatFileProtocol, Sendable {
     typealias UploadResult = (decodedData: Data, encodedData: Data, nonce: String, cid: String)
+    typealias UploadFileResult = (file: UploadResult, preview: UploadResult?)
     
     // MARK: Dependencies
     
@@ -47,6 +49,7 @@ final class ChatFileService: ChatFileProtocol, Sendable {
     private var fileDownloadAttemptsCount: [String: Int] = [:]
     private var uploadingFilesDictionary: [String: FileMessage] = [:]
     private var previewDownloadsAttemps: [String: Int] = [:]
+    private var uploadTasks: [String: Task<UploadFileResult, Error>] = [:]
     private let synchronizer = AsyncStreamSender<@MainActor () -> Void>()
     private let _updateFileFields = ObservableSender<FileUpdateProperties>()
     
@@ -197,6 +200,19 @@ final class ChatFileService: ChatFileProtocol, Sendable {
         }
         
         return decodedData
+    }
+    
+    func cancelUpload(messageId: String, fileId: String) async {
+        if let task = uploadTasks[fileId] {
+            task.cancel()
+            uploadTasks[fileId] = nil
+            uploadingFiles.removeAll { $0 == fileId }
+        } else {
+            await removeFromRichFile(
+                oldId: fileId,
+                txId: messageId
+            )
+        }
     }
     
     func isDownloadPreviewLimitReached(for fileId: String) -> Bool {
@@ -725,6 +741,7 @@ private extension ChatFileService {
             replyMessage: replyMessage,
             storageProtocol: storageProtocol
         )
+        fileMessage.adamantMessage = messageLocally
         
         cachePreviewFiles(files)
         
@@ -755,15 +772,15 @@ private extension ChatFileService {
                 messageLocally: messageLocally
             )
             
-            let message = createAdamantMessage(
-                with: richFiles,
-                text: text,
-                replyMessage: replyMessage,
-                storageProtocol: storageProtocol
-            )
+            guard let fileMessage = uploadingFilesDictionary[txId],
+                  let adamantMessage = fileMessage.adamantMessage,
+                  !fileMessage.files.isEmpty
+            else {
+                return await chatsProvider.removeMessage(with: txId)
+            }
             
             _ = try await chatsProvider.sendFileMessage(
-                message,
+                adamantMessage,
                 recipientId: partnerAddress,
                 transactionLocalyId: txId,
                 from: chatroom
@@ -886,6 +903,35 @@ private extension ChatFileService {
         )
     }
     
+    func createFileUploadTask(
+        file: FileResult,
+        chatroom: Chatroom?,
+        keyPair: Keypair,
+        storageProtocol: NetworkFileProtocolType,
+        saveEncrypted: Bool
+    ) -> Task<UploadFileResult, Error> {
+        return Task {
+            let uploadProgress: @Sendable (Int) -> Void = { [synchronizer, file] value in
+                synchronizer.send { [weak self] in
+                    self?.sendProgress(
+                        for: file.url.absoluteString,
+                        progress: value
+                    )
+                }
+            }
+            
+            let result = try await uploadFileToServer(
+                file: file,
+                recipientPublicKey: chatroom?.partner?.publicKey ?? .empty,
+                senderPrivateKey: keyPair.privateKey,
+                storageProtocol: storageProtocol,
+                progress: uploadProgress
+            )
+            
+            return result
+        }
+    }
+    
     func processFilesUpload(
         fileMessage: inout FileMessage,
         chatroom: Chatroom?,
@@ -903,47 +949,53 @@ private extension ChatFileService {
         for i in files.indices where !files[i].isUploaded {
             let file = files[i].file
             
-            let uploadProgress: @Sendable (Int) -> Void = { [synchronizer, file] value in
-                synchronizer.send { [weak self] in
-                    self?.sendProgress(
-                        for: file.url.absoluteString,
-                        progress: value
-                    )
-                }
-            }
+            // We possible already cancelled uploading this file, but effectively we didn't start uploading it
+            guard uploadingFiles.contains(file.url.absoluteString) else { continue }
             
-            let result = try await uploadFileToServer(
+            let uploadTask = createFileUploadTask(
                 file: file,
-                recipientPublicKey: chatroom?.partner?.publicKey ?? .empty,
-                senderPrivateKey: keyPair.privateKey,
-                storageProtocol: storageProtocol, 
-                progress: uploadProgress
-            )
-            
-            sendProgress(
-                for: result.file.cid,
-                progress: 100
-            )
-            
-            try cacheUploadedFile(
-                fileResult: result.file,
-                previewResult: result.preview,
-                file: file,
-                ownerId: ownerId,
-                partnerAddress: partnerAddress,
+                chatroom: chatroom,
+                keyPair: keyPair,
+                storageProtocol: storageProtocol,
                 saveEncrypted: saveEncrypted
             )
             
-            await updateRichFile(
-                oldId: file.url.absoluteString,
-                fileResult: result.file,
-                previewResult: result.preview,
-                fileMessage: &fileMessage,
-                richFiles: &richFiles,
-                file: file,
-                txId: txId,
-                messageLocally: messageLocally
-            )
+            uploadTasks[file.url.absoluteString] = uploadTask
+            
+            defer {
+                uploadTasks[file.url.absoluteString] = nil
+            }
+            
+            do {
+                let result = try await uploadTask.value
+                
+                sendProgress(
+                    for: result.file.cid,
+                    progress: 100
+                )
+                
+                try cacheUploadedFile(
+                    fileResult: result.file,
+                    previewResult: result.preview,
+                    file: file,
+                    ownerId: ownerId,
+                    partnerAddress: partnerAddress,
+                    saveEncrypted: saveEncrypted
+                )
+                
+                await updateRichFile(
+                    oldId: file.url.absoluteString,
+                    fileResult: result.file,
+                    previewResult: result.preview,
+                    file: file,
+                    txId: txId
+                )
+            } catch is CancellationError {
+                await removeFromRichFile(
+                    oldId: file.url.absoluteString,
+                    txId: txId
+                )
+            }
         }
     }
     
@@ -989,11 +1041,8 @@ private extension ChatFileService {
         oldId: String,
         fileResult: UploadResult,
         previewResult: UploadResult?,
-        fileMessage: inout FileMessage,
-        richFiles: inout [RichMessageFile.File],
         file: FileResult,
-        txId: String,
-        messageLocally: AdamantMessage
+        txId: String
     ) async {
         let cached = filesStorage.isCachedLocally(fileResult.cid)
         uploadingFiles.removeAll { $0 == oldId }
@@ -1019,6 +1068,11 @@ private extension ChatFileService {
             )
         }
         
+        guard var (fileMessage, richMessage) = uploadingFilesDictionary[richMessageId: txId]
+        else { return }
+        
+        var richFiles = richMessage.files
+        
         if let index = richFiles.firstIndex(where: { $0.id == oldId }) {
             richFiles[index].id = fileResult.cid
             richFiles[index].nonce = fileResult.nonce
@@ -1035,16 +1089,40 @@ private extension ChatFileService {
             uploadingFilesDictionary[txId] = fileMessage
         }
         
-        guard case let .richMessage(payload) = messageLocally,
-              var richMessage = payload as? RichMessageFile
-        else { return }
-        
         richMessage.files = richFiles
         
         try? await chatsProvider.updateTxMessageContent(
             txId: txId,
             richMessage: richMessage
         )
+    }
+    
+    func removeFromRichFile(
+        oldId: String,
+        txId: String
+    ) async {
+        uploadingFiles.removeAll { $0 == oldId }
+        
+        guard var (fileMessage, richMessage) = uploadingFilesDictionary[richMessageId: txId]
+        else { return }
+                
+        richMessage.files = richMessage.files.filter { $0.id != oldId }
+        fileMessage.adamantMessage = .richMessage(payload: richMessage)
+        
+        let updatedFiles = fileMessage.files.filter { $0.file.url.absoluteString != oldId }
+        
+        fileMessage.files = updatedFiles
+        uploadingFilesDictionary[txId] = fileMessage
+        
+        if !updatedFiles.isEmpty {
+            // skip double update which causes bugs
+            // first update: here
+            // second update: if fileMessages is empty in sendFile method
+            try? await chatsProvider.updateTxMessageContent(
+                txId: txId,
+                richMessage: richMessage
+            )
+        }
     }
     
     func handleUploadError(
@@ -1136,12 +1214,35 @@ private extension ChatFileService {
             throw FileManagerError.cantEncryptFile
         }
         
-        let cid = try await filesNetworkManager.uploadFiles(
+        try Task.checkCancellation()
+        
+        let result = await filesNetworkManager.uploadFiles(
             encodedData,
             type: storageProtocol,
             uploadProgress: uploadProgress
-        ).get()
+        )
         
-        return (data, encodedData, nonce, cid)
+        switch result {
+        case let .success(cid):
+            return (data, encodedData, nonce, cid)
+        case let .failure(error):
+            if case .apiError(let apiError) = error,
+               apiError == .requestCancelled {
+                try Task.checkCancellation()
+            }
+            
+            throw error
+        }
+    }
+}
+
+private extension Dictionary where Key == String, Value == FileMessage {
+    subscript(richMessageId txId: String) -> (FileMessage, RichMessageFile)? {
+        guard let fileMessage = self[txId],
+              case let .richMessage(payload) = fileMessage.adamantMessage,
+              let richMessage = payload as? RichMessageFile
+        else { return nil }
+        
+        return (fileMessage, richMessage)
     }
 }

--- a/Adamant/Modules/Chat/ViewModel/ChatFileService.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatFileService.swift
@@ -760,16 +760,14 @@ private extension ChatFileService {
 
         do {
             try await processFilesUpload(
-                fileMessage: &fileMessage,
+                fileMessage: fileMessage,
                 chatroom: chatroom,
                 keyPair: keyPair,
                 storageProtocol: storageProtocol,
                 ownerId: ownerId,
                 partnerAddress: partnerAddress,
                 saveEncrypted: saveEncrypted, 
-                txId: txId,
-                richFiles: &richFiles,
-                messageLocally: messageLocally
+                txId: txId
             )
             
             guard let fileMessage = uploadingFilesDictionary[txId],
@@ -933,16 +931,14 @@ private extension ChatFileService {
     }
     
     func processFilesUpload(
-        fileMessage: inout FileMessage,
+        fileMessage: FileMessage,
         chatroom: Chatroom?,
         keyPair: Keypair,
         storageProtocol: NetworkFileProtocolType,
         ownerId: String,
         partnerAddress: String,
         saveEncrypted: Bool,
-        txId: String,
-        richFiles: inout [RichMessageFile.File],
-        messageLocally: AdamantMessage
+        txId: String
     ) async throws {
         let files = fileMessage.files
         

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -419,14 +419,7 @@ final class ChatViewModel: NSObject {
     
     func hideMessage(id: String) {
         Task {
-            guard let transaction = chatTransactions.first(where: { $0.chatMessageId == id })
-            else { return }
-            
-            transaction.isHidden = true
-            try? transaction.managedObjectContext?.save()
-            
-            chatroom?.updateLastTransaction()
-            await chatsProvider.removeMessage(with: transaction.transactionId)
+            await chatsProvider.removeMessage(with: id)
         }
     }
     
@@ -723,6 +716,12 @@ final class ChatViewModel: NSObject {
         
         lastDateHeaderUpdate = Date()
         updateMessages(resetLoadingProperty: false)
+    }
+    
+    func cancelFileUploading(messageId: String, file: ChatFile) {
+        Task {
+            await chatFileService.cancelUpload(messageId: messageId, fileId: file.file.id)
+        }
     }
 
     func openFile(messageId: String, file: ChatFile) {

--- a/Adamant/ServiceProtocols/ChatFileProtocol.swift
+++ b/Adamant/ServiceProtocols/ChatFileProtocol.swift
@@ -71,6 +71,8 @@ protocol ChatFileProtocol: Sendable {
     
     func isDownloadPreviewLimitReached(for fileId: String) -> Bool
     
+    func cancelUpload(messageId: String, fileId: String) async
+    
     func isPreviewAutoDownloadAllowedByPolicy(
         hasPartnerName: Bool,
         isFromCurrentSender: Bool,

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -1942,6 +1942,7 @@ extension AdamantChatsProvider {
     func removeMessage(with id: String) {
         if !self.removedMessages.contains(id) {
             self.removedMessages.append(id)
+            markTransactionAsHidden(id: id)
             
             if self.accountService.hasStayInAccount {
                 self.securedStore.set(removedMessages, for: StoreKey.accountService.removedMessages)
@@ -1953,6 +1954,23 @@ extension AdamantChatsProvider {
         chatroom.managedObjectContext?.perform {
             chatroom.markAsReaded()
             try? chatroom.managedObjectContext?.save()
+        }
+    }
+    
+    private func markTransactionAsHidden(id: String) {
+        let request = NSFetchRequest<ChatTransaction>(entityName: "ChatTransaction")
+        request.predicate = NSPredicate(format: "transactionId == %@", String(id))
+        request.fetchLimit = 1
+        
+        let privateContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        privateContext.parent = stack.container.viewContext
+        
+        privateContext.performAndWait {
+            if let transaction = (try? privateContext.fetch(request))?.first {
+                transaction.isHidden = true
+                try? transaction.managedObjectContext?.save()
+                transaction.chatroom?.updateLastTransaction()
+            }
         }
     }
     

--- a/CommonKit/Sources/CommonKit/Models/ApiServiceError.swift
+++ b/CommonKit/Sources/CommonKit/Models/ApiServiceError.swift
@@ -75,6 +75,9 @@ extension ApiServiceError: Equatable {
             
         case (.networkError, .networkError):
             return true
+        
+        case (.requestCancelled, .requestCancelled):
+            return true
             
         default:
             return false


### PR DESCRIPTION
Cancelling file upload.

I've introduced new `ChatAction` - `cancelUploading(messageId: String, file: ChatFile)`.

For handling - `ChatFileService.cancelUpload`. To handle it in `ChatFileService` I've introduced  `var uploadTasks: [String: Task<UploadFileResult, Error>]`.

For removing single file from message - `removeFromRichFile` function was introduced.

Moved DB-operations for hiding message from `func hideMessage(id: String)` in `ChatViewModel` to `func removeMessage(with id: String)` in `AdamantChatProvider`.

For now there is no specific UI. Just tapping on uploading file - cancels uploading and removes file.