### PR TITLE
[trello.com/c/aZtAfZ44] move updateUnreadMessages to another publisher

### DIFF
--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -340,6 +340,7 @@ extension ChatViewController {
         viewModel.messagesUpdated
             .sink { [weak self] _ in
                 self?.updateMessagesPosition()
+                self?.updateUnreadMessages()
             }
             .store(in: &subscriptions)
 
@@ -500,13 +501,6 @@ extension ChatViewController {
         viewModel.didTapSelectText
             .sink { [weak self] text in
                 self?.didTapSelectText(text: text)
-            }
-            .store(in: &subscriptions)
-
-        viewModel.$unreadMesaggesIndexes
-            .removeDuplicates()
-            .sink { [weak self] _ in
-                self?.updateUnreadMessages()
             }
             .store(in: &subscriptions)
 

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -553,8 +553,8 @@ final class ChatViewModel: NSObject {
                 scrollToId = messageId
                 
                 dialog.send(.progress(false))
-                if let index = messages.firstIndex(where: { $0.id == messageId }) {
-                    markMessageAsRead(index: index)
+                if let chatroom {
+                    await chatsProvider.markMessageAsRead(chatroom: chatroom, message: messageId)
                 }
             } catch {
                 print(error)

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -74,6 +74,7 @@ final class ChatViewModel: NSObject {
             updatePositionIfNeeded()
         }
     }
+    private(set) var unreadMesaggesIndexes: Set<Int>?
 
     private var tempCancellables = Set<AnyCancellable>()
     private var hideHeaderTimer: AnyCancellable?
@@ -123,7 +124,6 @@ final class ChatViewModel: NSObject {
     @ObservableValue private(set) var isHeaderLoading = false
     @ObservableValue private(set) var fullscreenLoading = false
     @ObservableValue private(set) var messages = [ChatMessage]()
-    @ObservableValue private(set) var unreadMesaggesIndexes: Set<Int>?
     @ObservableValue private(set) var unreadMessagesIds: OrderedSet<String>?
     @ObservableValue private(set) var messagesWithUnredReactionsIds: OrderedSet<String>?
     @ObservableValue private(set) var isAttachmentButtonAvailable = false


### PR DESCRIPTION
This helps when you first enter the chat to trigger additional reading and read messages in the visibility zone
In other scenarios this notification helps to update the reading of incoming reactions to visible messages, as the previous publisher did
Fix that sometimes reaction didnt read after tap to push on the other screen