### PR TITLE
[trello.com/c/QBfqpo6A] Allow more side panel width on macOS

### DIFF
--- a/Adamant/App/AppDelegate.swift
+++ b/Adamant/App/AppDelegate.swift
@@ -766,5 +766,16 @@ private enum TabScreens {
 private func makeSplitController() -> UISplitViewController {
     let controller = UISplitViewController()
     controller.preferredDisplayMode = .oneBesideSecondary
+    
+    // Set the default ratio to 1:2
+    controller.preferredPrimaryColumnWidthFraction = 0.3337
+    
+    let minimumPrimaryColumnWidth: CGFloat = UIScreen.main.bounds.width * 0.2
+    // Set the minimum ratio to 1:5, or to 300px if 1:5 results in a smaller value
+    controller.minimumPrimaryColumnWidth = minimumPrimaryColumnWidth > 300 ? minimumPrimaryColumnWidth : 300
+    
+    // Set the maximum ratio to 3:1
+    controller.maximumPrimaryColumnWidth = UIScreen.main.bounds.width * 0.75
+    
     return controller
 }


### PR DESCRIPTION
* Setting the default ratio to 1:2
* Setting the minimum ratio to 1:5, or to 300px if 1:5 results in a smaller value
* Setting the maximum ratio to 3:1