### PR TITLE
[trello.com/c/GpoP9FLk] Added logic of cancelling of the current tasks

### DIFF
--- a/Adamant/App/DI/AppAssembly.swift
+++ b/Adamant/App/DI/AppAssembly.swift
@@ -255,6 +255,7 @@ struct AppAssembly: MainThreadAssembly {
                 securedStore: r.resolve(SecuredStore.self)!,
                 walletServiceCompose: r.resolve(WalletServiceCompose.self)!,
                 currencyInfoService: r.resolve(InfoServiceProtocol.self)!,
+                coreDataStack: r.resolve(CoreDataStack.self)!,
                 connection: r.resolve(ReachabilityMonitor.self)!.connectionPublisher
             )
         }.inObjectScope(.container).initCompleted { (r, c) in

--- a/Adamant/ServiceProtocols/DataProviders/CoreDataStack.swift
+++ b/Adamant/ServiceProtocols/DataProviders/CoreDataStack.swift
@@ -11,4 +11,5 @@ import CoreData
 
 protocol CoreDataStack: Sendable {
     var container: NSPersistentContainer { get }
+    func clearCoreData()
 }

--- a/Adamant/Services/AdamantAccountService.swift
+++ b/Adamant/Services/AdamantAccountService.swift
@@ -21,6 +21,7 @@ final class AdamantAccountService: AccountService, @unchecked Sendable {
     private let securedStore: SecuredStore
     private let walletServiceCompose: WalletServiceCompose
     private let currencyInfoService: InfoServiceProtocol
+    private let coreDataStack: CoreDataStack
 
     weak var notificationsService: NotificationsService?
     weak var pushNotificationsTokenService: PushNotificationsTokenService?
@@ -46,6 +47,7 @@ final class AdamantAccountService: AccountService, @unchecked Sendable {
         securedStore: SecuredStore,
         walletServiceCompose: WalletServiceCompose,
         currencyInfoService: InfoServiceProtocol,
+        coreDataStack: CoreDataStack,
         connection: AnyObservable<Bool>
     ) {
         self.apiService = apiService
@@ -54,6 +56,7 @@ final class AdamantAccountService: AccountService, @unchecked Sendable {
         self.securedStore = securedStore
         self.walletServiceCompose = walletServiceCompose
         self.currencyInfoService = currencyInfoService
+        self.coreDataStack = coreDataStack
         
         NotificationCenter.default.addObserver(forName: .AdamantAccountService.forceUpdateBalance, object: nil, queue: OperationQueue.main) { [weak self] _ in
             self?.update()
@@ -459,6 +462,8 @@ extension AdamantAccountService {
         keypair = nil
         passphrase = nil
         state = .notLogged
+        apiService.cancelCurrentTasks()
+        coreDataStack.clearCoreData()
         
         guard wasLogged else { return }
         NotificationCenter.default.post(name: .AdamantAccountService.userLoggedOut, object: self)

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -530,10 +530,17 @@ extension AdamantChatsProvider {
                         senderId: address,
                         privateKey: privateKey
                     )
+                    await self?.setupAsReadyToSyncChats()
                 }
             case .failure:
                 break
             }
+        }
+    }
+    
+    func setupAsReadyToSyncChats() {
+        if isInitiallySynced {
+            isInitiallySynced = false
         }
     }
     

--- a/Adamant/Services/DataProviders/InMemoryCoreDataStack.swift
+++ b/Adamant/Services/DataProviders/InMemoryCoreDataStack.swift
@@ -25,24 +25,22 @@ final class InMemoryCoreDataStack: CoreDataStack {
         container.persistentStoreDescriptions = [description]
         container.loadPersistentStores { (_, _) in }
         container.viewContext.mergePolicy = NSMergePolicy(merge: NSMergePolicyType.mergeByPropertyObjectTrumpMergePolicyType)
+    }
+    
+    func clearCoreData() {
+        let context = container.viewContext
         
-        NotificationCenter.default.addObserver(forName: Notification.Name.AdamantAccountService.userLoggedOut, object: nil, queue: OperationQueue.main) { [weak self] _ in
-            guard let context = self?.container.viewContext else {
-                return
+        let fetch = NSFetchRequest<NSManagedObject>(entityName: "BaseAccount")
+        
+        do {
+            let result = try context.fetch(fetch)
+            for account in result {
+                context.delete(account)
             }
             
-            let fetch = NSFetchRequest<NSManagedObject>(entityName: "BaseAccount")
-            
-            do {
-                let result = try context.fetch(fetch)
-                for account in result {
-                    context.delete(account)
-                }
-                
-                try context.save()
-            } catch {
-                print("Got error saving context after reset")
-            }
+            try context.save()
+        } catch {
+            print("Got error saving context after reset")
         }
     }
 }

--- a/CommonKit/Sources/CommonKit/Protocols/AdamantApiServiceProtocol.swift
+++ b/CommonKit/Sources/CommonKit/Protocols/AdamantApiServiceProtocol.swift
@@ -131,4 +131,6 @@ public protocol AdamantApiServiceProtocol: ApiServiceProtocol {
         keypair: Keypair,
         votes: [DelegateVote]
     ) async -> ApiServiceResult<Bool>
+    
+    func cancelCurrentTasks()
 }

--- a/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApi+AdamantApiTask.swift
+++ b/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApi+AdamantApiTask.swift
@@ -1,0 +1,38 @@
+//
+//  AdamantApi+AdamantApiTask.swift
+//  CommonKit
+//
+//  Created by Sergei Veretennikov on 04.03.2025.
+//
+
+import Foundation
+
+final class AdamantApiTask<Output>: CancellableTask {
+    private let task: Task<Result<Output, ApiServiceError>, Never>
+    private let id = UUID()
+    var value: Result<Output, ApiServiceError> {
+        get async {
+            await task.value
+        }
+    }
+    
+    init(task: Task<Result<Output, ApiServiceError>, Never>) {
+        self.task = task
+    }
+    
+    func cancel() {
+        task.cancel()
+    }
+    
+    func storeIn(taskStorage: inout [UUID: CancellableTask]) {
+        taskStorage[id] = self
+    }
+    
+    func removeFrom(taskStorage: inout [UUID: CancellableTask]) {
+        taskStorage[id] = nil
+    }
+}
+
+protocol CancellableTask {
+    func cancel()
+}

--- a/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApiService.swift
+++ b/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApiService.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 
-public final class AdamantApiService {
+public final class AdamantApiService: @unchecked Sendable {
+    @Atomic private var adamantApiTaskStorage: [UUID: CancellableTask] = [:]
+    
     public let adamantCore: AdamantCore
     public let service: BlockchainHealthCheckWrapper<AdamantApiCore>
     
@@ -22,12 +24,29 @@ public final class AdamantApiService {
     
     public func request<Output>(
         waitsForConnectivity: Bool = false,
-        _ request: @Sendable (APICoreProtocol, NodeOrigin) async -> ApiServiceResult<Output>
+        _ request: @Sendable @escaping (APICoreProtocol, NodeOrigin) async -> ApiServiceResult<Output>
     ) async -> ApiServiceResult<Output> {
-        await service.request(
-            waitsForConnectivity: waitsForConnectivity
-        ) { admApiCore, origin in
-            await request(admApiCore.apiCore, origin)
+        let task = AdamantApiTask<Output>(task: Task {
+            await service.request(
+                waitsForConnectivity: waitsForConnectivity
+            ) { admApiCore, origin in
+                let result = await request(admApiCore.apiCore, origin)
+                do {
+                    try Task.checkCancellation()
+                } catch {
+                    return .failure(.requestCancelled)
+                }
+                return result
+            }
+        })
+        task.storeIn(taskStorage: &adamantApiTaskStorage)
+        defer { task.removeFrom(taskStorage: &adamantApiTaskStorage) }
+        return await task.value
+    }
+    
+    public func cancelCurrentTasks() {
+        adamantApiTaskStorage.forEach { _, task in
+            task.cancel()
         }
     }
 }


### PR DESCRIPTION
This PR is about refactoring and optimization. 

What has been done: 
1. Mainly is that I've added logic to cancel current tasks of current user. It led to some data race errors before because of following logic:
    1. User have triggered initial chats update.
    2. User logged out before request triggered by the 1st step haven't been finished yet.
    3. CoreDate have updated.
    4. Request triggered from 1st step updates  CoreData. 
    5. User logs in to the other wallet
    6. As result old messages from old core data of the previous wallet
2. I've made CoreData invalidation due to logging out event to be synchronious 
3. I've made updating of the `isInitiallySynced` value on user logging in event to pretend every new logging-in as the first logging-in one lifecycle of the app.
4. Introduced `AdamantApiTask` to manage and indentify the lifecycle of the Tasks created in `AdamantApiService`.
`AdamantApiTask` uses `id` to identify each tasks, for store and remove it from the tasks storage in `AdamantApiService`. It also conforms new custom `CancellableTask` interface to avoid Generic restrictions of `request<Output>` function