### PR TITLE
[trello.com/c/dEf1yVQr/] Allow sending the first message faster

### DIFF
--- a/Adamant/App/AppDelegate.swift
+++ b/Adamant/App/AppDelegate.swift
@@ -175,7 +175,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         // MARK: 6 Reachability & Autoupdate
-        repeater = RepeaterService()
+        repeater = container.resolve(RepeaterService.self)
 
         // Configure reachability
         if let reachability = container.resolve(ReachabilityMonitor.self) {
@@ -257,11 +257,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } else {
             dialogService.showError(withMessage: "Failed to register TransfersProvider autoupdate. Please, report a bug", supportEmail: true, error: nil)
         }
-
-        if let accountService = container.resolve(AccountService.self) {
-            repeater.registerForegroundCall(label: "accountService", interval: 15, queue: .global(qos: .utility), callback: accountService.update)
-        } else {
-            dialogService.showError(withMessage: "Failed to register AccountService autoupdate. Please, report a bug", supportEmail: true, error: nil)
+        
+        // Setup wallet auto update
+        if let service = container.resolve(WalletAutoUpdateService.self) {
+            Task { await service.start()}
         }
 
         if let addressBookService = container.resolve(AddressBookService.self) {

--- a/Adamant/App/DI/AppAssembly.swift
+++ b/Adamant/App/DI/AppAssembly.swift
@@ -488,6 +488,18 @@ struct AppAssembly: MainThreadAssembly {
                 wallet.injectDependencies(from: container)
             }
         }
+        
+        container.register(RepeaterService.self){ _ in 
+            RepeaterService()
+        }.inObjectScope(.container)
+                           
+        container.register(WalletAutoUpdateService.self) {
+            WalletAutoUpdateService(
+                visibleWalletService: $0.resolve(VisibleWalletsService.self)!,
+                walletStoreServiceProvider: $0.resolve(WalletStoreServiceProviderProtocol.self)!,
+                repeaterService: $0.resolve(RepeaterService.self)!
+            )
+        }.inObjectScope(.container)
 
         // MARK: ApiService Compose
         container.register(ApiServiceComposeProtocol.self) {

--- a/Adamant/App/DI/AppAssembly.swift
+++ b/Adamant/App/DI/AppAssembly.swift
@@ -497,7 +497,8 @@ struct AppAssembly: MainThreadAssembly {
             WalletAutoUpdateService(
                 visibleWalletService: $0.resolve(VisibleWalletsService.self)!,
                 walletStoreServiceProvider: $0.resolve(WalletStoreServiceProviderProtocol.self)!,
-                repeaterService: $0.resolve(RepeaterService.self)!
+                repeaterService: $0.resolve(RepeaterService.self)!, 
+                accountService: $0.resolve(AccountService.self)!
             )
         }.inObjectScope(.container)
 

--- a/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
+++ b/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
@@ -94,7 +94,6 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
         loadWallets()
         setupView()
         addObservers()
-        updateBalances()
         setColors()
     }
 
@@ -147,8 +146,8 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
     }
 
     @objc private func updateBalances() {
-        refreshControl.endRefreshing()
         NotificationCenter.default.post(name: .AdamantAccountService.forceUpdateAllBalances, object: nil)
+        refreshControl.endRefreshing()
     }
 
     private func setupView() {

--- a/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
+++ b/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
@@ -144,13 +144,6 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
             .store(in: &subscriptions)
 
         NotificationCenter.default
-            .notifications(named: .AdamantAccountService.accountDataUpdated, object: nil)
-            .sink { @MainActor [weak self] _ in
-                self?.update()
-            }
-            .store(in: &subscriptions)
-
-        NotificationCenter.default
             .notifications(named: .AdamantAccountService.userLoggedOut, object: nil)
             .sink { @MainActor [weak self] _ in
                 self?.admWallet = nil

--- a/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
+++ b/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
@@ -242,13 +242,6 @@ final class BtcWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
             .store(in: &subscriptions)
 
         NotificationCenter.default
-            .notifications(named: .AdamantAccountService.accountDataUpdated, object: nil)
-            .sink { @MainActor [weak self] _ in
-                self?.update()
-            }
-            .store(in: &subscriptions)
-
-        NotificationCenter.default
             .notifications(named: .AdamantAccountService.userLoggedOut, object: nil)
             .sink { @MainActor [weak self] _ in
                 self?.btcWallet = nil

--- a/Adamant/Modules/Wallets/Dash/DashWalletService.swift
+++ b/Adamant/Modules/Wallets/Dash/DashWalletService.swift
@@ -190,13 +190,6 @@ final class DashWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
             .store(in: &subscriptions)
 
         NotificationCenter.default
-            .notifications(named: .AdamantAccountService.accountDataUpdated, object: nil)
-            .sink { @MainActor [weak self] _ in
-                self?.update()
-            }
-            .store(in: &subscriptions)
-
-        NotificationCenter.default
             .notifications(named: .AdamantAccountService.userLoggedOut, object: nil)
             .sink { @MainActor [weak self] _ in
                 self?.dashWallet = nil

--- a/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
+++ b/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
@@ -210,13 +210,6 @@ final class DogeWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
             .store(in: &subscriptions)
 
         NotificationCenter.default
-            .notifications(named: .AdamantAccountService.accountDataUpdated, object: nil)
-            .sink { @MainActor [weak self] _ in
-                self?.update()
-            }
-            .store(in: &subscriptions)
-
-        NotificationCenter.default
             .notifications(named: .AdamantAccountService.userLoggedOut, object: nil)
             .sink { @MainActor [weak self] _ in
                 self?.dogeWallet = nil

--- a/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
+++ b/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
@@ -247,13 +247,6 @@ final class EthWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, ERC2
             .store(in: &subscriptions)
 
         NotificationCenter.default
-            .notifications(named: .AdamantAccountService.accountDataUpdated, object: nil)
-            .sink { @MainActor [weak self] _ in
-                self?.update()
-            }
-            .store(in: &subscriptions)
-
-        NotificationCenter.default
             .notifications(named: .AdamantAccountService.userLoggedOut, object: nil)
             .sink { @MainActor [weak self] _ in
                 self?.ethWallet = nil

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
@@ -226,13 +226,6 @@ extension KlyWalletService {
             .store(in: &subscriptions)
 
         NotificationCenter.default
-            .notifications(named: .AdamantAccountService.accountDataUpdated, object: nil)
-            .sink { @MainActor [weak self] _ in
-                self?.update()
-            }
-            .store(in: &subscriptions)
-
-        NotificationCenter.default
             .notifications(named: .AdamantAccountService.userLoggedOut, object: nil)
             .sink { @MainActor [weak self] _ in
                 self?.klyWallet = nil

--- a/Adamant/ServiceProtocols/AccountService.swift
+++ b/Adamant/ServiceProtocols/AccountService.swift
@@ -162,6 +162,7 @@ protocol AccountService: AnyObject, Sendable {
 
     /// Update logged account info
     func update()
+    func updateOnlyADM()
     func updateWithRefreshUI()
     func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?)
 

--- a/Adamant/Services/AdamantAccountService.swift
+++ b/Adamant/Services/AdamantAccountService.swift
@@ -225,6 +225,10 @@ extension AdamantAccountService {
     func update() {
         self.update(nil)
     }
+    
+    func updateOnlyADM() {
+        self.update(nil, updateOnlyADM: true)
+    }
 
     func updateAll() {
         update(nil, updateOnlyVisible: false)
@@ -238,7 +242,7 @@ extension AdamantAccountService {
         update(nil, updateOnlyVisible: true, shouldUpdateUIBalance: true)
     }
 
-    func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?, updateOnlyVisible: Bool, shouldUpdateUIBalance: Bool = false) {
+    func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?, updateOnlyVisible: Bool = true, shouldUpdateUIBalance: Bool = false, updateOnlyADM: Bool = false) {
         switch state {
         case .notLogged, .isLoggingIn, .updating:
             return
@@ -253,8 +257,6 @@ extension AdamantAccountService {
         guard let loggedAccount = account, let publicKey = loggedAccount.publicKey else {
             return
         }
-
-        let wallets = walletServiceCompose.getWallets()
 
         Task { @Sendable in
             let result = await apiService.getAccount(byPublicKey: publicKey)
@@ -284,13 +286,17 @@ extension AdamantAccountService {
                 state = prevState
             }
         }
-
-        for wallet in wallets {
-            if !updateOnlyVisible || !(walletsStoreService?.isInvisible(wallet) ?? false) {
-                if shouldUpdateUIBalance {
-                    wallet.core.updateWithRefreshUIBalance()
-                } else {
-                    wallet.core.update()
+        
+        if !updateOnlyADM {
+            let wallets = walletServiceCompose.getWallets()
+            
+            for wallet in wallets {
+                if !updateOnlyVisible || !(walletsStoreService?.isInvisible(wallet) ?? false) {
+                    if shouldUpdateUIBalance {
+                        wallet.core.updateWithRefreshUIBalance()
+                    } else {
+                        wallet.core.update()
+                    }
                 }
             }
         }

--- a/Adamant/Services/AdamantVisibleWalletsService/AdamantVisibleWalletsService.swift
+++ b/Adamant/Services/AdamantVisibleWalletsService/AdamantVisibleWalletsService.swift
@@ -11,33 +11,33 @@ import CommonKit
 import Foundation
 
 final class AdamantVisibleWalletsService: VisibleWalletsService, @unchecked Sendable {
-
+    
     // MARK: Dependencies
     let SecureStore: SecureStore
     let accountService: AccountService
     let walletsServiceCompose: WalletServiceCompose
-
+    
     // MARK: Proprieties
-
+    
     private enum Types {
         case indexes
         case visibility
-
+        
         var path: String {
             switch self {
-            case .indexes: return StoreKey.visibleWallets.useCustomIndexes
-            case .visibility: return StoreKey.visibleWallets.useCustomVisibility
+                case .indexes: return StoreKey.visibleWallets.useCustomIndexes
+                case .visibility: return StoreKey.visibleWallets.useCustomVisibility
             }
         }
     }
-
+    
     @Atomic private var notificationsSet: Set<AnyCancellable> = []
-
+    
     @ObservableValue private var state: AdamantVisibleWalletsServiceState
     var statePublisher: AnyObservable<Void> {
         $state.map { _ in }.eraseToAnyPublisher()
     }
-
+    
     // MARK: Lifecycle
     init(
         SecureStore: SecureStore,
@@ -48,14 +48,14 @@ final class AdamantVisibleWalletsService: VisibleWalletsService, @unchecked Send
         self.accountService = accountService
         self.walletsServiceCompose = walletsServiceCompose
         self.state = .init()
-
+        
         NotificationCenter.default
             .notifications(named: .AdamantAccountService.userLoggedOut)
             .sink { [weak self] _ in
                 self?.userLoggedOut()
             }
             .store(in: &notificationsSet)
-
+        
         NotificationCenter.default
             .notifications(named: .AdamantAccountService.userLoggedIn)
             .sink { [weak self] _ in
@@ -63,14 +63,14 @@ final class AdamantVisibleWalletsService: VisibleWalletsService, @unchecked Send
             }
             .store(in: &notificationsSet)
     }
-
+    
     // MARK: Notification actions
-
+    
     private func userLoggedIn() {
         state.invisibleWallets = getInvisibleWallets()
         state.indexesWallets = getSortedWallets(includeInvisible: false)
     }
-
+    
     private func userLoggedOut() {
         SecureStore.remove(StoreKey.visibleWallets.invisibleWallets)
         SecureStore.remove(StoreKey.visibleWallets.indexWallets)
@@ -79,22 +79,22 @@ final class AdamantVisibleWalletsService: VisibleWalletsService, @unchecked Send
         state.invisibleWallets.removeAll()
         state.indexesWallets.removeAll()
     }
-
+    
     // MARK: Visible
-
+    
     func addToInvisibleWallets(_ walletTokenUniqueID: String) {
         var wallets = getInvisibleWallets()
         wallets.append(walletTokenUniqueID)
         setInvisibleWallets(wallets)
     }
-
+    
     func removeFromInvisibleWallets(_ walletTokenUniqueID: String) {
         var wallets = getInvisibleWallets()
         guard let index = wallets.firstIndex(of: walletTokenUniqueID) else { return }
         wallets.remove(at: index)
         setInvisibleWallets(wallets)
     }
-
+    
     private func getInvisibleWallets() -> [String] {
         guard isUseCustomFilter(for: .visibility) else {
             let wallets = walletsServiceCompose.getWallets()
@@ -102,83 +102,84 @@ final class AdamantVisibleWalletsService: VisibleWalletsService, @unchecked Send
                 .map { $0.core.tokenUniqueID }
             return wallets
         }
-
+        
         return SecureStore.get(StoreKey.visibleWallets.invisibleWallets) ?? []
     }
-
+    
     func isInvisible(_ walletTokenUniqueID: String) -> Bool {
         state.invisibleWallets.contains(walletTokenUniqueID)
     }
-
+    
     private func setInvisibleWallets(_ wallets: [String]) {
         SecureStore.set(wallets, for: StoreKey.visibleWallets.invisibleWallets)
         setUseCustomFilter(for: .visibility, value: true)
         state.invisibleWallets = getInvisibleWallets()
     }
-
+    
     // MARK: Index Positions
-
+    
     func getSortedWallets(includeInvisible: Bool) -> [String] {
         guard isUseCustomFilter(for: .indexes) else {
             // Sort by default ordinal number
             // Coins without an order are shown last, alphabetically
             let wallets = walletsServiceCompose.getWallets().map { $0.core }
             let walletsIV =
-                includeInvisible
-                ? wallets
-                : wallets.filter { $0.defaultVisibility == true }
-
+            includeInvisible
+            ? wallets
+            : wallets.filter { $0.defaultVisibility == true }
+            
+            
             var walletsWithIndexes =
-                walletsIV
+            walletsIV
                 .filter { $0.defaultOrdinalLevel != nil }
                 .sorted(by: { $0.defaultOrdinalLevel! < $1.defaultOrdinalLevel! })
             let walletsWithNoIndexes =
-                walletsIV
+            walletsIV
                 .filter { $0.defaultOrdinalLevel == nil }
                 .sorted(by: { $0.tokenName < $1.tokenName })
-
+            
             walletsWithIndexes.append(contentsOf: walletsWithNoIndexes)
-
+            
             return walletsWithIndexes.map { $0.tokenUniqueID }
         }
-
+        
         let path =
-            !includeInvisible
-            ? StoreKey.visibleWallets.indexWallets
-            : StoreKey.visibleWallets.indexWalletsWithInvisible
-
+        includeInvisible
+        ? StoreKey.visibleWallets.indexWalletsWithInvisible
+        : StoreKey.visibleWallets.indexWallets
+        
         guard let indexes: [String] = SecureStore.get(path) else {
             return []
         }
         return indexes
     }
-
+    
     func setIndexPositionWallets(_ wallets: [String], includeInvisible: Bool) {
         let path =
-            !includeInvisible
-            ? StoreKey.visibleWallets.indexWallets
-            : StoreKey.visibleWallets.indexWalletsWithInvisible
-
+        includeInvisible
+        ? StoreKey.visibleWallets.indexWalletsWithInvisible
+        : StoreKey.visibleWallets.indexWallets
+        
         SecureStore.set(wallets, for: path)
         state.indexesWallets = getSortedWallets(includeInvisible: false)
         setUseCustomFilter(for: .indexes, value: true)
-
+        
     }
-
+    
     func reset() {
         setUseCustomFilter(for: .indexes, value: false)
         setUseCustomFilter(for: .visibility, value: false)
         state.indexesWallets = getSortedWallets(includeInvisible: false)
         state.invisibleWallets = getInvisibleWallets()
     }
-
+    
     private func isUseCustomFilter(for type: Types) -> Bool {
         guard let result: Bool = SecureStore.get(type.path) else {
             return false
         }
         return result
     }
-
+    
     private func setUseCustomFilter(for type: Types, value: Bool) {
         SecureStore.set(value, for: type.path)
     }

--- a/Adamant/Services/RepeaterService.swift
+++ b/Adamant/Services/RepeaterService.swift
@@ -10,7 +10,7 @@ import CommonKit
 import Foundation
 
 final class RepeaterService {
-    private class Client: @unchecked Sendable {
+    private final class Client: @unchecked Sendable {
         let interval: TimeInterval
         let queue: DispatchQueue?
         var timer: Timer?

--- a/Adamant/Services/WalletAutoUpdaterService.swift
+++ b/Adamant/Services/WalletAutoUpdaterService.swift
@@ -1,0 +1,136 @@
+//
+//  WalletAutoUpdaterService.swift
+//  Adamant
+//
+//  Created by Dmitrij Meidus on 16.04.25.
+//  Copyright © 2025 Adamant. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+/// Actor responsible for managing and scheduling automatic wallet updates.
+///
+/// Listens to two primary event streams:
+/// 1. `visibleWalletService.statePublisher` — adjusts the set of active update tasks whenever wallet visibility changes.
+/// 2. `walletStoreServiceProvider.currentWalletPublisher` — fully reinitializes all update tasks whenever the underlying wallet list changes.
+///
+/// For each visible wallet, uses `repeaterService` to register or unregister a background callback
+/// `updateWithRefreshUIBalance()` at an interval determined by the wallet’s type.
+actor WalletAutoUpdateService {
+    private let visibleWalletService: VisibleWalletsService
+    private let walletStoreServiceProvider: WalletStoreServiceProviderProtocol
+    private let repeaterService: RepeaterService
+    
+    private var cancellables = Set<AnyCancellable>()
+    private var walletsRepetitions = Set<String>()
+    
+    init(
+        visibleWalletService: VisibleWalletsService,
+        walletStoreServiceProvider: WalletStoreServiceProviderProtocol,
+        repeaterService: RepeaterService
+    ) {
+        self.visibleWalletService = visibleWalletService
+        self.walletStoreServiceProvider = walletStoreServiceProvider
+        self.repeaterService = repeaterService
+    }
+    
+    func start(){
+        NotificationCenter.default
+            .notifications(named: .AdamantAccountService.userLoggedIn)
+            .sink { [weak self] _ in
+                Task {
+                    guard let self = self else { return }
+                    try? await Task.sleep(interval: 0.5)
+                    await self.setup()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func setup() async {
+        await walletStoreServiceProvider.currentWalletPublisher
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                Task {
+                    await self.reinit()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func reinit() async {
+        self.walletsRepetitions.removeAll()
+        visibleWalletService.statePublisher
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                Task { await self.updateRepetitions() }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func updateRepetitions() async {
+        let currentWallets = walletStoreServiceProvider.sorted(includeInvisible: false)
+        
+        let oldReps = walletsRepetitions
+        var newReps: Set<String> = []
+        
+        for wallet in currentWallets {
+            let id = wallet.core.tokenUniqueID
+            let core = wallet.core
+            newReps.insert(id)
+            guard !oldReps.contains(id) else {
+                continue 
+            }
+            
+            repeaterService.registerForegroundCall(
+                label: id,
+                interval: getTimeIntervalFor(wallet: core),
+                queue: .global(qos: .utility),
+                callback: {
+                    print("[\(Date())] " + "updating wallet: \(id)" + "\n----------------------")
+                    core.updateWithRefreshUIBalance()
+                }
+            )
+        }
+        
+        self.walletsRepetitions = newReps
+        
+        guard oldReps.count > 0 else { return }
+        
+        let toRemove = oldReps.subtracting(newReps)
+        for id in toRemove {
+            print("unregistering: \(id)")
+            repeaterService.unregisterForegroundCall(label: id)
+        }
+    }
+    
+    private func getTimeIntervalFor(wallet: WalletCoreProtocol) -> TimeInterval {
+        switch wallet {
+            case is AdmWalletService:
+                return WalletsUpdateConstants.adm.rawValue
+            case is EthWalletService:
+                return WalletsUpdateConstants.erc20.rawValue
+            case is ERC20WalletService:
+                return WalletsUpdateConstants.erc20.rawValue
+            case is DashWalletService:
+                return WalletsUpdateConstants.dash.rawValue
+            case is DogeWalletService:
+                return WalletsUpdateConstants.doge.rawValue
+            case is BtcWalletService:
+                return WalletsUpdateConstants.btc.rawValue
+            case is KlyWalletService:
+                return WalletsUpdateConstants.kly.rawValue
+            default:
+                return 50
+        }
+    }
+    
+    private enum WalletsUpdateConstants: TimeInterval {
+        case adm = 5
+        case erc20, dash = 25
+        case doge = 30
+        case btc, kly = 50
+        case admNewAccount = 2
+    }
+}

--- a/Adamant/Services/WalletAutoUpdaterService.swift
+++ b/Adamant/Services/WalletAutoUpdaterService.swift
@@ -23,6 +23,7 @@ actor WalletAutoUpdateService {
     private let repeaterService: RepeaterService
     
     private var cancellables = Set<AnyCancellable>()
+    private var notificationCancellables = Set<AnyCancellable>()
     private var walletsRepetitions = Set<String>()
     
     init(
@@ -45,7 +46,17 @@ actor WalletAutoUpdateService {
                     await self.setup()
                 }
             }
-            .store(in: &cancellables)
+            .store(in: &notificationCancellables)
+        
+        NotificationCenter.default
+            .notifications(named: .AdamantAccountService.userLoggedOut)
+            .sink { [weak self] _ in
+                Task {
+                    guard let self = self else { return }
+                    await self.removeState()
+                }
+            }
+            .store(in: &notificationCancellables)
     }
     
     private func setup() async {
@@ -103,6 +114,14 @@ actor WalletAutoUpdateService {
             print("unregistering: \(id)")
             repeaterService.unregisterForegroundCall(label: id)
         }
+    }
+    
+    func removeState() {
+        for id in walletsRepetitions {
+            repeaterService.unregisterForegroundCall(label: id)
+        }
+        walletsRepetitions.removeAll()
+        cancellables.removeAll()
     }
     
     private func getTimeIntervalFor(wallet: WalletCoreProtocol) -> TimeInterval {

--- a/Adamant/Services/WalletAutoUpdaterService.swift
+++ b/Adamant/Services/WalletAutoUpdaterService.swift
@@ -9,14 +9,20 @@
 import Foundation
 import Combine
 
-/// Actor responsible for managing and scheduling automatic wallet updates.
+/// Actor responsible for orchestrating automatic wallet updates throughout the app lifecycle.
 ///
-/// Listens to two primary event streams:
-/// 1. `visibleWalletService.statePublisher` — adjusts the set of active update tasks whenever wallet visibility changes.
-/// 2. `walletStoreServiceProvider.currentWalletPublisher` — fully reinitializes all update tasks whenever the underlying wallet list changes.
+/// After you call `start()`, it listens for:
+/// 1. **Login / Logout** via NotificationCenter:
+///    - On login it waits 0.5 s and then sets up subscriptions.
+///    - On logout it tears down all scheduling state.
+/// 2. **Wallet list changes** via `walletStoreServiceProvider.currentWalletPublisher`:
+///    - Fully reinitializes its internal wallet registry whenever the set of available wallets changes.
+/// 3. **Visibility changes** via `visibleWalletService.statePublisher`:
+///    - Adjusts which wallets are actively scheduled for periodic updates.
 ///
-/// For each visible wallet, uses `repeaterService` to register or unregister a background callback
-/// `updateWithRefreshUIBalance()` at an interval determined by the wallet’s type.
+/// For each visible wallet, it uses `repeaterService` to register a recurring `update()` call at a
+/// wallet‑type‑specific interval (shorter for new ADM accounts, longer for BTC/KLY, etc.), and
+/// unregisters any tasks when wallets go out of scope or the user logs out.
 actor WalletAutoUpdateService {
     private let visibleWalletService: VisibleWalletsService
     private let walletStoreServiceProvider: WalletStoreServiceProviderProtocol
@@ -103,8 +109,7 @@ actor WalletAutoUpdateService {
                 interval: getTimeIntervalFor(wallet: core),
                 queue: .global(qos: .utility),
                 callback: {
-                    print("[\(Date())] " + "updating wallet: \(id)" + "\n----------------------")
-                    core.updateWithRefreshUIBalance()
+                    core.update()
                 }
             )
         }
@@ -115,7 +120,6 @@ actor WalletAutoUpdateService {
         
         let toRemove = oldReps.subtracting(newReps)
         for id in toRemove {
-            print("unregistering: \(id)")
             repeaterService.unregisterForegroundCall(label: id)
         }
     }
@@ -132,31 +136,38 @@ actor WalletAutoUpdateService {
         switch wallet {
             case is AdmWalletService:
                 if let isNewAccount = accountService.account?.isNewAccount, isNewAccount {
-                    return WalletsUpdateConstants.admNewAccount.rawValue
+                    return WalletsUpdateConstants.admNewAccount.interval
                 }
-                return WalletsUpdateConstants.adm.rawValue
+                return WalletsUpdateConstants.adm.interval
             case is EthWalletService:
-                return WalletsUpdateConstants.erc20.rawValue
+                return WalletsUpdateConstants.erc20.interval
             case is ERC20WalletService:
-                return WalletsUpdateConstants.erc20.rawValue
+                return WalletsUpdateConstants.erc20.interval
             case is DashWalletService:
-                return WalletsUpdateConstants.dash.rawValue
+                return WalletsUpdateConstants.dash.interval
             case is DogeWalletService:
-                return WalletsUpdateConstants.doge.rawValue
+                return WalletsUpdateConstants.doge.interval
             case is BtcWalletService:
-                return WalletsUpdateConstants.btc.rawValue
+                return WalletsUpdateConstants.btc.interval
             case is KlyWalletService:
-                return WalletsUpdateConstants.kly.rawValue
+                return WalletsUpdateConstants.kly.interval
             default:
                 return 50
         }
     }
     
-    private enum WalletsUpdateConstants: TimeInterval {
-        case adm = 5
-        case erc20, dash = 25
-        case doge = 30
-        case btc, kly = 50
-        case admNewAccount = 2
+    private enum WalletsUpdateConstants {
+        case adm, erc20, dash, doge, btc, kly, admNewAccount
+        
+        var interval: TimeInterval {
+            switch self {
+                case .adm:              return 5
+                case .erc20, .dash:     return 25
+                case .doge:             return 30
+                case .btc, .kly:        return 50
+                case .admNewAccount:    return 2
+            }
+        }
     }
+
 }

--- a/Adamant/Services/WalletAutoUpdaterService.swift
+++ b/Adamant/Services/WalletAutoUpdaterService.swift
@@ -22,18 +22,22 @@ actor WalletAutoUpdateService {
     private let walletStoreServiceProvider: WalletStoreServiceProviderProtocol
     private let repeaterService: RepeaterService
     
+    private let accountService: AccountService
+    
     private var cancellables = Set<AnyCancellable>()
     private var notificationCancellables = Set<AnyCancellable>()
     private var walletsRepetitions = Set<String>()
     
-    init(
+   init(
         visibleWalletService: VisibleWalletsService,
         walletStoreServiceProvider: WalletStoreServiceProviderProtocol,
-        repeaterService: RepeaterService
+        repeaterService: RepeaterService,
+        accountService: AccountService
     ) {
         self.visibleWalletService = visibleWalletService
         self.walletStoreServiceProvider = walletStoreServiceProvider
         self.repeaterService = repeaterService
+        self.accountService = accountService
     }
     
     func start(){
@@ -127,6 +131,9 @@ actor WalletAutoUpdateService {
     private func getTimeIntervalFor(wallet: WalletCoreProtocol) -> TimeInterval {
         switch wallet {
             case is AdmWalletService:
+                if let isNewAccount = accountService.account?.isNewAccount, isNewAccount {
+                    return WalletsUpdateConstants.admNewAccount.rawValue
+                }
                 return WalletsUpdateConstants.adm.rawValue
             case is EthWalletService:
                 return WalletsUpdateConstants.erc20.rawValue

--- a/CommonKit/Sources/CommonKit/Core/SecuredStore.swift
+++ b/CommonKit/Sources/CommonKit/Core/SecuredStore.swift
@@ -34,7 +34,7 @@ extension StoreKey {
     public enum visibleWallets {
         public static let invisibleWallets = "invisible.wallets"
         public static let indexWallets = "index.wallets"
-        public static let indexWalletsWithInvisible = "index.wallets.include.ivisible"
+        public static let indexWalletsWithInvisible = "index.wallets.include.invisible"
         public static let useCustomIndexes = "visible.wallets.useCustomIndexes"
         public static let useCustomVisibility = "visible.wallets.useCustomVisibility"
     }

--- a/CommonKit/Sources/CommonKit/Models/AdamantAccount.swift
+++ b/CommonKit/Sources/CommonKit/Models/AdamantAccount.swift
@@ -99,6 +99,10 @@ extension AdamantAccount {
     public var isEnoughMoneyForTransaction: Bool {
         balance >= AdamantApiService.KvsFee
     }
+    
+    public var isNewAccount: Bool {
+        balance == 0 && unconfirmedBalance == 0
+    }
 }
 // MARK: - JSON
 /*


### PR DESCRIPTION
Introduce new service for wallets auto updates by interval. 

For new accounts ADM time update should be different. But instead of hard calculation is account new or not I decided to make different update for case where user does not have confirmed and uncorfirmed money. Almost always I think this case should work only for new accounts, while in case where it is not new - it even makes UX better. While we don;t need to implement correct calculation is account new or not for other parts pf the app.

Removed `NotificationCenter.default.notifications(named: .AdamantAccountService.accountDataUpdated` that was used to update wallets from account update, instead service is responsible for updates now. 

Because of legacy code instead of refactoring i added `updateOnlyADM` parameter for account update to keep wallets update in that place where it needs, but auto updates now trigger only from the new service. 

https://trello.com/c/A960REMF