### PR TITLE
[trello.com/c/sG80IZan] remove chat reeding when app is not active macOs

### DIFF
--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -46,6 +46,7 @@ final class ChatViewController: MessagesViewController {
     private var isScrollDownButtonHidden = true
     private var previousUnreadCount: Int = 0
     private var scrollToPositionType: UICollectionView.ScrollPosition = .top
+    private var isAppActive = true
 
     private lazy var inputBar = ChatInputBar()
     private lazy var loadingView = LoadingView()
@@ -309,8 +310,16 @@ extension ChatViewController {
             .notifications(named: UIApplication.didBecomeActiveNotification)
             .sink { @MainActor [weak self] _ in
                 guard let self = self else { return }
+                self.isAppActive = true
+                self.updateUnreadMessages()
                 let indexes = self.messagesCollectionView.indexPathsForVisibleItems
                 self.viewModel.updatePreviewFor(indexes: indexes)
+            }
+            .store(in: &subscriptions)
+        
+        NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)
+            .sink { [weak self] _ in
+                self?.isAppActive = false
             }
             .store(in: &subscriptions)
 
@@ -571,6 +580,9 @@ extension ChatViewController {
     }
 
     fileprivate func updateUnreadMessages() {
+        if isMacOS && !isAppActive {
+            return
+        }
         guard let unreadIndexes = viewModel.unreadMesaggesIndexes, !unreadIndexes.isEmpty else { return }
         let visibleIndexPaths = messagesCollectionView.indexPathsForVisibleItems
 


### PR DESCRIPTION
It has a limitation, if you just remove the application from focus, reading will still continue. You need to switch to another application so that the messenger goes to the background