### PR TITLE
[trello.com/c/QCnKo03A] Adding the logic of timestampMs

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		6FCF2D522D54F2B600F64D20 /* AdmDialogService+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCF2D502D54F2B600F64D20 /* AdmDialogService+Extension.swift */; };
 		6FCF2D532D54F2B600F64D20 /* AdamantDialogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCF2D4F2D54F2B600F64D20 /* AdamantDialogService.swift */; };
 		6FF9F08C2D6CEB340013A3B1 /* CoreDataRealationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9F08B2D6CEB150013A3B1 /* CoreDataRealationMapper.swift */; };
+		85ACCA662D68DC57005658CE /* ChatMessagesSortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85ACCA652D68DC52005658CE /* ChatMessagesSortDescriptor.swift */; };
 		85B405022D3012D5000AB744 /* AccountViewController+Form.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B405012D3012C7000AB744 /* AccountViewController+Form.swift */; };
 		9300F94629D0149100FEDDB8 /* RichMessageProviderWithStatusCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9300F94529D0149100FEDDB8 /* RichMessageProviderWithStatusCheck.swift */; };
 		9304F8BE292F88F900173F18 /* ANSPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9304F8BD292F88F900173F18 /* ANSPayload.swift */; };
@@ -1002,6 +1003,7 @@
 		6FCF2D502D54F2B600F64D20 /* AdmDialogService+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdmDialogService+Extension.swift"; sourceTree = "<group>"; };
 		6FF9F08B2D6CEB150013A3B1 /* CoreDataRealationMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataRealationMapper.swift; sourceTree = "<group>"; };
 		74D5744703A7ECC98E244B14 /* Pods-AdmCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdmCore.debug.xcconfig"; path = "Target Support Files/Pods-AdmCore/Pods-AdmCore.debug.xcconfig"; sourceTree = "<group>"; };
+		85ACCA652D68DC52005658CE /* ChatMessagesSortDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagesSortDescriptor.swift; sourceTree = "<group>"; };
 		85B405012D3012C7000AB744 /* AccountViewController+Form.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountViewController+Form.swift"; sourceTree = "<group>"; };
 		9300F94529D0149100FEDDB8 /* RichMessageProviderWithStatusCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichMessageProviderWithStatusCheck.swift; sourceTree = "<group>"; };
 		9304F8BD292F88F900173F18 /* ANSPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSPayload.swift; sourceTree = "<group>"; };
@@ -1903,6 +1905,14 @@
 				6FCF2D502D54F2B600F64D20 /* AdmDialogService+Extension.swift */,
 			);
 			path = AdmDialogService;
+            sourceTree = "<group>";
+        };
+		85ACCA672D68DC60005658CE /* CoreDataHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				85ACCA652D68DC52005658CE /* ChatMessagesSortDescriptor.swift */,
+			);
+			path = CoreDataHelpers;
 			sourceTree = "<group>";
 		};
 		85B405002D3012BD000AB744 /* AccountViewController */ = {
@@ -2670,6 +2680,7 @@
 				AA7202E22D6B4A4B00CCAC20 /* PasteInterceptingPasswordCell.swift */,
 				AA8FFFE42D513780001D8576 /* EdgeInsetTextField.swift */,
 				AA8FFFE22D513670001D8576 /* CustomFieldRow.swift */,
+				85ACCA672D68DC60005658CE /* CoreDataHelpers */,
 				93775E452A674FA9009061AC /* Markdown+Adamant.swift */,
 				E9061B96207501E40011F104 /* AdamantUserInfoKey.swift */,
 				E94008862114F05B00CD2D67 /* AddressValidationResult.swift */,
@@ -3623,6 +3634,7 @@
 				26A975FF2B7E843E0095C367 /* SelectTextView.swift in Sources */,
 				93294B822AAD0BB400911109 /* BtcWalletFactory.swift in Sources */,
 				AAB01CB12D3AF01B007D6BF4 /* DogeApiServiceProtocol.swift in Sources */,
+				85ACCA662D68DC57005658CE /* ChatMessagesSortDescriptor.swift in Sources */,
 				648DD7A42237DB9E00B811FD /* DogeWalletService+Send.swift in Sources */,
 				93294B7D2AAD067000911109 /* AppContainer.swift in Sources */,
 				93ED214C2CC3561800AA1FC8 /* TransactionsStatusServiceComposeProtocol.swift in Sources */,

--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -1905,8 +1905,8 @@
 				6FCF2D502D54F2B600F64D20 /* AdmDialogService+Extension.swift */,
 			);
 			path = AdmDialogService;
-            sourceTree = "<group>";
-        };
+			sourceTree = "<group>";
+		};
 		85ACCA672D68DC60005658CE /* CoreDataHelpers */ = {
 			isa = PBXGroup;
 			children = (

--- a/Adamant/Adamant.xcdatamodeld/Adamant.xcdatamodel/contents
+++ b/Adamant/Adamant.xcdatamodeld/Adamant.xcdatamodel/contents
@@ -49,6 +49,7 @@
         <attribute name="nonceRaw" optional="YES" attributeType="String"/>
         <attribute name="recipientId" attributeType="String" defaultValueString=""/>
         <attribute name="senderId" attributeType="String" defaultValueString=""/>
+        <attribute name="timestampMs" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="transactionId" attributeType="String" defaultValueString=""/>
         <attribute name="transactionStatusRaw" attributeType="String" defaultValueString=""/>
         <uniquenessConstraints>

--- a/Adamant/Helpers/CoreDataHelpers/ChatMessagesSortDescriptor.swift
+++ b/Adamant/Helpers/CoreDataHelpers/ChatMessagesSortDescriptor.swift
@@ -1,0 +1,18 @@
+//
+//  CoreData+Helpers.swift
+//  Adamant
+//
+//  Created by Sergei Veretennikov on 21.02.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import CoreData
+
+extension Array where Element == NSSortDescriptor {
+    static func sortChatTransactions(ascending: Bool) -> [NSSortDescriptor] {
+        [
+            NSSortDescriptor(key: "timestampMs", ascending: ascending),
+            NSSortDescriptor(key: "transactionId", ascending: ascending)
+        ]
+    }
+}

--- a/Adamant/Models/CoreData/CoinTransaction+CoreDataProperties.swift
+++ b/Adamant/Models/CoreData/CoinTransaction+CoreDataProperties.swift
@@ -31,6 +31,7 @@ extension CoinTransaction {
     @NSManaged public var blockchainType: String
     @NSManaged public var transactionStatusRaw: String
     @NSManaged public var nonceRaw: String?
+    @NSManaged public var timestampMs: Int64
 }
 
 extension CoinTransaction : Identifiable {

--- a/Adamant/Models/CoreData/CoinTransaction+TransactionDetails.swift
+++ b/Adamant/Models/CoreData/CoinTransaction+TransactionDetails.swift
@@ -38,4 +38,8 @@ extension CoinTransaction: TransactionDetails {
     var blockHeight: UInt64? {
         return nil
     }
+    
+    var timeIntervalMillisecondsSince1970: Int64 {
+        date?.timeIntervalMillisecondsSince1970 ?? .zero
+    }
 }

--- a/Adamant/Services/DataProviders/AdamantChatTransactionService.swift
+++ b/Adamant/Services/DataProviders/AdamantChatTransactionService.swift
@@ -207,9 +207,9 @@ actor AdamantChatTransactionService: ChatTransactionService {
             chatTransaction = trs
         }
         
-        chatTransaction.timestampMs = Int64(transaction.timestampMs ?? (transaction.timestamp * 1000))
-        chatTransaction.amount = transaction.amount as NSDecimalNumber
         chatTransaction.date = transaction.date as NSDate
+        chatTransaction.timestampMs = transaction.timestampMillisecondsFromDate
+        chatTransaction.amount = transaction.amount as NSDecimalNumber
         chatTransaction.recipientId = transaction.recipientId
         chatTransaction.senderId = transaction.senderId
         chatTransaction.transactionId = String(transaction.id)
@@ -248,9 +248,9 @@ actor AdamantChatTransactionService: ChatTransactionService {
             transfer.blockId = transaction.blockId
         } else {
             transfer = TransferTransaction(context: context)
-            transfer.timestampMs = Int64(transaction.timestampMs ?? transaction.timestamp * 1000)
-            transfer.amount = transaction.amount as NSDecimalNumber
             transfer.date = transaction.date as NSDate
+            transfer.timestampMs = transaction.timestampMillisecondsFromDate
+            transfer.amount = transaction.amount as NSDecimalNumber
             transfer.recipientId = transaction.recipientId
             transfer.senderId = transaction.senderId
             transfer.transactionId = String(transaction.id)

--- a/Adamant/Services/DataProviders/AdamantChatTransactionService.swift
+++ b/Adamant/Services/DataProviders/AdamantChatTransactionService.swift
@@ -93,14 +93,15 @@ actor AdamantChatTransactionService: ChatTransactionService {
         removedMessages: [String],
         context: NSManagedObjectContext
     ) -> ChatTransaction? {
-        let messageTransaction: ChatTransaction
+        let chatTransaction: ChatTransaction
         guard let chat = transaction.asset.chat else {
             if transaction.type == .send {
-                messageTransaction = transferTransaction(from: transaction, isOut: isOutgoing, partner: partner, context: context)
-                return messageTransaction
+                chatTransaction = transferTransaction(from: transaction, isOut: isOutgoing, partner: partner, context: context)
+                return chatTransaction
             }
             return nil
         }
+        
         
         // MARK: Decode message, message must contain data
         if let decodedMessage = adamantCore.decodeMessage(
@@ -129,11 +130,11 @@ actor AdamantChatTransactionService: ChatTransactionService {
                         }
                         
                         trs.comment = decodedMessage
-                        messageTransaction = trs
+                        chatTransaction = trs
                     } else {
                         let trs = MessageTransaction(entity: MessageTransaction.entity(), insertInto: context)
                         trs.message = decodedMessage
-                        messageTransaction = trs
+                        chatTransaction = trs
                         
                         let markdown = markdownParser.parse(decodedMessage)
                         
@@ -147,7 +148,7 @@ actor AdamantChatTransactionService: ChatTransactionService {
                         transaction: transaction,
                         context: context
                     ) {
-                        messageTransaction = trs
+                        chatTransaction = trs
                         break
                     }
                     
@@ -156,7 +157,7 @@ actor AdamantChatTransactionService: ChatTransactionService {
                         transaction: transaction,
                         context: context
                     ) {
-                        messageTransaction = trs
+                        chatTransaction = trs
                         break
                     }
                     
@@ -165,7 +166,7 @@ actor AdamantChatTransactionService: ChatTransactionService {
                         transaction: transaction,
                         context: context
                     ) {
-                        messageTransaction = trs
+                        chatTransaction = trs
                         break
                     }
                     
@@ -174,7 +175,7 @@ actor AdamantChatTransactionService: ChatTransactionService {
                         transaction: transaction,
                         context: context
                     ) {
-                        messageTransaction = trs
+                        chatTransaction = trs
                         break
                     }
                     
@@ -183,19 +184,19 @@ actor AdamantChatTransactionService: ChatTransactionService {
                         transaction: transaction,
                         context: context
                     ) {
-                        messageTransaction = trs
+                        chatTransaction = trs
                         break
                     }
                     
                     let trs = MessageTransaction(entity: MessageTransaction.entity(), insertInto: context)
                     trs.message = decodedMessage
-                    messageTransaction = trs
+                    chatTransaction = trs
                 }
             } else {
                 let trs = MessageTransaction(entity: MessageTransaction.entity(), insertInto: context)
                 trs.message = ""
                 trs.isHidden = true
-                messageTransaction = trs
+                chatTransaction = trs
             }
         }
         // MARK: Failed to decode, or message was empty
@@ -203,30 +204,31 @@ actor AdamantChatTransactionService: ChatTransactionService {
             let trs = MessageTransaction(entity: MessageTransaction.entity(), insertInto: context)
             trs.message = ""
             trs.isHidden = true
-            messageTransaction = trs
+            chatTransaction = trs
         }
         
-        messageTransaction.amount = transaction.amount as NSDecimalNumber
-        messageTransaction.date = transaction.date as NSDate
-        messageTransaction.recipientId = transaction.recipientId
-        messageTransaction.senderId = transaction.senderId
-        messageTransaction.transactionId = String(transaction.id)
-        messageTransaction.type = Int16(chat.type.rawValue)
-        messageTransaction.height = Int64(transaction.height)
-        messageTransaction.isConfirmed = true
-        messageTransaction.isOutgoing = isOutgoing
-        messageTransaction.blockId = transaction.blockId
-        messageTransaction.confirmations = transaction.confirmations
-        messageTransaction.chatMessageId = String(transaction.id)
-        messageTransaction.fee = transaction.fee as NSDecimalNumber
-        messageTransaction.statusEnum = MessageStatus.delivered
-        messageTransaction.partner = partner
-        messageTransaction.senderPublicKey = transaction.senderPublicKey
+        chatTransaction.timestampMs = Int64(transaction.timestampMs ?? (transaction.timestamp * 1000))
+        chatTransaction.amount = transaction.amount as NSDecimalNumber
+        chatTransaction.date = transaction.date as NSDate
+        chatTransaction.recipientId = transaction.recipientId
+        chatTransaction.senderId = transaction.senderId
+        chatTransaction.transactionId = String(transaction.id)
+        chatTransaction.type = Int16(chat.type.rawValue)
+        chatTransaction.height = Int64(transaction.height)
+        chatTransaction.isConfirmed = true
+        chatTransaction.isOutgoing = isOutgoing
+        chatTransaction.blockId = transaction.blockId
+        chatTransaction.confirmations = transaction.confirmations
+        chatTransaction.chatMessageId = String(transaction.id)
+        chatTransaction.fee = transaction.fee as NSDecimalNumber
+        chatTransaction.statusEnum = MessageStatus.delivered
+        chatTransaction.partner = partner
+        chatTransaction.senderPublicKey = transaction.senderPublicKey
         
-        let transactionId = messageTransaction.transactionId
-        messageTransaction.isHidden = removedMessages.contains(transactionId)
+        let transactionId = chatTransaction.transactionId
+        chatTransaction.isHidden = removedMessages.contains(transactionId)
         
-        return messageTransaction
+        return chatTransaction
     }
     
     func transferTransaction(
@@ -246,6 +248,7 @@ actor AdamantChatTransactionService: ChatTransactionService {
             transfer.blockId = transaction.blockId
         } else {
             transfer = TransferTransaction(context: context)
+            transfer.timestampMs = Int64(transaction.timestampMs ?? transaction.timestamp * 1000)
             transfer.amount = transaction.amount as NSDecimalNumber
             transfer.date = transaction.date as NSDate
             transfer.recipientId = transaction.recipientId

--- a/Adamant/Services/DataProviders/AdamantChatTransactionService.swift
+++ b/Adamant/Services/DataProviders/AdamantChatTransactionService.swift
@@ -208,7 +208,7 @@ actor AdamantChatTransactionService: ChatTransactionService {
         }
         
         chatTransaction.date = transaction.date as NSDate
-        chatTransaction.timestampMs = transaction.timestampMillisecondsFromDate
+        chatTransaction.timestampMs = Int64(transaction.timestampMs)
         chatTransaction.amount = transaction.amount as NSDecimalNumber
         chatTransaction.recipientId = transaction.recipientId
         chatTransaction.senderId = transaction.senderId
@@ -249,7 +249,7 @@ actor AdamantChatTransactionService: ChatTransactionService {
         } else {
             transfer = TransferTransaction(context: context)
             transfer.date = transaction.date as NSDate
-            transfer.timestampMs = transaction.timestampMillisecondsFromDate
+            transfer.timestampMs = Int64(transaction.timestampMs)
             transfer.amount = transaction.amount as NSDecimalNumber
             transfer.recipientId = transaction.recipientId
             transfer.senderId = transaction.senderId

--- a/Adamant/Services/DataProviders/AdamantChatsProvider+search.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider+search.swift
@@ -27,8 +27,7 @@ extension AdamantChatsProvider {
                 NSPredicate(format: "isHidden == false")])
         }
         
-        request.sortDescriptors = [NSSortDescriptor.init(key: "date", ascending: false),
-                                   NSSortDescriptor(key: "transactionId", ascending: false)]
+        request.sortDescriptors = .sortChatTransactions(ascending: false)
         
         do {
             let results = try stack.container.viewContext.fetch(request)
@@ -55,8 +54,7 @@ extension AdamantChatsProvider {
             NSPredicate(format: "richContent.hash CONTAINS[cd] %@", hash)
         ])
         
-        request.sortDescriptors = [NSSortDescriptor.init(key: "date", ascending: false),
-                                   NSSortDescriptor(key: "transactionId", ascending: false)]
+        request.sortDescriptors = .sortChatTransactions(ascending: false)
         
         do {
             let results = try stack.container.viewContext.fetch(request)

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -973,6 +973,7 @@ extension AdamantChatsProvider {
         let transaction = MessageTransaction(context: context)
         let id = UUID().uuidString
         transaction.date = Date() as NSDate
+        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
         transaction.recipientId = recipientId
         transaction.senderId = senderId
         transaction.type = Int16(type.rawValue)
@@ -1019,6 +1020,7 @@ extension AdamantChatsProvider {
         let id = UUID().uuidString
         let transaction = RichMessageTransaction(context: context)
         transaction.date = Date() as NSDate
+        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
         transaction.recipientId = recipientId
         transaction.senderId = senderId
         transaction.type = Int16(type.rawValue)
@@ -1183,6 +1185,7 @@ extension AdamantChatsProvider {
         
         // MARK: 2. Update transaction
         transaction.date = Date() as NSDate
+        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
         transaction.statusEnum = .pending
         
         if let chatroom = transaction.chatroom {
@@ -1412,8 +1415,7 @@ extension AdamantChatsProvider {
         request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(format: "chatroom = %@", chatroom),
             NSPredicate(format: "isHidden == false")])
-        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: true),
-                                   NSSortDescriptor(key: "transactionId", ascending: true)]
+        request.sortDescriptors = .sortChatTransactions(ascending: true)
         let controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: context, sectionNameKeyPath: nil, cacheName: nil)
         
         return controller
@@ -1426,8 +1428,7 @@ extension AdamantChatsProvider {
             NSPredicate(format: "isUnread == true"),
             NSPredicate(format: "isHidden == false")])
         
-        request.sortDescriptors = [NSSortDescriptor.init(key: "date", ascending: false),
-                                   NSSortDescriptor(key: "transactionId", ascending: false)]
+        request.sortDescriptors = .sortChatTransactions(ascending: false)
         
         let controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: stack.container.viewContext, sectionNameKeyPath: "chatroom.partner.address", cacheName: nil)
         

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -973,7 +973,7 @@ extension AdamantChatsProvider {
         let transaction = MessageTransaction(context: context)
         let id = UUID().uuidString
         transaction.date = Date() as NSDate
-        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
+        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
         transaction.recipientId = recipientId
         transaction.senderId = senderId
         transaction.type = Int16(type.rawValue)
@@ -1020,7 +1020,7 @@ extension AdamantChatsProvider {
         let id = UUID().uuidString
         let transaction = RichMessageTransaction(context: context)
         transaction.date = Date() as NSDate
-        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
+        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
         transaction.recipientId = recipientId
         transaction.senderId = senderId
         transaction.type = Int16(type.rawValue)
@@ -1185,7 +1185,7 @@ extension AdamantChatsProvider {
         
         // MARK: 2. Update transaction
         transaction.date = Date() as NSDate
-        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
+        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
         transaction.statusEnum = .pending
         
         if let chatroom = transaction.chatroom {

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -973,7 +973,7 @@ extension AdamantChatsProvider {
         let transaction = MessageTransaction(context: context)
         let id = UUID().uuidString
         transaction.date = Date() as NSDate
-        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
+        transaction.timestampMs = transaction.timeIntervalMillisecondsSince1970
         transaction.recipientId = recipientId
         transaction.senderId = senderId
         transaction.type = Int16(type.rawValue)
@@ -1020,7 +1020,7 @@ extension AdamantChatsProvider {
         let id = UUID().uuidString
         let transaction = RichMessageTransaction(context: context)
         transaction.date = Date() as NSDate
-        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
+        transaction.timestampMs = transaction.timeIntervalMillisecondsSince1970
         transaction.recipientId = recipientId
         transaction.senderId = senderId
         transaction.type = Int16(type.rawValue)
@@ -1185,7 +1185,7 @@ extension AdamantChatsProvider {
         
         // MARK: 2. Update transaction
         transaction.date = Date() as NSDate
-        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
+        transaction.timestampMs = transaction.timeIntervalMillisecondsSince1970
         transaction.statusEnum = .pending
         
         if let chatroom = transaction.chatroom {

--- a/Adamant/Services/DataProviders/AdamantTransfersProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantTransfersProvider.swift
@@ -443,7 +443,7 @@ extension AdamantTransfersProvider {
         let transaction = TransferTransaction(context: context)
         transaction.amount = amount as NSDecimalNumber
         transaction.date = Date() as NSDate
-        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
+        transaction.timestampMs = transaction.timeIntervalMillisecondsSince1970
         transaction.recipientId = recipient
         transaction.senderId = loggedAccount.address
         transaction.type = Int16(TransactionType.chatMessage.rawValue)
@@ -637,7 +637,7 @@ extension AdamantTransfersProvider {
         let transaction = TransferTransaction(context: context)
         transaction.amount = amount as NSDecimalNumber
         transaction.date = Date() as NSDate
-        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
+        transaction.timestampMs = transaction.timeIntervalMillisecondsSince1970
         transaction.recipientId = recipient
         transaction.senderId = loggedAccount.address
         transaction.type = Int16(TransactionType.send.rawValue)

--- a/Adamant/Services/DataProviders/AdamantTransfersProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantTransfersProvider.swift
@@ -443,7 +443,7 @@ extension AdamantTransfersProvider {
         let transaction = TransferTransaction(context: context)
         transaction.amount = amount as NSDecimalNumber
         transaction.date = Date() as NSDate
-        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
+        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
         transaction.recipientId = recipient
         transaction.senderId = loggedAccount.address
         transaction.type = Int16(TransactionType.chatMessage.rawValue)
@@ -637,7 +637,7 @@ extension AdamantTransfersProvider {
         let transaction = TransferTransaction(context: context)
         transaction.amount = amount as NSDecimalNumber
         transaction.date = Date() as NSDate
-        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
+        transaction.timestampMs = transaction.date?.timeIntervalMillisecondsSince1970 ?? .zero
         transaction.recipientId = recipient
         transaction.senderId = loggedAccount.address
         transaction.type = Int16(TransactionType.send.rawValue)

--- a/Adamant/Services/DataProviders/AdamantTransfersProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantTransfersProvider.swift
@@ -340,8 +340,7 @@ extension AdamantTransfersProvider {
     // MARK: Controllers
     func transfersController() -> NSFetchedResultsController<TransferTransaction> {
         let request = NSFetchRequest<TransferTransaction>(entityName: TransferTransaction.entityName)
-        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false),
-                                   NSSortDescriptor(key: "transactionId", ascending: false)]
+        request.sortDescriptors = .sortChatTransactions(ascending: false)
         let controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: stack.container.viewContext, sectionNameKeyPath: nil, cacheName: nil)
         
         return controller
@@ -349,8 +348,7 @@ extension AdamantTransfersProvider {
     
     func transfersController(for account: CoreDataAccount) -> NSFetchedResultsController<TransferTransaction> {
         let request = NSFetchRequest<TransferTransaction>(entityName: TransferTransaction.entityName)
-        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false),
-                                   NSSortDescriptor(key: "transactionId", ascending: false)]
+        request.sortDescriptors = .sortChatTransactions(ascending: false)
         request.predicate = NSPredicate(format: "partner = %@", account)
         
         let controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: stack.container.viewContext, sectionNameKeyPath: nil, cacheName: nil)
@@ -361,8 +359,7 @@ extension AdamantTransfersProvider {
     func unreadTransfersController() -> NSFetchedResultsController<TransferTransaction> {
         let request = NSFetchRequest<TransferTransaction>(entityName: TransferTransaction.entityName)
         request.predicate = NSPredicate(format: "isUnread == true")
-        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false),
-                                   NSSortDescriptor(key: "transactionId", ascending: false)]
+        request.sortDescriptors = .sortChatTransactions(ascending: false)
         let controller = NSFetchedResultsController(fetchRequest: request, managedObjectContext: stack.container.viewContext, sectionNameKeyPath: nil, cacheName: nil)
         
         return controller
@@ -446,6 +443,7 @@ extension AdamantTransfersProvider {
         let transaction = TransferTransaction(context: context)
         transaction.amount = amount as NSDecimalNumber
         transaction.date = Date() as NSDate
+        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
         transaction.recipientId = recipient
         transaction.senderId = loggedAccount.address
         transaction.type = Int16(TransactionType.chatMessage.rawValue)
@@ -639,6 +637,7 @@ extension AdamantTransfersProvider {
         let transaction = TransferTransaction(context: context)
         transaction.amount = amount as NSDecimalNumber
         transaction.date = Date() as NSDate
+        transaction.timestampMs = Int64(transaction.date?.timeIntervalSince1970 ?? .zero)
         transaction.recipientId = recipient
         transaction.senderId = loggedAccount.address
         transaction.type = Int16(TransactionType.send.rawValue)

--- a/CommonKit/Sources/CommonKit/Helpers/AdamantUtilities.swift
+++ b/CommonKit/Sources/CommonKit/Helpers/AdamantUtilities.swift
@@ -24,7 +24,7 @@ public enum AdamantUtilities {
         return Date(timeIntervalSince1970: timestamp + magicAdamantTimeInterval)
     }
     
-    private static let magicAdamantTimeInterval: TimeInterval = {
+    public static let magicAdamantTimeInterval: TimeInterval = {
         // JS handles moth as 0-based number, swift handles month as 1-based number.
         let components = DateComponents(calendar: Calendar(identifier: .gregorian), timeZone: TimeZone(abbreviation: "UTC"), year: 2017, month: 9, day: 2, hour: 17)
         return components.date!.timeIntervalSince1970

--- a/CommonKit/Sources/CommonKit/Helpers/Date+TimestampMs.swift
+++ b/CommonKit/Sources/CommonKit/Helpers/Date+TimestampMs.swift
@@ -1,0 +1,20 @@
+//
+//  Date+Milliseconds.swift
+//  Adamant
+//
+//  Created by Sergei Veretennikov on 24.02.2025.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+
+public extension NSDate {
+    var timeIntervalMillisecondsSince1970: Int64 {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "SSS"
+        guard let milliseconds = Int64(formatter.string(from: self as Date)) else {
+            return Int64(timeIntervalSince1970) * 1000
+        }
+        return Int64(timeIntervalSince1970) * 1000 + milliseconds
+    }
+}

--- a/CommonKit/Sources/CommonKit/Helpers/Date+TimestampMs.swift
+++ b/CommonKit/Sources/CommonKit/Helpers/Date+TimestampMs.swift
@@ -10,6 +10,6 @@ import Foundation
 
 public extension NSDate {
     var timeIntervalMillisecondsSince1970: Int64 {
-        Int64(timeIntervalSince1970 * 1000) % 1000
+        Int64(timeIntervalSince1970 * 1000)
     }
 }

--- a/CommonKit/Sources/CommonKit/Helpers/Date+TimestampMs.swift
+++ b/CommonKit/Sources/CommonKit/Helpers/Date+TimestampMs.swift
@@ -10,11 +10,6 @@ import Foundation
 
 public extension NSDate {
     var timeIntervalMillisecondsSince1970: Int64 {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "SSS"
-        guard let milliseconds = Int64(formatter.string(from: self as Date)) else {
-            return Int64(timeIntervalSince1970) * 1000
-        }
-        return Int64(timeIntervalSince1970) * 1000 + milliseconds
+        Int64(timeIntervalSince1970 * 1000) % 1000
     }
 }

--- a/CommonKit/Sources/CommonKit/Models/ServerDTOs/Transaction.swift
+++ b/CommonKit/Sources/CommonKit/Models/ServerDTOs/Transaction.swift
@@ -14,7 +14,7 @@ public struct Transaction: Sendable {
     public let blockId: String
     public let type: TransactionType
     public let timestamp: UInt64
-    public let timestampMs: UInt64?
+    public let timestampMs: UInt64
     public let senderPublicKey: String
     public let senderId: String
     public let requesterPublicKey: String?
@@ -79,7 +79,7 @@ extension Transaction: Codable {
         
         let timestamp = try container.decode(UInt64.self, forKey: .timestamp)
         self.timestamp = timestamp + UInt64(AdamantUtilities.magicAdamantTimeInterval)
-        self.timestampMs = (try? container.decodeIfPresent(UInt64.self, forKey: .timestampMs)) ?? self.timestamp
+        self.timestampMs = (try? container.decodeIfPresent(UInt64.self, forKey: .timestampMs)) ?? self.timestamp * 1000
         self.date = AdamantUtilities.decodeAdamant(timestamp: TimeInterval(timestamp))
     }
     
@@ -107,16 +107,6 @@ extension Transaction: Codable {
         try container.encode(fee.shiftedToAdamant(), forKey: .fee) // Decimal
     }
     
-}
-
-public extension Transaction {
-    var timestampMillisecondsFromDate: Int64 {
-        if let timestampMs = timestampMs {
-            Int64(timestampMs)
-        } else {
-            (date as NSDate).timeIntervalMillisecondsSince1970
-        }
-    }
 }
 
 extension Transaction: WrappableModel {

--- a/CommonKit/Sources/CommonKit/Models/ServerDTOs/Transaction.swift
+++ b/CommonKit/Sources/CommonKit/Models/ServerDTOs/Transaction.swift
@@ -109,6 +109,16 @@ extension Transaction: Codable {
     
 }
 
+public extension Transaction {
+    var timestampMillisecondsFromDate: Int64 {
+        if let timestampMs = timestampMs {
+            Int64(timestampMs)
+        } else {
+            (date as NSDate).timeIntervalMillisecondsSince1970
+        }
+    }
+}
+
 extension Transaction: WrappableModel {
     public static let ModelKey = "transaction"
 }

--- a/CommonKit/Sources/CommonKit/Models/ServerDTOs/Transaction.swift
+++ b/CommonKit/Sources/CommonKit/Models/ServerDTOs/Transaction.swift
@@ -14,6 +14,7 @@ public struct Transaction: Sendable {
     public let blockId: String
     public let type: TransactionType
     public let timestamp: UInt64
+    public let timestampMs: UInt64?
     public let senderPublicKey: String
     public let senderId: String
     public let requesterPublicKey: String?
@@ -37,6 +38,7 @@ extension Transaction: Codable {
         case blockId
         case type
         case timestamp
+        case timestampMs
         case senderPublicKey
         case senderId
         case requesterPublicKey
@@ -58,7 +60,6 @@ extension Transaction: Codable {
         self.height = (try? container.decode(Int64.self, forKey: .height)) ?? 0
         self.blockId = (try? container.decode(String.self, forKey: .blockId)) ?? ""
         self.type = try container.decode(TransactionType.self, forKey: .type)
-        self.timestamp = try container.decode(UInt64.self, forKey: .timestamp)
         self.senderPublicKey = try container.decode(String.self, forKey: .senderPublicKey)
         self.senderId = try container.decode(String.self, forKey: .senderId)
         self.recipientId = (try? container.decode(String.self, forKey: .recipientId)) ?? ""
@@ -75,8 +76,11 @@ extension Transaction: Codable {
         
         let fee = try container.decode(Decimal.self, forKey: .fee)
         self.fee = fee.shiftedFromAdamant()
-
-        self.date = AdamantUtilities.decodeAdamant(timestamp: TimeInterval(self.timestamp))
+        
+        let timestamp = try container.decode(UInt64.self, forKey: .timestamp)
+        self.timestamp = timestamp + UInt64(AdamantUtilities.magicAdamantTimeInterval)
+        self.timestampMs = (try? container.decodeIfPresent(UInt64.self, forKey: .timestampMs)) ?? self.timestamp
+        self.date = AdamantUtilities.decodeAdamant(timestamp: TimeInterval(timestamp))
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -87,6 +91,7 @@ extension Transaction: Codable {
         try container.encode(blockId, forKey: .blockId) // String
         try container.encode(type, forKey: .type) // TransactionType
         try container.encode(timestamp, forKey: .timestamp) // UInt64
+        try container.encode(timestampMs, forKey: .timestampMs) // UInt64
         try container.encode(senderPublicKey, forKey: .senderPublicKey) // String
         try container.encode(senderId, forKey: .senderId) // String
         try container.encode(recipientId, forKey: .recipientId) // String?


### PR DESCRIPTION
I've added a new field for Transaction DTO which are mapped in ChatTransaction entities. Now we have only timestamp field, but we need to have backward compatibility so I setting now the timestamp value from the backend multiplied by 1000 if there is no timestampMs in this DTO. 
And I've changed comparing descriptor of the CoreData's ChatTransactions to make comparing more precisely because we are comparing the timestampMs now