### PR TITLE
[trello.com/c/4QfDaVMi] Excessive token standard for ADM, BTC, ETH, DOGE, DASH, KLY

### DIFF
--- a/Adamant/Modules/Account/WalletCollectionViewCell.swift
+++ b/Adamant/Modules/Account/WalletCollectionViewCell.swift
@@ -50,7 +50,7 @@ private extension WalletCollectionViewCell {
     @MainActor
     func update(item: WalletCollectionViewCellModel) {
         currencyImageView.image = item.currencyImage
-        if item.currencyNetwork == item.currencySymbol {
+        if item.currencyNetwork == item.currencySymbol || item.currencySymbol == EthWalletService.currencySymbol {
             currencySymbolLabel.text = item.currencySymbol
         } else {
             let currencyFont = currencySymbolLabel.font ?? .systemFont(ofSize: 12)


### PR DESCRIPTION
Handle case for ETH which has currencySymbol different from the currencyNetwork while it still not a token.