### PR TITLE
[trello.com/c/aZtAfZ44] fix richmessage didnt mark unread when it has new reaction

### DIFF
--- a/Adamant/Modules/Chat/ViewModel/ChatMessageFactory.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatMessageFactory.swift
@@ -571,17 +571,8 @@ extension ChatMessageFactory {
     }
 
     fileprivate func checkTransactionForUnreadReaction(transaction: ChatTransaction) -> Bool {
-        if let messageTransaction = transaction as? MessageTransaction,
-            let richTransactions = messageTransaction.richMessageTransactions,
-            !richTransactions.isEmpty
-        {
-            return richTransactions.contains { $0.isUnread }
-        }
-
-        if let transferTransaction = transaction as? TransferTransaction,
-            let richTransactions = transferTransaction.richMessageTransactions,
-            !richTransactions.isEmpty
-        {
+        if let richTransactions = transaction.richMessageTransactions,
+           !richTransactions.isEmpty {
             return richTransactions.contains { $0.isUnread }
         }
 


### PR DESCRIPTION
After i moved relationship with reactions to parent class I didn't update this method, now everything works as it should