### PR TITLE
[trello.com/c/2Dz3alvN] Fixed a memory leak.

### DIFF
--- a/Adamant/App/DI/AppAssembly.swift
+++ b/Adamant/App/DI/AppAssembly.swift
@@ -173,7 +173,7 @@ struct AppAssembly: MainThreadAssembly {
         // MARK: ApiService
         container.register(AdamantApiServiceProtocol.self) { r in
             AdamantApiService(
-                healthCheckWrapper: .init(
+                healthCheckWrapper: AdamantHealthCheck(
                     service: .init(apiCore: r.resolve(APICoreProtocol.self)!),
                     nodesStorage: r.resolve(NodesStorageProtocol.self)!,
                     nodesAdditionalParamsStorage: r.resolve(NodesAdditionalParamsStorageProtocol.self)!,

--- a/Adamant/Services/AdamantAccountService.swift
+++ b/Adamant/Services/AdamantAccountService.swift
@@ -472,11 +472,11 @@ extension AdamantAccountService {
         keypair = nil
         passphrase = nil
         state = .notLogged
-        apiService.cancelCurrentTasks()
         coreDataStack.clearCoreData()
 
         guard wasLogged else { return }
         NotificationCenter.default.post(name: .AdamantAccountService.userLoggedOut, object: self)
+        apiService.cancelCurrentTasks()
     }
 }
 

--- a/CommonKit/Sources/CommonKit/ExtensionsTools/ExtensionsApiFactory.swift
+++ b/CommonKit/Sources/CommonKit/ExtensionsTools/ExtensionsApiFactory.swift
@@ -19,7 +19,7 @@ public struct ExtensionsApiFactory {
     public func make() -> ExtensionsApi {
         .init(
             apiService: AdamantApiService(
-                healthCheckWrapper: .init(
+                healthCheckWrapper: AdamantHealthCheck(
                     service: AdamantApiCore(apiCore: APICore()),
                     nodesStorage: NodesStorage(
                         SecureStore: SecureStore,

--- a/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApi+AdamantApiTask.swift
+++ b/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApi+AdamantApiTask.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class AdamantApiTask<Output>: CancellableTask {
     private let task: Task<Result<Output, ApiServiceError>, Never>
-    var id: UUID!
+    private let id: UUID
     
     var isCancelled: Bool {
         task.isCancelled
@@ -25,8 +25,9 @@ final class AdamantApiTask<Output>: CancellableTask {
         }
     }
 
-    init(task: Task<Result<Output, ApiServiceError>, Never>) {
+    init(task: Task<Result<Output, ApiServiceError>, Never>, id: UUID) {
         self.task = task
+        self.id = id
     }
 
     func cancel() {

--- a/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApi+AdamantApiTask.swift
+++ b/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApi+AdamantApiTask.swift
@@ -9,10 +9,19 @@ import Foundation
 
 final class AdamantApiTask<Output>: CancellableTask {
     private let task: Task<Result<Output, ApiServiceError>, Never>
-    private let id = UUID()
+    var id: UUID!
+    
+    var isCancelled: Bool {
+        task.isCancelled
+    }
+    
     var value: Result<Output, ApiServiceError> {
         get async {
-            await task.value
+            let value = await task.value
+            if task.isCancelled {
+                return .failure(ApiServiceError.requestCancelled)
+            }
+            return value
         }
     }
 
@@ -23,16 +32,9 @@ final class AdamantApiTask<Output>: CancellableTask {
     func cancel() {
         task.cancel()
     }
-
-    func storeIn(taskStorage: inout [UUID: CancellableTask]) {
-        taskStorage[id] = self
-    }
-
-    func removeFrom(taskStorage: inout [UUID: CancellableTask]) {
-        taskStorage[id] = nil
-    }
 }
 
 protocol CancellableTask {
+    var isCancelled: Bool { get }
     func cancel()
 }

--- a/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApiService.swift
+++ b/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApiService.swift
@@ -50,9 +50,8 @@ public final class AdamantApiService: @unchecked Sendable {
                 ) { admApiCore, origin in
                     return await request(admApiCore.apiCore, origin)
                 }
-            }
+            }, id: taskId
         )
-        task.id = taskId
         _adamantApiTaskStorage.mutate { storage in
             storage[taskId] = task
         }

--- a/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApiService.swift
+++ b/CommonKit/Sources/CommonKit/Services/ApiService/AdamantApiService.swift
@@ -8,14 +8,25 @@
 
 import Foundation
 
+
+///
+/// I need to override HealthCheckWrapped because of now we have an option to cancel the tasks
+/// and there is some situations when we are waiting for connection on the node and recursevly calling `request`
+/// function without any break condition and that is bad and unsafe. I've added a functionality of pushing the assosiated with the task `UUID`
+/// and checking it for a cancellation before doing something in the recursive function
+/// `request(waitsForConnectivity:taskId:isCancelled:_ request:)`
+/// 
+
+
 public final class AdamantApiService: @unchecked Sendable {
     @Atomic private var adamantApiTaskStorage: [UUID: CancellableTask] = [:]
+    private var cancelled: Bool = false
 
     public let adamantCore: AdamantCore
-    public let service: BlockchainHealthCheckWrapper<AdamantApiCore>
+    public let service: AdamantHealthCheck
 
     public init(
-        healthCheckWrapper: BlockchainHealthCheckWrapper<AdamantApiCore>,
+        healthCheckWrapper: AdamantHealthCheck,
         adamantCore: AdamantCore
     ) {
         service = healthCheckWrapper
@@ -26,23 +37,30 @@ public final class AdamantApiService: @unchecked Sendable {
         waitsForConnectivity: Bool = false,
         _ request: @Sendable @escaping (APICoreProtocol, NodeOrigin) async -> ApiServiceResult<Output>
     ) async -> ApiServiceResult<Output> {
+        let taskId: UUID = .init()
         let task = AdamantApiTask<Output>(
             task: Task {
                 await service.request(
-                    waitsForConnectivity: waitsForConnectivity
-                ) { admApiCore, origin in
-                    let result = await request(admApiCore.apiCore, origin)
-                    do {
-                        try Task.checkCancellation()
-                    } catch {
-                        return .failure(.requestCancelled)
+                    waitsForConnectivity: waitsForConnectivity,
+                    taskId: taskId,
+                    isCancelled: {
+                        adamantApiTaskStorage[taskId]?.isCancelled
+                        ?? true
                     }
-                    return result
+                ) { admApiCore, origin in
+                    return await request(admApiCore.apiCore, origin)
                 }
             }
         )
-        task.storeIn(taskStorage: &adamantApiTaskStorage)
-        defer { task.removeFrom(taskStorage: &adamantApiTaskStorage) }
+        task.id = taskId
+        _adamantApiTaskStorage.mutate { storage in
+            storage[taskId] = task
+        }
+        defer {
+            _adamantApiTaskStorage.mutate { storage in
+                storage[taskId] = nil
+            }
+        }
         return await task.value
     }
 
@@ -61,4 +79,50 @@ extension AdamantApiService: AdamantApiServiceProtocol {
     public var nodesInfo: NodesListInfo { service.nodesInfo }
 
     public func healthCheck() { service.healthCheck() }
+}
+
+public final class AdamantHealthCheck: BlockchainHealthCheckWrapper<AdamantApiCore> {
+    func request<Output>(
+        waitsForConnectivity: Bool,
+        taskId: UUID,
+        isCancelled: () -> Bool,
+        _ requestAction: (AdamantApiCore, NodeOrigin) async -> Result<Output, AdamantApiCore.Error>
+    ) async -> Result<Output, AdamantApiCore.Error> {
+        var usedNodesIds: Set<UUID> = .init()
+        var lastConnectionError: Error?
+        
+        /// Check the cancellation of the task from the outside
+        guard !isCancelled() else {
+            return .failure(.requestCancelled)
+        }
+
+        while true {
+            let node = await nodesForRequest(waitsForConnectivity: waitsForConnectivity)
+                .first { !usedNodesIds.contains($0.id) }
+
+            guard let node else { break }
+            usedNodesIds.insert(node.id)
+            let response = await requestAction(service, node.preferredOrigin)
+
+            switch response {
+            case .success:
+                return response
+            case let .failure(error):
+                guard error.isNetworkError else { return response }
+                lastConnectionError = error
+            }
+        }
+        
+        healthCheck()
+
+        lastConnectionError =
+            lastConnectionError
+            ?? (nodes.contains { $0.isEnabled }
+                ? ApiServiceError.noNetworkError
+                : ApiServiceError.noEndpointsError(nodeGroupName: name))
+        
+        return await waitsForConnectivity
+        ? request(waitsForConnectivity: waitsForConnectivity, taskId: taskId, isCancelled: isCancelled, requestAction)
+        : .failure(lastConnectionError as? AdamantApiCore.Error ?? .noEndpointsAvailable(nodeGroupName: name))
+    }
 }

--- a/CommonKit/Sources/CommonKit/Services/HealthCheck/BlockchainHealthCheckWrapper.swift
+++ b/CommonKit/Sources/CommonKit/Services/HealthCheck/BlockchainHealthCheckWrapper.swift
@@ -15,7 +15,7 @@ public protocol BlockchainHealthCheckableService {
 }
 
 @HealthCheckActor
-public final class BlockchainHealthCheckWrapper<
+open class BlockchainHealthCheckWrapper<
     Service: BlockchainHealthCheckableService
 >: HealthCheckWrapper<Service, Service.Error>, Sendable {
     private let nodesStorage: NodesStorageProtocol

--- a/CommonKit/Sources/CommonKit/Services/HealthCheck/HealthCheckWrapper.swift
+++ b/CommonKit/Sources/CommonKit/Services/HealthCheck/HealthCheckWrapper.swift
@@ -113,6 +113,12 @@ open class HealthCheckWrapper<Service: Sendable, Error: HealthCheckableError>: S
         updateSortedNodes()
     }
 
+    func nodesForRequest(waitsForConnectivity: Bool) async -> [Node] {
+        await $sortedAllowedNodes.values.first {
+            !waitsForConnectivity || !$0.isEmpty
+        } ?? .init()
+    }
+
     nonisolated public func healthCheck() {
         Task { @HealthCheckActor in
             guard canPerformHealthCheck else { return }
@@ -176,12 +182,6 @@ extension HealthCheckWrapper {
             .notifications(named: UIApplication.willResignActiveNotification, object: nil)
             .sink { @HealthCheckActor [weak self] _ in self?.willResignActiveAction() }
             .store(in: &subscriptions)
-    }
-
-    fileprivate func nodesForRequest(waitsForConnectivity: Bool) async -> [Node] {
-        await $sortedAllowedNodes.values.first {
-            !waitsForConnectivity || !$0.isEmpty
-        } ?? .init()
     }
 
     fileprivate func updateHealthCheckTimerSubscription() {


### PR DESCRIPTION

 I need to override HealthCheckWrapped because now we have an option to cancel the tasks
 and there is some situations when we are waiting for a connection on the node and recursively calling `request`
 function without any break condition and that is bad and unsafe. I've added a functionality of pushing the associated with the task `UUID`
 and checking it for a cancellation before doing something in the recursive function
 `request(waitsForConnectivity:taskId:isCancelled:_ request:)` 