### PR TITLE
[trello.com/c/TOuHqbBz] update readedLastHeight immediately after reading the message

### DIFF
--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -428,6 +428,7 @@ final class ChatViewModel: NSObject {
         let message = _messages.wrappedValue[index]
         Task {
             await chatsProvider.markMessageAsRead(chatroom: chatroom, message: message.messageId)
+            await _ = chatsProvider.update(notifyState: true)
         }
     }
 

--- a/Adamant/Modules/ChatsList/ChatListViewController.swift
+++ b/Adamant/Modules/ChatsList/ChatListViewController.swift
@@ -1290,6 +1290,9 @@ extension ChatListViewController {
             if chatroom.hasUnreadMessages {
                 chatroom.markAsReaded()
                 self.removeManualAdress(adress: adress)
+                Task {
+                    await self.chatsProvider.update(notifyState: true)
+                }
             } else {
                 chatroom.markAsUnread()
                 self.chatsManuallyMarkedAsUnread.insert(adress)


### PR DESCRIPTION
fix bug when you open chat to read message and close app after this, reading didnt store to keychain because before that it can be updated only by chat list timer