### PR TITLE
[trello.com/c/iGILackD] fix-logo-extra-animation

### DIFF
--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -547,7 +547,8 @@ private extension ChatViewController {
     }
     
     func updateScrollToUnreadButtonPosition() {
-        if self.scrollDownButton.alpha == 0 {
+let offset = (scrollDownButton.alpha == 0) ? 0 : -(scrollToUnreadInset + scrollButtonHeight)
+scrollToUnreadBottomConstraint?.update(offset: offset)
             self.scrollToUnreadBottomConstraint?.update(offset: 0)
         } else {
             self.scrollToUnreadBottomConstraint?.update(offset: -(scrollToUnreadInset + scrollButtonHeight))

--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -546,13 +546,21 @@ private extension ChatViewController {
     }
     
     func updateScrollToUnreadButtonPosition() {
-        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+        if messagesLoaded {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+                if self.scrollDownButton.alpha == 0 {
+                    self.scrollToUnreadBottomConstraint?.update(offset: 0)
+                } else {
+                    self.scrollToUnreadBottomConstraint?.update(offset: -(scrollToUnreadInset + scrollButtonHeight))
+                }
+                self.view.layoutIfNeeded()
+            }
+        } else {
             if self.scrollDownButton.alpha == 0 {
                 self.scrollToUnreadBottomConstraint?.update(offset: 0)
             } else {
                 self.scrollToUnreadBottomConstraint?.update(offset: -(scrollToUnreadInset + scrollButtonHeight))
             }
-            self.view.layoutIfNeeded()
         }
     }
     
@@ -778,7 +786,13 @@ private extension ChatViewController {
     func updateScrollDownButtonVisibility() {
         let topCount = viewModel.unreadMessagesIds?.count ?? 0
         
-        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+        if messagesLoaded {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+                self.scrollDownButton.alpha = self.isScrollPositionNearlyTheBottom ? 0 : 1
+                self.updateScrollToUnreadButtonPosition()
+                self.scrollDownButton.updateCounter(topCount)
+            }
+        } else {
             self.scrollDownButton.alpha = self.isScrollPositionNearlyTheBottom ? 0 : 1
             self.updateScrollToUnreadButtonPosition()
             self.scrollDownButton.updateCounter(topCount)
@@ -787,8 +801,11 @@ private extension ChatViewController {
 
     func updateScrollToUnreadButtonVisibility() {
         let count = viewModel.messagesWithUnredReactionsIds?.count ?? 0
-        
-        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+        if messagesLoaded {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+                self.scrollToUnreadReactButton.alpha = (count == 0) ? 0 : 1
+            }
+        } else {
             self.scrollToUnreadReactButton.alpha = (count == 0) ? 0 : 1
         }
         scrollToUnreadReactButton.updateCounter(count)

--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -547,12 +547,8 @@ private extension ChatViewController {
     }
     
     func updateScrollToUnreadButtonPosition() {
-let offset = (scrollDownButton.alpha == 0) ? 0 : -(scrollToUnreadInset + scrollButtonHeight)
-scrollToUnreadBottomConstraint?.update(offset: offset)
-            self.scrollToUnreadBottomConstraint?.update(offset: 0)
-        } else {
-            self.scrollToUnreadBottomConstraint?.update(offset: -(scrollToUnreadInset + scrollButtonHeight))
-        }
+        let offset = (scrollDownButton.alpha == 0) ? 0 : -(scrollToUnreadInset + scrollButtonHeight)
+        scrollToUnreadBottomConstraint?.update(offset: offset)
         if messagesLoaded {
             self.view.layoutIfNeeded()
         }
@@ -780,18 +776,19 @@ private extension ChatViewController {
     func updateScrollDownButtonVisibility() {
         let topCount = viewModel.unreadMessagesIds?.count ?? 0
         self.scrollDownButton.updateCounter(topCount)
-        if isScrollDownButtonHidden != isScrollPositionNearlyTheBottom {
+        guard isScrollDownButtonHidden != isScrollPositionNearlyTheBottom else { return }
             isScrollDownButtonHidden = isScrollPositionNearlyTheBottom
-            if messagesLoaded {
-                UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
-                    self.scrollDownButton.alpha = self.isScrollPositionNearlyTheBottom ? 0 : 1
-                    self.updateScrollToUnreadButtonPosition()
-                }
-            } else {
+            let buttonUpdate = {
                 self.scrollDownButton.alpha = self.isScrollPositionNearlyTheBottom ? 0 : 1
                 self.updateScrollToUnreadButtonPosition()
             }
-        }
+            if messagesLoaded {
+                UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+                    buttonUpdate()
+                }
+            } else {
+                buttonUpdate()
+            }
     }
 
     func updateScrollToUnreadButtonVisibility() {

--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -43,6 +43,8 @@ final class ChatViewController: MessagesViewController {
     private var isScrollPositionNearlyTheBottom = true
     private var viewAppeared = false
     private var scrollToUnreadBottomConstraint: Constraint?
+    private var isScrollDownButtonHidden = true
+    private var previousUnreadCount: Int = 0
     
     private lazy var inputBar = ChatInputBar()
     private lazy var loadingView = LoadingView()
@@ -142,7 +144,6 @@ final class ChatViewController: MessagesViewController {
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         updateIsScrollPositionNearlyTheBottom()
-        updateScrollDownButtonVisibility()
     }
     
     override func viewDidLayoutSubviews() {
@@ -157,8 +158,8 @@ final class ChatViewController: MessagesViewController {
         if navigationController?.delegate !== self {
             navigationController?.delegate = self
         }
-        
         viewModel.updatePartnerName()
+        updateScrollDownButtonVisibility()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -546,21 +547,13 @@ private extension ChatViewController {
     }
     
     func updateScrollToUnreadButtonPosition() {
-        if messagesLoaded {
-            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
-                if self.scrollDownButton.alpha == 0 {
-                    self.scrollToUnreadBottomConstraint?.update(offset: 0)
-                } else {
-                    self.scrollToUnreadBottomConstraint?.update(offset: -(scrollToUnreadInset + scrollButtonHeight))
-                }
-                self.view.layoutIfNeeded()
-            }
+        if self.scrollDownButton.alpha == 0 {
+            self.scrollToUnreadBottomConstraint?.update(offset: 0)
         } else {
-            if self.scrollDownButton.alpha == 0 {
-                self.scrollToUnreadBottomConstraint?.update(offset: 0)
-            } else {
-                self.scrollToUnreadBottomConstraint?.update(offset: -(scrollToUnreadInset + scrollButtonHeight))
-            }
+            self.scrollToUnreadBottomConstraint?.update(offset: -(scrollToUnreadInset + scrollButtonHeight))
+        }
+        if messagesLoaded {
+            self.view.layoutIfNeeded()
         }
     }
     
@@ -785,30 +778,36 @@ private extension ChatViewController {
     
     func updateScrollDownButtonVisibility() {
         let topCount = viewModel.unreadMessagesIds?.count ?? 0
-        
-        if messagesLoaded {
-            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+        self.scrollDownButton.updateCounter(topCount)
+        if isScrollDownButtonHidden != isScrollPositionNearlyTheBottom {
+            isScrollDownButtonHidden = isScrollPositionNearlyTheBottom
+            if messagesLoaded {
+                UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+                    self.scrollDownButton.alpha = self.isScrollPositionNearlyTheBottom ? 0 : 1
+                    self.updateScrollToUnreadButtonPosition()
+                }
+            } else {
                 self.scrollDownButton.alpha = self.isScrollPositionNearlyTheBottom ? 0 : 1
                 self.updateScrollToUnreadButtonPosition()
-                self.scrollDownButton.updateCounter(topCount)
             }
-        } else {
-            self.scrollDownButton.alpha = self.isScrollPositionNearlyTheBottom ? 0 : 1
-            self.updateScrollToUnreadButtonPosition()
-            self.scrollDownButton.updateCounter(topCount)
         }
     }
 
     func updateScrollToUnreadButtonVisibility() {
         let count = viewModel.messagesWithUnredReactionsIds?.count ?? 0
-        if messagesLoaded {
-            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
-                self.scrollToUnreadReactButton.alpha = (count == 0) ? 0 : 1
-            }
-        } else {
-            self.scrollToUnreadReactButton.alpha = (count == 0) ? 0 : 1
-        }
         scrollToUnreadReactButton.updateCounter(count)
+
+        guard (previousUnreadCount == 0 && count > 0) || (previousUnreadCount > 0 && count == 0) else {
+            previousUnreadCount = count
+            return
+        }
+        previousUnreadCount = count
+        let updateAlpha = { self.scrollToUnreadReactButton.alpha = (count == 0) ? 0 : 1 }
+        if messagesLoaded {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut, animations: updateAlpha)
+        } else {
+            updateAlpha()
+        }
     }
     
     func updateDateHeaderIfNeeded() {
@@ -858,7 +857,7 @@ private extension ChatViewController {
             
             viewModel.scroll(to: unreadId)
         }
-        
+        button.alpha = 0
         return button
     }
     


### PR DESCRIPTION
UIView.animate affect on loadingview, so I avoided scenario when we can animate before messages loaded.
Also update animation call and alpha updates improve performance 