### PR TITLE
[trello.com/c/GgZUutG3] Increase paddings on User agreement screen

### DIFF
--- a/Adamant/Modules/Onboard/EulaViewController.xib
+++ b/Adamant/Modules/Onboard/EulaViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,7 +27,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Text" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u9T-NN-FZw" customClass="ReadonlyTextView" customModule="Adamant" customModuleProvider="target">
-                    <rect key="frame" x="16" y="44" width="382" height="770"/>
+                    <rect key="frame" x="24" y="56" width="366" height="758"/>
                     <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <fontDescription key="fontDescription" name="Exo2-Regular" family="Exo 2" pointSize="16"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -71,12 +71,12 @@
             <constraints>
                 <constraint firstItem="okW-9c-qaM" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="Bb4-c2-n3a"/>
                 <constraint firstAttribute="centerX" secondItem="yEd-IT-sBf" secondAttribute="trailing" constant="4" id="GcX-88-dew"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="u9T-NN-FZw" secondAttribute="trailing" constant="16" id="Pmu-v0-bgu"/>
-                <constraint firstItem="u9T-NN-FZw" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="ZNp-uc-7Pw"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="u9T-NN-FZw" secondAttribute="trailing" constant="24" id="Pmu-v0-bgu"/>
+                <constraint firstItem="u9T-NN-FZw" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="8" id="ZNp-uc-7Pw"/>
                 <constraint firstItem="yEd-IT-sBf" firstAttribute="top" secondItem="u9T-NN-FZw" secondAttribute="bottom" constant="8" id="b6a-XQ-A3v"/>
                 <constraint firstItem="okW-9c-qaM" firstAttribute="leading" secondItem="yEd-IT-sBf" secondAttribute="trailing" constant="8" id="dE9-tr-0Zz"/>
                 <constraint firstItem="yEd-IT-sBf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="gL5-3O-p23"/>
-                <constraint firstItem="u9T-NN-FZw" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="gVs-GI-i2w"/>
+                <constraint firstItem="u9T-NN-FZw" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="24" id="gVs-GI-i2w"/>
                 <constraint firstItem="yEd-IT-sBf" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="smu-qU-sjv"/>
                 <constraint firstItem="okW-9c-qaM" firstAttribute="top" secondItem="u9T-NN-FZw" secondAttribute="bottom" constant="8" id="uEh-iI-J1g"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="okW-9c-qaM" secondAttribute="trailing" constant="20" id="vi5-Kr-WS2"/>

--- a/Adamant/Modules/Onboard/EulaViewController.xib
+++ b/Adamant/Modules/Onboard/EulaViewController.xib
@@ -27,7 +27,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Text" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u9T-NN-FZw" customClass="ReadonlyTextView" customModule="Adamant" customModuleProvider="target">
-                    <rect key="frame" x="24" y="56" width="366" height="758"/>
+                    <rect key="frame" x="24" y="64" width="366" height="750"/>
                     <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <fontDescription key="fontDescription" name="Exo2-Regular" family="Exo 2" pointSize="16"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -36,7 +36,7 @@
                     </userDefinedRuntimeAttributes>
                 </textView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="okW-9c-qaM">
-                    <rect key="frame" x="211" y="822" width="183" height="40"/>
+                    <rect key="frame" x="211" y="818" width="183" height="40"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="40" id="azc-H1-2Lv"/>
                     </constraints>
@@ -53,7 +53,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yEd-IT-sBf">
-                    <rect key="frame" x="20" y="822" width="183" height="40"/>
+                    <rect key="frame" x="20" y="818" width="183" height="40"/>
                     <fontDescription key="fontDescription" name="Exo2-Regular" family="Exo 2" pointSize="18"/>
                     <state key="normal" title="Decline">
                         <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -69,16 +69,16 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="okW-9c-qaM" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="Bb4-c2-n3a"/>
+                <constraint firstItem="okW-9c-qaM" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" constant="-4" id="Bb4-c2-n3a"/>
                 <constraint firstAttribute="centerX" secondItem="yEd-IT-sBf" secondAttribute="trailing" constant="4" id="GcX-88-dew"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="u9T-NN-FZw" secondAttribute="trailing" constant="24" id="Pmu-v0-bgu"/>
-                <constraint firstItem="u9T-NN-FZw" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="8" id="ZNp-uc-7Pw"/>
-                <constraint firstItem="yEd-IT-sBf" firstAttribute="top" secondItem="u9T-NN-FZw" secondAttribute="bottom" constant="8" id="b6a-XQ-A3v"/>
+                <constraint firstItem="u9T-NN-FZw" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="ZNp-uc-7Pw"/>
+                <constraint firstItem="yEd-IT-sBf" firstAttribute="top" secondItem="u9T-NN-FZw" secondAttribute="bottom" constant="4" id="b6a-XQ-A3v"/>
                 <constraint firstItem="okW-9c-qaM" firstAttribute="leading" secondItem="yEd-IT-sBf" secondAttribute="trailing" constant="8" id="dE9-tr-0Zz"/>
                 <constraint firstItem="yEd-IT-sBf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="gL5-3O-p23"/>
                 <constraint firstItem="u9T-NN-FZw" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="24" id="gVs-GI-i2w"/>
-                <constraint firstItem="yEd-IT-sBf" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="smu-qU-sjv"/>
-                <constraint firstItem="okW-9c-qaM" firstAttribute="top" secondItem="u9T-NN-FZw" secondAttribute="bottom" constant="8" id="uEh-iI-J1g"/>
+                <constraint firstItem="yEd-IT-sBf" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" constant="-4" id="smu-qU-sjv"/>
+                <constraint firstItem="okW-9c-qaM" firstAttribute="top" secondItem="u9T-NN-FZw" secondAttribute="bottom" constant="4" id="uEh-iI-J1g"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="okW-9c-qaM" secondAttribute="trailing" constant="20" id="vi5-Kr-WS2"/>
             </constraints>
             <point key="canvasLocation" x="131.8840579710145" y="81.696428571428569"/>


### PR DESCRIPTION
Before:
<img width="807" alt="Screenshot 2025-04-11 at 10 27 37 AM" src="https://github.com/user-attachments/assets/43be082c-7f75-49ba-8024-53a57dcefe99" />


Commit 1:
<img width="807" alt="Screenshot 2025-04-11 at 10 28 10 AM" src="https://github.com/user-attachments/assets/ebaf42b7-17c5-402c-9d54-6aa74d8fa788" />

Commit 2:
<img width="807" alt="Screenshot 2025-04-11 at 11 29 31 AM" src="https://github.com/user-attachments/assets/3ee23ee6-90f8-4898-9e84-859dc4a97672" />

