### PR TITLE
[trello.com/c/gJBIZ5Cf]: tests for hexBytes

### DIFF
--- a/CommonKit/.swiftpm/xcode/xcshareddata/xcbaselines/CommonKitTests.xcbaseline/096E20D1-E7E0-41CE-A0E1-51611374B8F0.plist
+++ b/CommonKit/.swiftpm/xcode/xcshareddata/xcbaselines/CommonKitTests.xcbaseline/096E20D1-E7E0-41CE-A0E1-51611374B8F0.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>HexBytesTests</key>
+		<dict>
+			<key>test_hexBytes_performance</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.027400</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Time</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CommonKit/.swiftpm/xcode/xcshareddata/xcbaselines/CommonKitTests.xcbaseline/E6A8A214-5DA6-46B7-BBFC-56A2DDE26780.plist
+++ b/CommonKit/.swiftpm/xcode/xcshareddata/xcbaselines/CommonKitTests.xcbaseline/E6A8A214-5DA6-46B7-BBFC-56A2DDE26780.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>HexBytesTests</key>
+		<dict>
+			<key>test_hexBytes_performance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.029200</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CommonKit/.swiftpm/xcode/xcshareddata/xcbaselines/CommonKitTests.xcbaseline/Info.plist
+++ b/CommonKit/.swiftpm/xcode/xcshareddata/xcbaselines/CommonKitTests.xcbaseline/Info.plist
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>096E20D1-E7E0-41CE-A0E1-51611374B8F0</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro17,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>0</integer>
+				<key>cpuKind</key>
+				<string></string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>0</integer>
+				<key>modelCode</key>
+				<string>iPhone15,4</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>0</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+		<key>E6A8A214-5DA6-46B7-BBFC-56A2DDE26780</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro17,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone15,4</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CommonKit/Tests/CommonKitTests/HexBytesTests.swift
+++ b/CommonKit/Tests/CommonKitTests/HexBytesTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import CommonKit
+
+final class HexBytesTests: XCTestCase {
+    func test_hexBytes_smallStringWithLettersAndDigits() {
+        let input = "48656c6c6f"
+        let expectedOutput: [UInt8] = [0x48, 0x65, 0x6c, 0x6c, 0x6f]
+        XCTAssertEqual(input.hexBytes(), expectedOutput)
+    }
+    
+    func test_hexBytes_bigStringWithAllLettersAndAllDigits() {
+        let input = "1234567890abcdef"
+        let expectedOutput: [UInt8] = [0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef]
+        XCTAssertEqual(input.hexBytes(), expectedOutput)
+    }
+    
+    func test_hexBytes_emptyString() {
+        let input = ""
+        let expectedOutput: [UInt8] = []
+        XCTAssertEqual(input.hexBytes(), expectedOutput)
+    }
+    
+    func test_hexBytes_withEdgeHexValues() {
+        let input = "00ff"
+        let expectedOutput: [UInt8] = [0x00, 0xff]
+        XCTAssertEqual(input.hexBytes(), expectedOutput)
+    }
+    
+    func test_hexBytes_withUppercaseLetters() {
+        let input = "ABCDEF"
+        let expectedOutput: [UInt8] = [0xAB, 0xCD, 0xEF]
+        XCTAssertEqual(input.hexBytes(), expectedOutput)
+    }
+    
+    func test_hexBytes_replacesInvalidHexesWithZeros() {
+        let input = "AXBXCDEF"
+        let expectedOutput: [UInt8] = [0x00, 0x00, 0xCD, 0xEF]
+        XCTAssertEqual(input.hexBytes(), expectedOutput)
+    }
+    
+    func test_hexBytes_performance() {
+        let input = String.init(repeating: "0123456789abcdef", count: 20000)
+        
+        measure {
+            _ = input.hexBytes()
+        }
+    }
+}


### PR DESCRIPTION
Added unit-tests and performance test for `hexBytes` to ensure (at least locally), that there are no degradations on such frequently used function.