### PR TITLE
[trello.com/c/ccz1Joza] Bug: Placed Emoji is not visible

### DIFF
--- a/Adamant/Services/RichTransactionReactService/AdamantRichTransactionReactService.swift
+++ b/Adamant/Services/RichTransactionReactService/AdamantRichTransactionReactService.swift
@@ -117,6 +117,19 @@ private extension AdamantRichTransactionReactService {
         )
         
         self.reactions[id] = reactions
+        
+        let baseTransaction = getTransactionFromDB(id: id)
+        
+        switch baseTransaction {
+        case let trs as MessageTransaction:
+            update(transaction: trs)
+        case let trs as TransferTransaction:
+            update(transaction: trs)
+        case let trs as RichMessageTransaction:
+            update(transaction: trs)
+        default:
+            break
+        }
     }
     
     func update(transaction: RichMessageTransaction) {


### PR DESCRIPTION
returned the code that was responsible for installing emoji when sending. When I was working on processing received messages, I did not understand why this code was executed when receiving messages, because its logic had already been reproduced earlier. It turned out that it was necessary for set emoji when sending. It's a pity that it is written like that