### PR TITLE
[trello.com/c/ZWei9TCF] fix visual bug with pendings

### DIFF
--- a/Adamant/Models/BTCRawTransaction.swift
+++ b/Adamant/Models/BTCRawTransaction.swift
@@ -35,7 +35,7 @@ struct BTCRawTransaction {
             transactionStatus = confirmations > 0 ? .success : .pending
         } else {
             confirmationsValue = nil
-            transactionStatus = .notInitiated
+            transactionStatus = .registered
         }
         
         // Transfers

--- a/Adamant/Modules/Wallets/Doge/DogeWalletService+Send.swift
+++ b/Adamant/Modules/Wallets/Doge/DogeWalletService+Send.swift
@@ -138,7 +138,7 @@ extension BitcoinKit.Transaction: TransactionDetails {
     }
     
     var transactionStatus: TransactionStatus? {
-        return .pending
+        return .notInitiated
     }
     
     var senderAddress: String {

--- a/Adamant/Modules/Wallets/TransactionDetailsViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/TransactionDetailsViewControllerBase.swift
@@ -595,7 +595,8 @@ class TransactionDetailsViewControllerBase: FormViewController {
                !value.isEmpty {
                 row.value = value
             } else {
-                row.value = TransactionDetailsViewControllerBase.awaitingValueString
+                row.value = TransactionStatus.registered.localized
+                cell.detailTextLabel?.textColor = .adamant.attention
             }
         }
         

--- a/Adamant/Modules/Wallets/TransactionTableViewCell.swift
+++ b/Adamant/Modules/Wallets/TransactionTableViewCell.swift
@@ -192,11 +192,9 @@ final class TransactionTableViewCell: UITableViewCell {
             } else {
                 dateLabel.text = nil
             }
-        case .notInitiated:
-            dateLabel.text = TransactionDetailsViewControllerBase.awaitingValueString
         case .failed:
             dateLabel.text = TransactionStatus.failed.localized
-        case .pending, .registered:
+        case .pending, .registered, .notInitiated:
             dateLabel.text = TransactionStatus.pending.localized
         default:
             dateLabel.text = TransactionDetailsViewControllerBase.awaitingValueString


### PR DESCRIPTION
The initial status for transactions is .notInitiated. After the first response from the server, the status is assigned to .registered. For erc20 transactions, I changed nil scenario, since they are rich transactions and do not receive intermediate responses from the server.
Adamant/Modules/Wallets/TransactionTableViewCell.swift this cell should not show clock, so i change it