### PR TITLE
[trello.com/c/aedpNhWv] fix avatar blinking

### DIFF
--- a/Adamant/Modules/ChatsList/ChatListViewController.swift
+++ b/Adamant/Modules/ChatsList/ChatListViewController.swift
@@ -77,6 +77,8 @@ final class ChatListViewController: KeyboardObservingViewController {
         }
     }
     private var chatDeselectedIndex: IndexPath?
+    private var isScrolling = false
+    private var isRefreshing = false
 
     let defaultAvatar = UIImage.asset(named: "avatar-chat-placeholder") ?? .init()
 
@@ -394,17 +396,8 @@ final class ChatListViewController: KeyboardObservingViewController {
 
         lastDatesUpdate = Date()
         indexPaths.removeAll { $0 == swipedIndex }
-        tableView.reloadRowsAndPreserveSelection(at: indexPaths)
-    }
-
-    private func updateChats() {
-        guard accountService.account?.address != nil,
-            accountService.keypair?.privateKey != nil
-        else {
-            return
-        }
-        Task {
-            await handleRefresh()
+        if !isScrolling {
+            tableView.reloadRowsAndPreserveSelection(at: indexPaths)
         }
     }
 
@@ -490,6 +483,7 @@ final class ChatListViewController: KeyboardObservingViewController {
 
     @MainActor
     private func handleRefresh() async {
+        defer { isRefreshing = false }
         guard let result = await chatsProvider.update(notifyState: true) else { return }
 
         switch result {
@@ -615,12 +609,24 @@ extension ChatListViewController: UITableViewDelegate, UITableViewDataSource {
         let offsetY = scrollView.contentOffset.y + scrollView.safeAreaInsets.top
         scrollUpButton.isHidden = offsetY < cellHeight * 0.75
     }
+    
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         guard scrollView.contentOffset.y <= 0, scrollView.contentOffset.y < -100 else { return }
 
-        Task {
-            await handleRefresh()
+        if !isRefreshing {
+            isRefreshing = true
+            Task {
+                await handleRefresh()
+            }
         }
+    }
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        isScrolling = true
+    }
+    
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        isScrolling = false
     }
 }
 


### PR DESCRIPTION
After several hours and hundreds of swipes down I found that mostly it was for two reasons :
1. refreshDatesIfNeeded when we are updating through tableView willDisplay, so now its not updating while scrolling
2. handleRefresh multiple times if you try to spam update sometimes flick avatars
maybe there are some other scenarios, but even those that I fixed were quite rare, without changing the architectural approach it is unlikely that it will be possible to cure this by more than 99%

