### PR TITLE
[trello.com/c/HhqqTxCl] Fix work of onboarding points

### DIFF
--- a/Adamant/Modules/SwiftyOnboard/SwiftyOnboard.swift
+++ b/Adamant/Modules/SwiftyOnboard/SwiftyOnboard.swift
@@ -154,7 +154,7 @@ public class SwiftyOnboard: UIView, UIScrollViewDelegate {
                 let viewFrame = CGRect(x: 0, y: 0, width: self.frame.width, height: self.frame.height)
                 overlay.frame = viewFrame
                 self.overlay = overlay
-                self.overlay?.pageControl.addTarget(self, action: #selector(didTapPageControl), for: .allTouchEvents)
+                self.overlay?.pageControl.addTarget(self, action: #selector(didTapPageControl), for: .valueChanged)
             }
         }
     }


### PR DESCRIPTION
Before, when you touch onboarding points it could randomly move the current page to another (not with the same touch index). Here I fixed that. 