### PR TITLE
[trello.com/c/JnQ8ArFZ] fix scroll after delete messages

### DIFF
--- a/Adamant/Modules/Chat/View/Subviews/ChatMessagesCollection.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMessagesCollection.swift
@@ -46,8 +46,9 @@ final class ChatMessagesCollectionView: MessagesCollectionView {
     func reloadData(newIds: [String], isOnBottom: Bool) {
         let hasNewMessagesAtTop = newIds.first != currentIds.first
         let hasNewMessagesAtBottom = newIds.last != currentIds.last
+        let hasSameOrMoreMessages = newIds.count >= currentIds.count
 
-        guard hasNewMessagesAtTop || hasNewMessagesAtBottom else {
+        guard (hasNewMessagesAtTop || hasNewMessagesAtBottom), hasSameOrMoreMessages else {
             return applyNewIds(newIds)
         }
 


### PR DESCRIPTION
excluded the scenario of calling the position update if there are fewer messages

https://github.com/user-attachments/assets/bd411325-0903-4978-98e4-8f78c1ea38fc

