### PR TITLE
[trello.com/c/aedpNhWv] move avatar generate and set to main thread

### DIFF
--- a/Adamant/Modules/ChatsList/ChatListViewController.swift
+++ b/Adamant/Modules/ChatsList/ChatListViewController.swift
@@ -707,13 +707,8 @@ extension ChatListViewController {
                 cell.avatarImageView.tintColor = UIColor.adamant.primary
             } else {
                 if let address = partner.publicKey {
-                    DispatchQueue.global().async {
-                        let image = self.avatarService.avatar(for: address, size: 200)
-                        DispatchQueue.main.async {
-                            cell.avatarImage = image
-                        }
-                    }
-
+                    let image = self.avatarService.avatar(for: address, size: 200)
+                    cell.avatarImage = image
                     cell.avatarImageView.roundingMode = .round
                     cell.avatarImageView.clipsToBounds = true
                 } else {


### PR DESCRIPTION
Because the avatars were generated in the global queue and assigned in a different runloop than the rest of the cell, there were visual flickering of the avatars. I test on my iphone 15 pro and in debug each avatar was created for like 0.002 sec, so it should be ok to do it on main queue