### PR TITLE
[trello.com/c/ONt29HWW] Save the index of the current selected crypto in a carousel when switching between secrets and regular.

### DIFF
--- a/Adamant/Modules/Account/AccountViewController/AccountViewController.swift
+++ b/Adamant/Modules/Account/AccountViewController/AccountViewController.swift
@@ -184,6 +184,9 @@ final class AccountViewController: FormViewController {
                 guard let self = self else { return }
                 self.setupWalletsVC()
                 self.pagingViewController.reloadData()
+                if let pagingItemIndex = currentSelectedWallet?.identifier {
+                    self.pagingViewController.select(index: pagingItemIndex, animated: false)
+                }
                 guard index >= 0 else { return }
                 self.accountHeaderView.setWalletIcon(index == 0 ? .regular : .secret, badgeCount: index)
             }


### PR DESCRIPTION
By default, reloadData resets the currently selected item index.
My approach is to re-select the item after the reload.