### PR TITLE
[trello.com/c/iGILackD] animate reaction and message separate

### DIFF
--- a/Adamant/App/AppDelegate.swift
+++ b/Adamant/App/AppDelegate.swift
@@ -409,7 +409,7 @@ extension AppDelegate {
         chatListNav.dismiss(animated: true, completion: nil)
         tabbar.selectedIndex = 0
 
-        let vc = chatListVC.chatViewController(for: chatroom, with: transactionID)
+        let vc = chatListVC.chatViewController(for: chatroom, with: transactionID, animateMessageType: .message)
 
         vc.hidesBottomBarWhenPushed = true
 

--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -425,7 +425,7 @@ extension ChatViewController {
             .sink { [weak self] in self?.processFileToolbarView($0) }
             .store(in: &subscriptions)
 
-        viewModel.$scrollToIdAndPosition
+        viewModel.$scrollToId
             .sink { [weak self] in
                 guard let id = $0
                 else { return }
@@ -779,6 +779,7 @@ extension ChatViewController {
         state.isMessagesLoaded = true
         if viewModel.messageIdToShow == nil {
             if let unreadMessage = viewModel.unreadMessagesIds?.first {
+                viewModel.animationType = MessageAnimationType.none
                 scrollToPosition(.messageId(unreadMessage), setExtraOffset: true, scrollAt: .top)
             }
         }
@@ -862,6 +863,7 @@ extension ChatViewController {
                 state.isScrollingToBottom = true
                 self.messagesCollectionView.scrollToBottom(animated: true)
             } else if let id = viewModel.unreadMessagesIds?.first {
+                viewModel.animationType = MessageAnimationType.none
                 self.scrollToPosition(.messageId(id), animated: true)
                 viewModel.shouldScrollToBottom = true
             }
@@ -877,6 +879,7 @@ extension ChatViewController {
                 let unreadId = self.viewModel.messagesWithUnredReactionsIds?.last
             else { return }
             state.isAnimatingCellHighlight = false
+            viewModel.animationType = .reaction
             viewModel.scroll(to: unreadId)
         }
         button.alpha = 0
@@ -936,7 +939,9 @@ extension ChatViewController {
     }
 
     @MainActor
-    fileprivate func scrollToPosition(_ position: ChatStartPosition, animated: Bool = false, setExtraOffset: Bool = false, scrollAt: UICollectionView.ScrollPosition = .centeredVertically) {
+    fileprivate func scrollToPosition(_ position: ChatStartPosition,
+                                      animated: Bool = false,
+                                      setExtraOffset: Bool = false, scrollAt: UICollectionView.ScrollPosition = .centeredVertically) {
         chatMessagesCollectionView.fixedBottomOffset = nil
 
         switch position {
@@ -965,7 +970,7 @@ extension ChatViewController {
                 at: scrollAt,
                 animated: animated
             )
-
+            
             if setExtraOffset && !animated {
                 if checkIfNeedExtraOffsetForUnreadMessages() {
                     setExtraOffsetForNewMessages()
@@ -973,10 +978,12 @@ extension ChatViewController {
                 state.isAutoScrolling = false
             }
 
-            viewModel.cellIdForAnimation =
-                needToAnimateCell
-                ? id
-                : nil
+            if viewModel.animationType != MessageAnimationType.none {
+                viewModel.cellIdForAnimation =
+                needToAnimateCell ? id : nil
+                //if we will not trigger didEndScrolling
+                animateCell(at: .init(item: .zero, section: index))
+            }
 
             guard animated else { break }
 
@@ -1294,9 +1301,18 @@ extension ChatViewController {
                 self.state.isAnimatingCellHighlight = false
                 return
             }
-            
-            cell.animateMessageHighlight()
-            self.viewModel.shortVibro()
+            switch viewModel.animationType {
+            case .message:
+                cell.animateMessageHighlight()
+                viewModel.shortVibro()
+            case .reaction:
+                cell.animateReactionHighlight()
+                viewModel.shortVibro()
+            case nil:
+                break
+            case .some(.none):
+                break
+            }
             self.viewModel.cellIdForAnimation = nil
             self.state.isAnimatingCellHighlight = false
         }
@@ -1309,3 +1325,4 @@ private let messagePadding: CGFloat = 12
 private let filesToolbarViewHeight: CGFloat = 140
 private let targetYOffset: CGFloat = 20
 private let scrollButtonHeight: CGFloat = 30
+

--- a/Adamant/Modules/Chat/View/Helpers/AdamantCellAnimation.swift
+++ b/Adamant/Modules/Chat/View/Helpers/AdamantCellAnimation.swift
@@ -35,21 +35,6 @@ extension UIView {
         layer.cornerRadius = cornerRadius
     }
     
-    func animateHighlight(
-        highlightColor: UIColor = UIColor.adamant.active.withAlphaComponent(0.5),
-        duration: TimeInterval = 2.5
-    ) {
-        let originalColor = self.backgroundColor
-        
-        UIView.animate(withDuration: 0.35, animations: {
-            self.backgroundColor = highlightColor
-        }, completion: { _ in
-            UIView.animate(withDuration: duration - 0.35) {
-                self.backgroundColor = originalColor
-            }
-        })
-    }
-    
     func animateHighlightOverlay(
         overlayColor: UIColor = UIColor.adamant.active.withAlphaComponent(0.5)
     ) {

--- a/Adamant/Modules/Chat/View/Subviews/ChatBaseMessage/ChatMessageCell.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatBaseMessage/ChatMessageCell.swift
@@ -566,7 +566,10 @@ extension ChatMessageCell {
 
 extension ChatMessageCell: ChatCellProtocol {
     func animateMessageHighlight() {
-        messageContainerView.animateHighlight()
+        messageContainerView.animateHighlightOverlay()
+    }
+    func animateReactionHighlight() {
+        opponentReactionLabel.animateHighlightOverlay()
     }
 }
 

--- a/Adamant/Modules/Chat/View/Subviews/ChatCellProtocol.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatCellProtocol.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol ChatCellProtocol {
     func animateMessageHighlight()
+    func animateReactionHighlight()
 }

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/ChatMediaCell.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/ChatMediaCell.swift
@@ -127,6 +127,10 @@ extension ChatMediaCell {
 }
 
 extension ChatMediaCell: ChatCellProtocol {
+    func animateReactionHighlight() {
+        containerMediaView.animateReactionHighlight()
+    }
+    
     func animateMessageHighlight() {
         containerMediaView.animateMediaHighlight()
     }

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
@@ -248,6 +248,10 @@ extension ChatMediaContainerView {
     func animateMediaHighlight() {
         contentView.animateHighlightOverlay()
     }
+    
+    func animateReactionHighlight() {
+        opponentReactionLabel.animateHighlightOverlay()
+    }
 }
 
 extension ChatMediaContainerView: ChatMenuManagerDelegate {

--- a/Adamant/Modules/Chat/View/Subviews/ChatReply/ChatMessageReplyCell.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatReply/ChatMessageReplyCell.swift
@@ -682,7 +682,11 @@ extension ChatMessageReplyCell {
 
 extension ChatMessageReplyCell: ChatCellProtocol {
     func animateMessageHighlight() {
-        messageContainerView.animateHighlight()
+        messageContainerView.animateHighlightOverlay()
+    }
+    
+    func animateReactionHighlight() {
+        opponentReactionLabel.animateHighlightOverlay()
     }
 }
 

--- a/Adamant/Modules/Chat/View/Subviews/ChatTransaction/ChatTransactionCell.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatTransaction/ChatTransactionCell.swift
@@ -103,6 +103,10 @@ extension ChatTransactionCell {
 }
 
 extension ChatTransactionCell: ChatCellProtocol {
+    func animateReactionHighlight() {
+        transactionView.animateReactionHighlight()
+    }
+    
     func animateMessageHighlight() {
         transactionView.animateTransactionHighlight()
     }

--- a/Adamant/Modules/Chat/View/Subviews/ChatTransaction/Container/ChatTransactionContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatTransaction/Container/ChatTransactionContainerView.swift
@@ -378,6 +378,10 @@ extension ChatTransactionContainerView {
 
 extension ChatTransactionContainerView {
     func animateTransactionHighlight() {
-        contentView.animateHighlight()
+        contentView.animateHighlightOverlay()
+    }
+    
+    func animateReactionHighlight() {
+        opponentReactionLabel.animateHighlightOverlay()
     }
 }

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -91,6 +91,7 @@ final class ChatViewModel: NSObject {
     let minOffsetForStartLoadNewMessages: CGFloat = 100
     var tempOffsets: [String] = []
     var cellIdForAnimation: String?
+    var animationType: MessageAnimationType?
     var indexPathsForVisibleItems: () -> [IndexPath] = { .init() }
     var scrolledMessageId: Set<String>?
     var shouldScrollToBottom: Bool = true
@@ -135,7 +136,7 @@ final class ChatViewModel: NSObject {
     @ObservableValue private(set) var dateHeaderHidden: Bool = true
     @ObservableValue var inputText = ""
     @ObservableValue var replyMessage: MessageModel?
-    @ObservableValue var scrollToIdAndPosition: String?
+    @ObservableValue var scrollToId: String?
     @ObservableValue var filesPicked: [FileResult]? {
         didSet {
             updateFeeValue()
@@ -227,9 +228,11 @@ final class ChatViewModel: NSObject {
         account: AdamantAccount?,
         chatroom: Chatroom,
         messageIdToShow: String?,
-        isNewChat: Bool = false
+        isNewChat: Bool = false,
+        messageAnimationType: MessageAnimationType = MessageAnimationType.none
     ) {
         self.messageIdToShow = messageIdToShow
+        animationType = messageAnimationType
         assert(self.chatroom == nil, "Can't setup several times")
         self.chatroom = chatroom
         self.chatroom?.updateLastTransaction()
@@ -545,7 +548,7 @@ final class ChatViewModel: NSObject {
                 }
 
                 await waitForMessage(withId: messageId)
-                scrollToIdAndPosition = messageId
+                scrollToId = messageId
                 
                 dialog.send(.progress(false))
                 if let index = messages.firstIndex(where: { $0.id == messageId }) {
@@ -1994,4 +1997,10 @@ extension ChatViewModel: ElegantEmojiPickerDelegate {
             reactAction(previousArg.messageId, emoji: emoji)
         }
     }
+}
+
+enum MessageAnimationType {
+    case message
+    case reaction
+    case none
 }

--- a/Adamant/Modules/ChatsList/ChatListViewController.swift
+++ b/Adamant/Modules/ChatsList/ChatListViewController.swift
@@ -437,7 +437,8 @@ final class ChatListViewController: KeyboardObservingViewController {
     func chatViewController(
         for chatroom: Chatroom,
         with messageId: String? = nil,
-        newChat: Bool = false
+        newChat: Bool = false,
+        animateMessageType: MessageAnimationType = MessageAnimationType.none
     ) -> ChatViewController {
         let vc = screensFactory.makeChat()
         vc.hidesBottomBarWhenPushed = true
@@ -445,7 +446,8 @@ final class ChatListViewController: KeyboardObservingViewController {
             account: accountService.account,
             chatroom: chatroom,
             messageIdToShow: messageId,
-            isNewChat: newChat
+            isNewChat: newChat,
+            messageAnimationType: animateMessageType
         )
 
         return vc
@@ -958,23 +960,27 @@ extension ChatListViewController {
                 message: text?.string,
                 image: image
             ) { [weak self] in
-                self?.presentChatroom(chatroom, with: self?.messageId(transaction: transaction))
+                guard let self else { return }
+                let idAndAnimationType: (String, MessageAnimationType) = self.messageId(transaction: transaction)
+                
+                self.presentChatroom(chatroom, with: idAndAnimationType.0, animationType: idAndAnimationType.1)
             }
         }
     }
 
-    private func messageId(transaction: ChatTransaction) -> String? {
-        if let richTransaction = transaction as? RichMessageTransaction {
-            return richTransaction.getRichValue(for: RichContentKeys.react.reactto_id) ?? richTransaction.transactionId
+    private func messageId(transaction: ChatTransaction) -> (String, MessageAnimationType) {
+        if let richTransaction = transaction as? RichMessageTransaction,
+           let reactToId = richTransaction.getRichValue(for: RichContentKeys.react.reactto_id) {
+            return (reactToId, .reaction)
         } else {
-            return transaction.transactionId
+            return (transaction.transactionId, .message)
         }
     }
 
     @MainActor
-    func presentChatroom(_ chatroom: Chatroom, with message: String? = nil) {
+    func presentChatroom(_ chatroom: Chatroom, with message: String? = nil, animationType: MessageAnimationType) {
         // MARK: 1. Create and config ViewController
-        let vc = chatViewController(for: chatroom, with: message)
+        let vc = chatViewController(for: chatroom, with: message, animateMessageType: animationType)
 
         if let split = self.splitViewController, UIScreen.main.traitCollection.userInterfaceIdiom == .pad {
             let chat = UINavigationController(rootViewController: vc)
@@ -1606,7 +1612,7 @@ extension ChatListViewController: UISearchBarDelegate, UISearchResultsUpdating, 
                 tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
             }
 
-            presenter.presentChatroom(chatroom, with: message.transactionId)
+            presenter.presentChatroom(chatroom, with: message.transactionId, animationType: .message)
         }
     }
 
@@ -1624,7 +1630,7 @@ extension ChatListViewController: UISearchBarDelegate, UISearchResultsUpdating, 
                 tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
             }
 
-            presenter.presentChatroom(chatroom)
+            presenter.presentChatroom(chatroom, animationType: .none)
         }
     }
 


### PR DESCRIPTION
- add opponent reaction animation
- if the scroll goes to the reaction (including in app push notifications), the reaction is animated, the reaction itself without the message.  
- Now all cell animation is done through the overlay
- when scrolling down there is no longer a selection of the message and vibration