### PR TITLE
[trello.com/c/Y5q62UTf]: fix some SPM warnings

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -4835,10 +4835,10 @@
 		};
 		AA8FFFC82D4E6435001D8576 /* XCRemoteSwiftPackageReference "CryptoSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ChrisBenua/CryptoSwift";
+			repositoryURL = "https://github.com/Adamant-im/CryptoSwift.git";
 			requirement = {
 				kind = revision;
-				revision = f0ea2cac7983c4a808cade78743b391726ecc0ea;
+				revision = ae1cc15340ddf0f607981f9118fe80d7fd7cd2b5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Adamant.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Adamant.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -39,10 +39,10 @@
       },
       {
         "package": "CryptoSwift",
-        "repositoryURL": "https://github.com/ChrisBenua/CryptoSwift",
+        "repositoryURL": "https://github.com/Adamant-im/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "f0ea2cac7983c4a808cade78743b391726ecc0ea",
+          "revision": "ae1cc15340ddf0f607981f9118fe80d7fd7cd2b5",
           "version": null
         }
       },

--- a/CommonKit/Package.swift
+++ b/CommonKit/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/krzyzanowskim/CryptoSwift.git",
+            url: "https://github.com/ChrisBenua/CryptoSwift.git",
             .upToNextMinor(from: "1.5.0")
         ),
         .package(

--- a/CommonKit/Package.swift
+++ b/CommonKit/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/ChrisBenua/CryptoSwift.git",
+            url: "https://github.com/Adamant-im/CryptoSwift.git",
             .upToNextMinor(from: "1.5.0")
         ),
         .package(

--- a/LiskKit/Package.swift
+++ b/LiskKit/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium.git", from: "0.9.1"),
-        .package(url: "https://github.com/ChrisBenua/CryptoSwift.git", from: "1.3.0"),
+        .package(url: "https://github.com/Adamant-im/CryptoSwift.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0")
     ],
     targets: [

--- a/LiskKit/Package.swift
+++ b/LiskKit/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Sodium", url: "https://github.com/jedisct1/swift-sodium.git", from: "0.9.1"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.0"),
+        .package(url: "https://github.com/ChrisBenua/CryptoSwift.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0")
     ],
     targets: [


### PR DESCRIPTION
Migrated my fork to adamant account.

Fix 2 of 3 SPM warnings connected with fork of CryptoSwift.

The only warning left is:
```
'web3swift' dependency on 'https://github.com/krzyzanowskim/CryptoSwift.git' conflicts with dependency on 'https://github.com/Adamant-im/CryptoSwift' which has the same identity 'cryptoswift'. this will be escalated to an error in future versions of SwiftPM.
```

To resolve this I have to fork web3swift, I don't think it is reasonable right now