### PR TITLE
[trello.com/c/lwOnjxPQ] fix chat position update

### DIFF
--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -992,6 +992,7 @@ extension AdamantChatsProvider {
             transaction.statusEnum = MessageStatus.pending
             transaction.partner = context.object(with: partner.objectID) as? BaseAccount
             chatroom.lastTransaction = transaction
+            chatroom.updatedAt = transaction.date
             chatroom.addToTransactions(transaction)
             
             do {
@@ -1048,6 +1049,7 @@ extension AdamantChatsProvider {
             
             chatroom.addToTransactions(transaction)
             chatroom.lastTransaction = transaction
+            chatroom.updatedAt = transaction.date
             do {
                 try context.save()
                 return transaction


### PR DESCRIPTION
bug was:
1 Open chat list
2 Open a chat somewhere from bottom
3 Go back to chat list
4 Expected: This chat is on top of Chat list
5 Actual: Same position and date of last message didn’t change

https://github.com/user-attachments/assets/d190db33-098c-487c-971a-c91620336fd6

