### PR TITLE
[trello.com/c/G77vaoVI]: login right after pasting using paste button

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -467,8 +467,9 @@
 		AA33BEB62D303E240083E59C /* APICoreProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB52D303DB60083E59C /* APICoreProtocolMock.swift */; };
 		AA33BEB72D3041A30083E59C /* AddressConverterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB42D303CBD0083E59C /* AddressConverterMock.swift */; };
 		AA33BEB92D3044760083E59C /* BtcApiServiceProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */; };
-		AA8FFFCA2D4E6435001D8576 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AA8FFFC92D4E6435001D8576 /* CryptoSwift */; };
-		AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */; };
+		AA7202E32D6B4A5100CCAC20 /* PasteInterceptingPasswordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7202E22D6B4A4B00CCAC20 /* PasteInterceptingPasswordCell.swift */; };
+		AA7202E52D6B4ABB00CCAC20 /* PasteInterceptingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7202E42D6B4AAF00CCAC20 /* PasteInterceptingTextField.swift */; };
+		AA7202E72D6B4B3500CCAC20 /* PasteInterceptingPasswordRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7202E62D6B4B2E00CCAC20 /* PasteInterceptingPasswordRow.swift */; };
 		AA8FFFB02D497175001D8576 /* AdmWalletServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFAF2D49716D001D8576 /* AdmWalletServiceTests.swift */; };
 		AA8FFFB22D49726F001D8576 /* SecuredStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFB12D49726B001D8576 /* SecuredStoreMock.swift */; };
 		AA8FFFB42D497510001D8576 /* AccountServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFB32D497509001D8576 /* AccountServiceMock.swift */; };
@@ -478,6 +479,8 @@
 		AA8FFFBC2D49796A001D8576 /* ChatsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */; };
 		AA8FFFC02D4AC011001D8576 /* AdamantCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */; };
 		AA8FFFC42D4C1174001D8576 /* NativeAdamantCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFC32D4C1168001D8576 /* NativeAdamantCoreTests.swift */; };
+		AA8FFFCA2D4E6435001D8576 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AA8FFFC92D4E6435001D8576 /* CryptoSwift */; };
+		AA8FFFCC2D50D503001D8576 /* NodeOrigin+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */; };
 		AA8FFFE32D513681001D8576 /* CustomFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */; };
 		AA8FFFE52D513787001D8576 /* EdgeInsetTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */; };
 		AAB01CAD2D3AE44B007D6BF4 /* BitcoinKitTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */; };
@@ -1146,7 +1149,9 @@
 		AA33BEB42D303CBD0083E59C /* AddressConverterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressConverterMock.swift; sourceTree = "<group>"; };
 		AA33BEB52D303DB60083E59C /* APICoreProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICoreProtocolMock.swift; sourceTree = "<group>"; };
 		AA33BEB82D30446F0083E59C /* BtcApiServiceProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BtcApiServiceProtocolMock.swift; sourceTree = "<group>"; };
-		AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
+		AA7202E22D6B4A4B00CCAC20 /* PasteInterceptingPasswordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteInterceptingPasswordCell.swift; sourceTree = "<group>"; };
+		AA7202E42D6B4AAF00CCAC20 /* PasteInterceptingTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteInterceptingTextField.swift; sourceTree = "<group>"; };
+		AA7202E62D6B4B2E00CCAC20 /* PasteInterceptingPasswordRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteInterceptingPasswordRow.swift; sourceTree = "<group>"; };
 		AA8FFFAF2D49716D001D8576 /* AdmWalletServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdmWalletServiceTests.swift; sourceTree = "<group>"; };
 		AA8FFFB12D49726B001D8576 /* SecuredStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuredStoreMock.swift; sourceTree = "<group>"; };
 		AA8FFFB32D497509001D8576 /* AccountServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountServiceMock.swift; sourceTree = "<group>"; };
@@ -1156,6 +1161,7 @@
 		AA8FFFBB2D497966001D8576 /* ChatsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsProviderMock.swift; sourceTree = "<group>"; };
 		AA8FFFBF2D4AC00B001D8576 /* AdamantCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdamantCoreMock.swift; sourceTree = "<group>"; };
 		AA8FFFC32D4C1168001D8576 /* NativeAdamantCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAdamantCoreTests.swift; sourceTree = "<group>"; };
+		AA8FFFCB2D50D4F8001D8576 /* NodeOrigin+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NodeOrigin+Extensions.swift"; sourceTree = "<group>"; };
 		AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldRow.swift; sourceTree = "<group>"; };
 		AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsetTextField.swift; sourceTree = "<group>"; };
 		AAB01CAC2D3AE449007D6BF4 /* BitcoinKitTransactionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinKitTransactionFactory.swift; sourceTree = "<group>"; };
@@ -2601,6 +2607,9 @@
 		E913C9101FFFAA4B001A83F7 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				AA7202E62D6B4B2E00CCAC20 /* PasteInterceptingPasswordRow.swift */,
+				AA7202E42D6B4AAF00CCAC20 /* PasteInterceptingTextField.swift */,
+				AA7202E22D6B4A4B00CCAC20 /* PasteInterceptingPasswordCell.swift */,
 				AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */,
 				AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */,
 				93775E452A674FA9009061AC /* Markdown+Adamant.swift */,
@@ -3573,6 +3582,7 @@
 				3A4068342ACD7C18007E87BD /* CoinTransaction+TransactionDetails.swift in Sources */,
 				E921597B206503000000CA5C /* ButtonsStripeView.swift in Sources */,
 				93FC16A12B01DE120062B507 /* ERC20ApiService.swift in Sources */,
+				AA7202E72D6B4B3500CCAC20 /* PasteInterceptingPasswordRow.swift in Sources */,
 				3A299C692B838AA600B54C61 /* ChatMediaCell.swift in Sources */,
 				93294B9A2AAD624100911109 /* WalletFactoryCompose.swift in Sources */,
 				41C1698E29E7F36900FEB3CB /* AdamantRichTransactionReplyService.swift in Sources */,
@@ -3764,6 +3774,7 @@
 				E9942B87203D9E5100C163AF /* EurekaQRRow.swift in Sources */,
 				3ACD307E2BBD86B700ABF671 /* FilesStorageProprietiesService.swift in Sources */,
 				3AA50DF32AEBE67C00C58FC8 /* PartnerQRFactory.swift in Sources */,
+				AA7202E32D6B4A5100CCAC20 /* PasteInterceptingPasswordCell.swift in Sources */,
 				E9AA8C02212C5BF500F9249F /* AdmWalletService+Send.swift in Sources */,
 				E90847332196FEA80095825D /* TransferTransaction+CoreDataProperties.swift in Sources */,
 				9366588D2B0AB6BD00BDB2D3 /* CoinsNodesListState.swift in Sources */,
@@ -3886,6 +3897,7 @@
 				A5E0422B282AB18B0076CD13 /* BtcUnspentTransactionResponse.swift in Sources */,
 				E972206B201F44CA004F2AAD /* TransfersProvider.swift in Sources */,
 				3A20D93B2AE7F316005475A6 /* AdamantTransactionDetails.swift in Sources */,
+				AA7202E52D6B4ABB00CCAC20 /* PasteInterceptingTextField.swift in Sources */,
 				93294B962AAD320B00911109 /* ScreensFactory.swift in Sources */,
 				3A9015A72A614A62002A2464 /* AdamantEmojiService.swift in Sources */,
 				93ADE0722ACA66AF008ED641 /* VibrationSelectionView.swift in Sources */,

--- a/Adamant/Helpers/PasteInterceptingPasswordCell.swift
+++ b/Adamant/Helpers/PasteInterceptingPasswordCell.swift
@@ -1,0 +1,33 @@
+//
+//  PasteInterceptingPasswordCell.swift
+//  Adamant
+//
+//  Created by Christian Benua on 23.02.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import UIKit
+import Eureka
+
+final class PasteInterceptingPasswordCell: CustomFieldCell<String, PasteInterceptingTextField>, CellType {
+    
+    required init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override func setup() {
+        super.setup()
+        textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
+        textField.keyboardType = .asciiCapable
+        textField.isSecureTextEntry = true
+        textField.textContentType = .password
+        if let textLabel = textLabel {
+            textField.setContentHuggingPriority(textLabel.contentHuggingPriority(for: .horizontal) - 1, for: .horizontal)
+        }
+    }
+}

--- a/Adamant/Helpers/PasteInterceptingPasswordRow.swift
+++ b/Adamant/Helpers/PasteInterceptingPasswordRow.swift
@@ -1,0 +1,15 @@
+//
+//  PasteInterceptingPasswordRow.swift
+//  Adamant
+//
+//  Created by Christian Benua on 23.02.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Eureka
+
+final class PasteInterceptingPasswordRow: FieldRow<PasteInterceptingPasswordCell>, RowType {
+    required init(tag: String?) {
+        super.init(tag: tag)
+    }
+}

--- a/Adamant/Helpers/PasteInterceptingTextField.swift
+++ b/Adamant/Helpers/PasteInterceptingTextField.swift
@@ -1,0 +1,62 @@
+//
+//  PasteInterceptingTextField.swift
+//  Adamant
+//
+//  Created by Christian Benua on 23.02.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import UIKit
+
+final class PasteInterceptingTextField: UITextField, UITextFieldDelegate {
+    
+    private var isAfterPaste: Bool = false
+    var pasteInterceptor: ((String?) -> Void)?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    private func setup() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handlePasteNotification),
+            name: UITextField.textDidChangeNotification,
+            object: self
+        )
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func paste(_ sender: Any?) {
+        isAfterPaste = true
+        super.paste(sender)
+    }
+    
+    @objc func handlePasteNotification() {
+        if isAfterPaste {
+            pasteInterceptor?(text)
+        }
+        isAfterPaste = false
+    }
+    
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if isAfterPaste {
+            pasteInterceptor?(textField.text)
+        }
+        
+        isAfterPaste = false
+        return true
+    }
+}

--- a/Adamant/Modules/Login/LoginViewController.swift
+++ b/Adamant/Modules/Login/LoginViewController.swift
@@ -232,7 +232,9 @@ final class LoginViewController: FormViewController {
             $0.placeholderColor = UIColor.adamant.secondary
             $0.cell.textField.enablePasteButtonAndPasswordToggle {
                 // assing text to textfield like this to make loginButton update its enabled/disabled state
-                self.form.rowBy(tag: Rows.passphrase.tag)?.value = $0
+                let row = self.form.rowBy(tag: Rows.passphrase.tag) as? PasswordRow
+                row?.value = $0
+                row?.cell.textField.text = $0
                 self.loginWith(passphrase: $0)
             }
             $0.keyboardReturnType = KeyboardReturnTypeConfiguration(nextKeyboardType: .go, defaultKeyboardType: .go)

--- a/Adamant/Modules/Login/LoginViewController.swift
+++ b/Adamant/Modules/Login/LoginViewController.swift
@@ -226,16 +226,21 @@ final class LoginViewController: FormViewController {
         }
         
         // Passphrase row
-        <<< PasswordRow {
+        <<< PasteInterceptingPasswordRow {
             $0.tag = Rows.passphrase.tag
             $0.placeholder = Rows.passphrase.localized
             $0.placeholderColor = UIColor.adamant.secondary
-            $0.cell.textField.enablePasteButtonAndPasswordToggle {
+            $0.cell._textField.pasteInterceptor = { [weak self] text in
+                if let text {
+                    self?.loginWith(passphrase: text)
+                }
+            }
+            $0.cell.textField.enablePasteButtonAndPasswordToggle { [weak self] in
                 // assing text to textfield like this to make loginButton update its enabled/disabled state
-                let row = self.form.rowBy(tag: Rows.passphrase.tag) as? PasswordRow
+                let row = self?.form.rowBy(tag: Rows.passphrase.tag) as? PasteInterceptingPasswordRow
                 row?.value = $0
                 row?.cell.textField.text = $0
-                self.loginWith(passphrase: $0)
+                self?.loginWith(passphrase: $0)
             }
             $0.keyboardReturnType = KeyboardReturnTypeConfiguration(nextKeyboardType: .go, defaultKeyboardType: .go)
             }

--- a/Adamant/Modules/Login/LoginViewController.swift
+++ b/Adamant/Modules/Login/LoginViewController.swift
@@ -230,7 +230,11 @@ final class LoginViewController: FormViewController {
             $0.tag = Rows.passphrase.tag
             $0.placeholder = Rows.passphrase.localized
             $0.placeholderColor = UIColor.adamant.secondary
-            $0.cell.textField.enablePasteButtonAndPasswordToggle()
+            $0.cell.textField.enablePasteButtonAndPasswordToggle {
+                // assing text to textfield like this to make loginButton update its enabled/disabled state
+                self.form.rowBy(tag: Rows.passphrase.tag)?.value = $0
+                self.loginWith(passphrase: $0)
+            }
             $0.keyboardReturnType = KeyboardReturnTypeConfiguration(nextKeyboardType: .go, defaultKeyboardType: .go)
             }
             
@@ -550,9 +554,9 @@ extension LoginViewController {
 // MARK: UITextField + extensions
 
 private extension UITextField {
-    func enablePasteButtonAndPasswordToggle() {
+    func enablePasteButtonAndPasswordToggle(_ pasteButtonHandler: @escaping (String) -> Void) {
         let passwordToggleButton = makePasswordButton()
-        let pasteButton = makePasteButton()
+        let pasteButton = makePasteButton(pasteButtonHandler)
         
         let containerView = UIView()
         let buttonStack = UIStackView(arrangedSubviews: [pasteButton, passwordToggleButton])
@@ -579,17 +583,23 @@ private extension UITextField {
         rightViewMode = .always
     }
     
-    func makePasteButton() -> UIButton {
+    func makePasteButton(_ handler: @escaping (String) -> Void) -> UIButton {
         let button = UIButton(type: .custom)
         button.imageEdgeInsets = UITextField.buttonImageEdgeInsets
         button.setImage(.asset(named: "clipboard"), for: .normal)
-        button.addTarget(self, action: #selector(pasteFromPasteboard(_:)), for: .touchUpInside)
+        button.addAction(
+            UIAction { [weak self] _ in
+                self?.pasteFromPasteboard(handler)
+            },
+            for: .touchUpInside
+        )
         return button
     }
     
-    @objc func pasteFromPasteboard(_ sender: UIButton) {
+    @objc func pasteFromPasteboard(_ handler: @escaping (String) -> Void) {
         if let pasteboardText = UIPasteboard.general.string {
-            self.text = pasteboardText
+            let newText = String(pasteboardText.prefix(150))
+            handler(newText)
         }
     }
 }


### PR DESCRIPTION
Starting login flow right after tapping on paste button and trim too big passphrase

To handle `cmd+v` or `native iOS textfield paste button` - bunch of classes were introduced:

- `PasteInterceptingTextField` to override `paste(_ sender: Any?)`
- `PasteInterceptingPasswordCell` - like `PasswordCell` but with `PasteInterceptingTextField `
- `PasteInterceptingPasswordRow` - like `PasswordRow` but with `PasteInterceptingPasswordCell `