### PR TITLE
Fix develop wrong import

### DIFF
--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/Decoders/MainBlockchainInfoDTO.swift
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/Decoders/MainBlockchainInfoDTO.swift
@@ -7,7 +7,6 @@
 
 
 import Foundation
-import AdamantWalletsAssets
 
 public struct MainBlockchainInfoDTO: Codable {
     public let blockchain: String

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/Decoders/MainBlockchainInfoDTO.swift
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/Decoders/MainBlockchainInfoDTO.swift
@@ -5,7 +5,6 @@
 //  Created by Владимир Клевцов on 17.1.25..
 //
 
-
 import Foundation
 
 public struct MainBlockchainInfoDTO: Codable {


### PR DESCRIPTION
This PR fixes compilation error on `develop` caused by a wrong import