### PR TITLE
[trello.com/c/jKqpxiCa] update new message line and chat entering scroll

### DIFF
--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -328,6 +328,11 @@ private extension ChatViewController {
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.updateMessages()
+            }
+            .store(in: &subscriptions)
+        
+        viewModel.messagesUpdated
+            .sink { [weak self] _ in
                 self?.updateMessagesPosition()
             }
             .store(in: &subscriptions)
@@ -414,12 +419,14 @@ private extension ChatViewController {
             .sink { [weak self] in self?.processFileToolbarView($0) }
             .store(in: &subscriptions)
         
-        viewModel.$scrollToMessage
+        viewModel.$scrollToIdAndPosition
             .sink { [weak self] in
-                guard let toId = $0
+                guard let idAndPosition = $0
                 else { return }
                 
-                self?.scrollToPosition(.messageId(toId), animated: false)
+                self?.scrollToPosition = idAndPosition.position
+                self?.scrollToPosition(.messageId(idAndPosition.id), animated: false, setExtraOffset: self?.scrollToPosition == .top)
+                self?.viewModel.messageIdToShow = nil
             }
             .store(in: &subscriptions)
         
@@ -761,10 +768,12 @@ private extension ChatViewController {
     func updateMessagesPosition() {
         guard !messagesLoaded, !viewModel.messages.isEmpty else { return }
         messagesLoaded = true
-        if let position = viewModel.startPosition {
-            scrollToPosition(position)
-        } else if let unreadMessage = viewModel.unreadMessagesIds?.first {
-            scrollToPosition(.messageId(unreadMessage), animated: false)
+        if viewModel.messageIdToShow == nil {
+            if let unreadMessage = viewModel.unreadMessagesIds?.first {
+                scrollToPosition(.messageId(unreadMessage), setExtraOffset: true)
+            } else if let position = viewModel.startPosition {
+                scrollToPosition(position)
+            }
         }
     }
     
@@ -920,7 +929,7 @@ private extension ChatViewController {
     }
     
     @MainActor
-    func scrollToPosition(_ position: ChatStartPosition, animated: Bool = false) {
+    func scrollToPosition(_ position: ChatStartPosition, animated: Bool = false, setExtraOffset: Bool = false) {
         chatMessagesCollectionView.fixedBottomOffset = nil
         
         switch position {
@@ -944,6 +953,10 @@ private extension ChatViewController {
                 animated: animated
             )
             
+            if setExtraOffset {
+                setExtraOffsetForNewMessages()
+            }
+            
             viewModel.needToAnimateCellIndex = needToAnimateCell
             ? index
             : nil
@@ -958,6 +971,17 @@ private extension ChatViewController {
         
         guard !viewAppeared else { return }
         chatMessagesCollectionView.fixedBottomOffset = chatMessagesCollectionView.bottomOffset
+    }
+    
+    func setExtraOffsetForNewMessages() {
+        //extra scroll to 120 to see newMessage line and 2 strings from previus message
+        let newOffsetY = max(
+            messagesCollectionView.contentOffset.y - 120,
+            0
+        )
+        let newOffset = CGPoint(x: messagesCollectionView.contentOffset.x, y: newOffsetY)
+        
+        messagesCollectionView.setContentOffset(newOffset, animated: false)
     }
     
     func scrollDownOnNewMessageIfNeeded(previousBottomMessageId: String?) {

--- a/Adamant/Modules/Chat/View/Subviews/NewMessagesCell.swift
+++ b/Adamant/Modules/Chat/View/Subviews/NewMessagesCell.swift
@@ -12,7 +12,7 @@ import MessageKit
 final class NewMessagesCell: MessageReusableView {
     private let separatorLine: UIView = {
         let view = UIView()
-        view.backgroundColor = .adamant.active
+        view.backgroundColor = .adamant.newMessageLineColor
         return view
     }()
     
@@ -36,12 +36,12 @@ final class NewMessagesCell: MessageReusableView {
         
         let pixelSize = 1 / UIScreen.main.scale
         NSLayoutConstraint.activate([
-            separatorLine.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
-            separatorLine.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            separatorLine.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            separatorLine.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
             separatorLine.topAnchor.constraint(equalTo: topAnchor),
             separatorLine.heightAnchor.constraint(equalToConstant: pixelSize),
             
-            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
             label.topAnchor.constraint(equalTo: separatorLine.bottomAnchor, constant: 1)
         ])
     }

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -51,8 +51,8 @@ final class ChatViewModel: NSObject {
     private var controller: NSFetchedResultsController<ChatTransaction>?
     private var subscriptions = Set<AnyCancellable>()
     private var timerSubscription: AnyCancellable?
-    private var messageIdToShow: String?
     private var isLoading = false
+    var messageIdToShow: String?
     var separatorIndex: Int?
     var separatorId: String?
     var didAddSeparator: Bool = false
@@ -114,6 +114,7 @@ final class ChatViewModel: NSObject {
     let enableScroll = ObservableSender<Bool>()
     let showBuyAndSell = ObservableSender<Void>()
     let didUpdateCoreData = ObservableSender<Void>()
+    let messagesUpdated = ObservableSender<Void>()
     
     @ObservableValue private(set) var swipeableMessage: ChatSwipeWrapperModel = .default
     @ObservableValue private(set) var isHeaderLoading = false
@@ -132,7 +133,7 @@ final class ChatViewModel: NSObject {
     @ObservableValue private(set) var dateHeaderHidden: Bool = true
     @ObservableValue var inputText = ""
     @ObservableValue var replyMessage: MessageModel?
-    @ObservableValue var scrollToMessage: String?
+    @ObservableValue var scrollToIdAndPosition: (id: String, position: UICollectionView.ScrollPosition)?
     @ObservableValue var filesPicked: [FileResult]? {
         didSet {
             updateFeeValue()
@@ -140,8 +141,8 @@ final class ChatViewModel: NSObject {
     }
     
     var startPosition: ChatStartPosition? {
-        if let messageIdToShow = messageIdToShow {
-            return .messageId(messageIdToShow, toBottomIfNotFound: false)
+        if messageIdToShow != nil {
+            return nil
         }
         
         guard let address = chatroom?.partner?.address else { return nil }
@@ -556,7 +557,11 @@ final class ChatViewModel: NSObject {
                 
                 await waitForMessage(withId: messageId)
                 
-                scrollToMessage = messageId
+                if let lastMessageId = messages.last?.id {
+                    let position: UICollectionView.ScrollPosition = (messageId == lastMessageId) ? .top : .bottom
+                    scrollToIdAndPosition = (id: messageId, position: position)
+                }
+                
                 dialog.send(.progress(false))
                 if let index = messages.firstIndex(where: { $0.id == messageId }) {
                     markMessageAsRead(index: index)
@@ -1118,7 +1123,6 @@ private extension ChatViewModel {
             .removeDuplicates()
             .sink { [weak self] unreadIndexes in
                 self?.unreadMesaggesIndexes = unreadIndexes
-                self?.updateSeparatorId()
             }
             .store(in: &subscriptions)
         $messages
@@ -1281,15 +1285,17 @@ private extension ChatViewModel {
                 expirationTimestamp: &expirationTimestamp
             )
             
-            postProcess(messages: &messages)
             messagesWithUnredReactionsIds = reactId
             unreadMessagesIds = messageId
+            postProcess(messages: &messages)
             
             setupNewMessages(
                 newMessages: messages,
                 resetLoadingProperty: resetLoadingProperty,
                 expirationTimestamp: expirationTimestamp
             )
+            updateSeparatorId()
+            messagesUpdated.send()
         }
     }
     
@@ -1736,13 +1742,13 @@ private extension ChatViewModel {
     func updateSeparatorId() {
         guard !didAddSeparator, !messages.isEmpty else { return }
         
+        didAddSeparator = true
         guard let firstUnreadId = unreadMessagesIds?.first else {
             separatorId = nil
             separatorIndex = nil
             return
         }
         
-        didAddSeparator = true
         separatorId = firstUnreadId
         updateSeparatorIndex()
     }

--- a/CommonKit/Sources/CommonKit/Helpers/UIHelpers/UIColor+adamant.swift
+++ b/CommonKit/Sources/CommonKit/Helpers/UIHelpers/UIColor+adamant.swift
@@ -271,5 +271,7 @@ extension UIColor {
         
         // Outcome transfer icon background, light red
         public static let transferOutcomeIconBackground = #colorLiteral(red: 0.9411764706, green: 0.5215686275, blue: 0.5294117647, alpha: 1) //#F08587
+        
+        public static let newMessageLineColor = #colorLiteral(red: 0.2705882353, green: 0.2705882353, blue: 0.2705882353, alpha: 1)
     }
 }


### PR DESCRIPTION
- Change padding and color of new message line
- now separator not adding after entering chat for new messages, only while entering if we have some new messages
- Now the scroll priority when entering the chat is as follows: 
push notifications taped message -> newmessages separator -> save position
P.s. I cant put everything in one place like in updateMessagesPosition() because scroll to push notifications taped message sometimes need extra message loading request. So its separate. 