### PR TITLE
[trello.com/c/dEf1yVQr] Allow sending the first message faster

### DIFF
--- a/Adamant.xcodeproj/project.pbxproj
+++ b/Adamant.xcodeproj/project.pbxproj
@@ -204,13 +204,6 @@
 			);
 			target = E96D64DA2295CD4700CA5587 /* NotificationServiceExtension */;
 		};
-		D3A8618F2DA1C1AD0007B599 /* Exceptions for "NotificationServiceExtension" folder in "TransferNotificationContentExtension" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				WalletImages/bitcoin_notificationContent.png,
-			);
-			target = E957E12C229B10F80019732A /* TransferNotificationContentExtension */;
-		};
 		D3A861992DA1C1B10007B599 /* Exceptions for "TransferNotificationContentExtension" folder in "TransferNotificationContentExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -256,7 +249,6 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				D3A8618E2DA1C1AD0007B599 /* Exceptions for "NotificationServiceExtension" folder in "NotificationServiceExtension" target */,
-				D3A8618F2DA1C1AD0007B599 /* Exceptions for "NotificationServiceExtension" folder in "TransferNotificationContentExtension" target */,
 			);
 			path = NotificationServiceExtension;
 			sourceTree = "<group>";

--- a/Adamant/Modules/Account/AccountViewController/AccountViewController.swift
+++ b/Adamant/Modules/Account/AccountViewController/AccountViewController.swift
@@ -981,7 +981,7 @@ final class AccountViewController: FormViewController {
         }
         
         Task { @MainActor in
-            accountService.updateWithRefreshUI()
+            accountService.update(shouldUpdateUIBalance: true, updateOnlyADM: false, updateOnlyVisible: true)
         }
         refreshControl.endRefreshing()
     }

--- a/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
+++ b/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
@@ -103,8 +103,7 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
 
     private func addObservers() {
         for (index, wallet) in wallets.enumerated() {
-            NotificationCenter.default.publisher(for: wallet.walletUpdatedNotification, object: wallet)
-                .removeDuplicates()
+            wallet.walletUpdatePublisher
                 .receive(on: DispatchQueue.main)
                 .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
                 .sink { [weak self] _ in

--- a/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
+++ b/Adamant/Modules/Settings/VisibleWallets/VisibleWalletsViewController.swift
@@ -145,7 +145,7 @@ final class VisibleWalletsViewController: KeyboardObservingViewController {
     }
 
     @objc private func updateBalances() {
-        NotificationCenter.default.post(name: .AdamantAccountService.forceUpdateAllBalances, object: nil)
+        accountService.update(shouldUpdateUIBalance: true, updateOnlyADM: false, updateOnlyVisible: false)
         refreshControl.endRefreshing()
     }
 

--- a/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
+++ b/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
@@ -55,6 +55,18 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
     var qqPrefix: String {
         return Self.qqPrefix
     }
+    
+    var balanceCheckInterval: Int? {
+        Self.balanceCheckInterval
+    }
+    
+    var balanceValidInterval: Int? {
+        Self.balanceValidInterval
+    }
+    
+    var balanceCheckIntervalNewAccount: Int? {
+        Self.coinInfo?.balanceCheckIntervalNewAccount
+    }
 
     var nodeGroups: [NodeGroup] {
         [.adm]
@@ -130,7 +142,7 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
     // MARK: - Logic
     override init() {
         super.init()
-
+        
         // Notifications
         addObservers()
     }

--- a/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
+++ b/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
@@ -84,7 +84,6 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
     var vibroService: VibroService!
 
     // MARK: - Notifications
-    let walletUpdatedNotification = Notification.Name("adamant.admWallet.updated")
     let serviceEnabledChanged = Notification.Name("adamant.admWallet.enabledChanged")
     let transactionFeeUpdated = Notification.Name("adamant.admWallet.feeUpdated")
     let serviceStateChanged = Notification.Name("adamant.admWallet.stateChanged")
@@ -212,11 +211,6 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
     }
 
     private func postUpdateNotification(with wallet: WalletAccount) {
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-        )
         Task { @MainActor in
             walletUpdateSender.send()
         }

--- a/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
+++ b/Adamant/Modules/Wallets/Adamant/AdmWalletService.swift
@@ -84,6 +84,7 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
     var vibroService: VibroService!
 
     // MARK: - Notifications
+    let adamantAccount = Notification.Name("adamant.admWallet.walletUpdated")
     let serviceEnabledChanged = Notification.Name("adamant.admWallet.enabledChanged")
     let transactionFeeUpdated = Notification.Name("adamant.admWallet.feeUpdated")
     let serviceStateChanged = Notification.Name("adamant.admWallet.stateChanged")
@@ -160,6 +161,13 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
                 self?.admWallet = nil
             }
             .store(in: &subscriptions)
+        
+        NotificationCenter.default
+            .notifications(named: .AdamantAccountService.walletUpdated, object: nil)
+            .sink { [weak self] _ in
+                self?.update()
+            }
+            .store(in: &subscriptions)
     }
 
     func updateWithRefreshUIBalance(){
@@ -191,8 +199,10 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
 
         admWallet?.isBalanceInitialized = !accountService.isBalanceExpired
 
-        if let wallet = wallet {
-            postUpdateNotification(with: wallet)
+        if wallet != nil {
+            Task { @MainActor in
+                walletUpdateSender.send()
+            }
         }
 
         if isRaised {
@@ -208,12 +218,6 @@ final class AdmWalletService: NSObject, WalletCoreProtocol, WalletStaticCoreProt
 
     func validate(address: String) -> AddressValidationResult {
         addressRegex.perfectMatch(with: address) ? .valid : .invalid(description: nil)
-    }
-
-    private func postUpdateNotification(with wallet: WalletAccount) {
-        Task { @MainActor in
-            walletUpdateSender.send()
-        }
     }
 
     func getWalletAddress(byAdamantAddress address: String) async throws -> String {
@@ -254,7 +258,9 @@ extension AdmWalletService: NSFetchedResultsControllerDelegate {
 
         if newCount != wallet.notifications {
             wallet.notifications = newCount
-            postUpdateNotification(with: wallet)
+            Task { @MainActor in
+                walletUpdateSender.send()
+            }
         }
     }
 }

--- a/Adamant/Modules/Wallets/Adamant/AdmWalletViewController.swift
+++ b/Adamant/Modules/Wallets/Adamant/AdmWalletViewController.swift
@@ -10,6 +10,7 @@ import CommonKit
 import Eureka
 import SafariServices
 import UIKit
+import Combine
 
 extension String.adamant.wallets {
     static var adamant: String {
@@ -87,7 +88,9 @@ final class AdmWalletViewController: WalletViewControllerBase {
 
     // MARK: - Props & Deps
     var hideFreeTokensRow = false
-
+    
+    var cancellables: Set<AnyCancellable> = []
+    
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
@@ -198,12 +201,14 @@ final class AdmWalletViewController: WalletViewControllerBase {
 
         // Notifications
         if let service = service {
-            NotificationCenter.default.addObserver(
-                forName: service.core.walletUpdatedNotification,
-                object: service.core,
-                queue: OperationQueue.main,
-                using: { [weak self] _ in MainActor.assumeIsolatedSafe { self?.updateRows() } }
-            )
+            service.core.walletUpdatePublisher
+                .receive(on: DispatchQueue.main)
+                .sink { _ in
+                    MainActor.assumeIsolatedSafe { 
+                        self.updateRows() 
+                    }
+                }
+                .store(in: &cancellables)
         }
 
         NotificationCenter.default.addObserver(

--- a/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
+++ b/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
@@ -157,7 +157,6 @@ final class BtcWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
     private let walletPath = "m/44'/0'/21'/0/0"
 
     // MARK: - Notifications
-    let walletUpdatedNotification = Notification.Name("adamant.btcWallet.walletUpdated")
     let serviceEnabledChanged = Notification.Name("adamant.btcWallet.enabledChanged")
     let serviceStateChanged = Notification.Name("adamant.btcWallet.stateChanged")
     let transactionFeeUpdated = Notification.Name("adamant.btcWallet.feeUpdated")
@@ -317,12 +316,6 @@ final class BtcWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
         
         walletUpdateSender.send()
         
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-        )
-        
         setState(.upToDate)
 
         if let rate = try? await getFeeRate() {
@@ -397,12 +390,6 @@ final class BtcWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
             guard let self = self else { return }
             try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
-
-            NotificationCenter.default.post(
-                name: walletUpdatedNotification,
-                object: self,
-                userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-            )
 
             await walletUpdateSender.send()
         }.eraseToAnyCancellable()
@@ -484,12 +471,6 @@ extension BtcWalletService {
         )
         self.btcWallet = eWallet
         let kvsAddressModel = makeKVSAddressModel(wallet: eWallet)
-
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: eWallet]
-        )
 
         await walletUpdateSender.send()
 

--- a/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
+++ b/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
@@ -101,6 +101,14 @@ final class BtcWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
     var qqPrefix: String {
         return Self.qqPrefix
     }
+    
+    var balanceCheckInterval: Int? {
+        Self.balanceCheckInterval
+    }
+    
+    var balanceValidInterval: Int? {
+        Self.balanceValidInterval
+    }
 
     var isSupportIncreaseFee: Bool {
         return true

--- a/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
+++ b/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
@@ -388,7 +388,7 @@ final class BtcWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
 
         balanceInvalidationSubscription = Task { [weak self] in
             guard let self = self else { return }
-            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceCheckIntervalDefault) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             await walletUpdateSender.send()

--- a/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
+++ b/Adamant/Modules/Wallets/Bitcoin/BtcWalletService.swift
@@ -394,8 +394,8 @@ final class BtcWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
         wallet.isBalanceInitialized = true
 
         balanceInvalidationSubscription = Task { [weak self] in
-            try await Task.sleep(interval: Self.balanceLifetime, pauseInBackground: true)
-            guard let self else { return }
+            guard let self = self else { return }
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? 50000) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             NotificationCenter.default.post(

--- a/Adamant/Modules/Wallets/Dash/DashWalletService.swift
+++ b/Adamant/Modules/Wallets/Dash/DashWalletService.swift
@@ -289,8 +289,8 @@ final class DashWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
         wallet.isBalanceInitialized = true
 
         balanceInvalidationSubscription = Task { [weak self] in
-            try await Task.sleep(interval: Self.balanceLifetime, pauseInBackground: true)
-            guard let self else { return }
+            guard let self = self else { return }
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? 50000) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             NotificationCenter.default.post(

--- a/Adamant/Modules/Wallets/Dash/DashWalletService.swift
+++ b/Adamant/Modules/Wallets/Dash/DashWalletService.swift
@@ -283,7 +283,7 @@ final class DashWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
 
         balanceInvalidationSubscription = Task { [weak self] in
             guard let self = self else { return }
-            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceCheckIntervalDefault) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             await self.walletUpdateSender.send()

--- a/Adamant/Modules/Wallets/Dash/DashWalletService.swift
+++ b/Adamant/Modules/Wallets/Dash/DashWalletService.swift
@@ -117,7 +117,6 @@ final class DashWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
     }
 
     // MARK: - Notifications
-    let walletUpdatedNotification = Notification.Name("adamant.dashWallet.walletUpdated")
     let serviceEnabledChanged = Notification.Name("adamant.dashWallet.enabledChanged")
     let serviceStateChanged = Notification.Name("adamant.dashWallet.stateChanged")
     let transactionFeeUpdated = Notification.Name("adamant.dashWallet.feeUpdated")
@@ -265,12 +264,6 @@ final class DashWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
         
         walletUpdateSender.send()
         
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-        )
-        
         setState(.upToDate)
     }
 
@@ -292,12 +285,6 @@ final class DashWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
             guard let self = self else { return }
             try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
-
-            NotificationCenter.default.post(
-                name: walletUpdatedNotification,
-                object: self,
-                userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-            )
 
             await self.walletUpdateSender.send()
         }.eraseToAnyCancellable()
@@ -338,12 +325,6 @@ extension DashWalletService {
 
         self.dashWallet = eWallet
         let kvsAddressModel = makeKVSAddressModel(wallet: eWallet)
-
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: eWallet]
-        )
 
         self.walletUpdateSender.send()
 

--- a/Adamant/Modules/Wallets/Dash/DashWalletService.swift
+++ b/Adamant/Modules/Wallets/Dash/DashWalletService.swift
@@ -49,6 +49,14 @@ final class DashWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
     var qqPrefix: String {
         return Self.qqPrefix
     }
+    
+    var balanceCheckInterval: Int? {
+        Self.balanceCheckInterval
+    }
+    
+    var balanceValidInterval: Int? {
+        Self.balanceValidInterval
+    }
 
     var nodeGroups: [NodeGroup] {
         [.dash]

--- a/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
+++ b/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
@@ -106,6 +106,14 @@ final class DogeWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
     var qqPrefix: String {
         return Self.qqPrefix
     }
+    
+    var balanceCheckInterval: Int? {
+        Self.balanceCheckInterval
+    }
+    
+    var balanceValidInterval: Int? {
+        Self.balanceValidInterval
+    }
 
     var nodeGroups: [NodeGroup] {
         [.doge]

--- a/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
+++ b/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
@@ -309,8 +309,8 @@ final class DogeWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
         wallet.isBalanceInitialized = true
 
         balanceInvalidationSubscription = Task { [weak self] in
-            try await Task.sleep(interval: Self.balanceLifetime, pauseInBackground: true)
-            guard let self else { return }
+            guard let self = self else { return }
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? 50000) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             NotificationCenter.default.post(

--- a/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
+++ b/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
@@ -303,7 +303,7 @@ final class DogeWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
 
         balanceInvalidationSubscription = Task { [weak self] in
             guard let self = self else { return }
-            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceCheckIntervalDefault) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             await self.walletUpdateSender.send()

--- a/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
+++ b/Adamant/Modules/Wallets/Doge/DogeWalletService.swift
@@ -124,7 +124,6 @@ final class DogeWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
     @Atomic private(set) var isWarningGasPrice = false
 
     // MARK: - Notifications
-    let walletUpdatedNotification = Notification.Name("adamant.dogeWallet.walletUpdated")
     let serviceEnabledChanged = Notification.Name("adamant.dogeWallet.enabledChanged")
     let serviceStateChanged = Notification.Name("adamant.dogeWallet.stateChanged")
     let transactionFeeUpdated = Notification.Name("adamant.dogeWallet.feeUpdated")
@@ -284,12 +283,6 @@ final class DogeWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
         }
         
         walletUpdateSender.send()
-        
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-        )
 
         setState(.upToDate)
     }
@@ -312,12 +305,6 @@ final class DogeWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @un
             guard let self = self else { return }
             try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
-
-            NotificationCenter.default.post(
-                name: walletUpdatedNotification,
-                object: self,
-                userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-            )
 
             await self.walletUpdateSender.send()
         }.eraseToAnyCancellable()
@@ -356,12 +343,6 @@ extension DogeWalletService {
         )
         self.dogeWallet = eWallet
         let kvsAddressModel = makeKVSAddressModel(wallet: eWallet)
-
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: eWallet]
-        )
 
         await walletUpdateSender.send()
 

--- a/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
+++ b/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
@@ -221,9 +221,6 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
 
         self.setState(.notInitiated)
         
-        print("qwe [\(Date())] " + "\(self.balanceCheckInterval!)" + "\n----------------------")
-        print("qwe [\(Date())] " + "\(self.balanceValidInterval!)" + "\n----------------------")
-
         // Notifications
         addObservers()
     }
@@ -386,8 +383,8 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
         wallet.isBalanceInitialized = true
 
         balanceInvalidationSubscription = Task { [weak self] in
-            try await Task.sleep(interval: Self.balanceLifetime, pauseInBackground: true)
-            guard let self else { return }
+            guard let self = self else { return }
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? 50000) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             NotificationCenter.default.post(

--- a/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
+++ b/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
@@ -67,6 +67,14 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
     var qqPrefix: String {
         EthWalletService.qqPrefix
     }
+    
+    var balanceCheckInterval: Int? {
+        EthWalletService.balanceCheckInterval
+    }
+    
+    var balanceValidInterval: Int? {
+        EthWalletService.balanceValidInterval
+    }
 
     var isSupportIncreaseFee: Bool {
         true
@@ -212,6 +220,9 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
         serviceStateChanged = Notification.Name("adamant.erc20Wallet.\(token.symbol).stateChanged")
 
         self.setState(.notInitiated)
+        
+        print("qwe [\(Date())] " + "\(self.balanceCheckInterval!)" + "\n----------------------")
+        print("qwe [\(Date())] " + "\(self.balanceValidInterval!)" + "\n----------------------")
 
         // Notifications
         addObservers()

--- a/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
+++ b/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
@@ -376,7 +376,7 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
 
         balanceInvalidationSubscription = Task { [weak self] in
             guard let self = self else { return }
-            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceCheckIntervalDefault) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             await self.walletUpdateSender.send()

--- a/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
+++ b/Adamant/Modules/Wallets/ERC20/ERC20WalletService.swift
@@ -136,7 +136,6 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
     var ethBIP32Service: EthBIP32ServiceProtocol!
 
     // MARK: - Notifications
-    let walletUpdatedNotification: Notification.Name
     let serviceEnabledChanged: Notification.Name
     let transactionFeeUpdated: Notification.Name
     let serviceStateChanged: Notification.Name
@@ -214,7 +213,6 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
 
     init(token: ERC20Token) {
         self.token = token
-        walletUpdatedNotification = Notification.Name("adamant.erc20Wallet.\(token.symbol).walletUpdated")
         serviceEnabledChanged = Notification.Name("adamant.erc20Wallet.\(token.symbol).enabledChanged")
         transactionFeeUpdated = Notification.Name("adamant.erc20Wallet.\(token.symbol).feeUpdated")
         serviceStateChanged = Notification.Name("adamant.erc20Wallet.\(token.symbol).stateChanged")
@@ -300,12 +298,6 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
         }
         
         walletUpdateSender.send()
-        
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-        )
 
         setState(.upToDate)
 
@@ -387,12 +379,6 @@ final class ERC20WalletService: WalletCoreProtocol, ERC20GasAlgorithmComputable,
             try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
-            NotificationCenter.default.post(
-                name: walletUpdatedNotification,
-                object: self,
-                userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-            )
-
             await self.walletUpdateSender.send()
         }.eraseToAnyCancellable()
     }
@@ -429,12 +415,6 @@ extension ERC20WalletService {
             enabled = true
             NotificationCenter.default.post(name: serviceEnabledChanged, object: self)
         }
-
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: eWallet]
-        )
 
         await walletUpdateSender.send()
 

--- a/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
+++ b/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
@@ -339,7 +339,7 @@ final class EthWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, ERC2
 
         balanceInvalidationSubscription = Task { [weak self] in
             guard let self = self else { return }
-            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceCheckIntervalDefault) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             await self.walletUpdateSender.send()

--- a/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
+++ b/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
@@ -160,7 +160,6 @@ final class EthWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, ERC2
     var ethBIP32Service: EthBIP32ServiceProtocol!
 
     // MARK: - Notifications
-    let walletUpdatedNotification = Notification.Name("adamant.ethWallet.walletUpdated")
     let serviceEnabledChanged = Notification.Name("adamant.ethWallet.enabledChanged")
     let transactionFeeUpdated = Notification.Name("adamant.ethWallet.feeUpdated")
     let serviceStateChanged = Notification.Name("adamant.ethWallet.stateChanged")
@@ -330,12 +329,6 @@ final class EthWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, ERC2
         }
         
         walletUpdateSender.send()
-        
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-        )
 
         setState(.upToDate)
         await calculateFee()
@@ -348,12 +341,6 @@ final class EthWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, ERC2
             guard let self = self else { return }
             try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
-
-            NotificationCenter.default.post(
-                name: walletUpdatedNotification,
-                object: self,
-                userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-            )
 
             await self.walletUpdateSender.send()
         }.eraseToAnyCancellable()
@@ -450,12 +437,6 @@ extension EthWalletService {
         // MARK: 3. Update
         ethWallet = eWallet
         let kvsAddressModel = makeKVSAddressModel(wallet: eWallet)
-
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: eWallet]
-        )
 
         await walletUpdateSender.send()
 

--- a/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
+++ b/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
@@ -111,6 +111,14 @@ final class EthWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, ERC2
     var qqPrefix: String {
         Self.qqPrefix
     }
+    
+    var balanceCheckInterval: Int? {
+        Self.balanceCheckInterval
+    }
+    
+    var balanceValidInterval: Int? {
+        Self.balanceValidInterval
+    }
 
     var isSupportIncreaseFee: Bool {
         true

--- a/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
+++ b/Adamant/Modules/Wallets/Ethereum/EthWalletService.swift
@@ -345,8 +345,8 @@ final class EthWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, ERC2
         wallet.isBalanceInitialized = true
 
         balanceInvalidationSubscription = Task { [weak self] in
-            try await Task.sleep(interval: Self.balanceLifetime, pauseInBackground: true)
-            guard let self else { return }
+            guard let self = self else { return }
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? 50000) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             NotificationCenter.default.post(

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
@@ -97,7 +97,6 @@ final class KlyWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
 
     // MARK: Notifications
 
-    let walletUpdatedNotification = Notification.Name("adamant.klyWallet.walletUpdated")
     let serviceEnabledChanged = Notification.Name("adamant.klyWallet.enabledChanged")
     let transactionFeeUpdated = Notification.Name("adamant.klyWallet.feeUpdated")
     let serviceStateChanged = Notification.Name("adamant.klyWallet.stateChanged")
@@ -287,12 +286,6 @@ extension KlyWalletService {
         }
         
         walletUpdateSender.send()
-        
-        NotificationCenter.default.post(
-            name: walletUpdatedNotification,
-            object: self,
-            userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-        )
 
         if let nonce = try? await getNonce(address: wallet.address) {
             wallet.nonce = nonce
@@ -317,12 +310,6 @@ extension KlyWalletService {
             guard let self = self else { return }
             try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
-
-            NotificationCenter.default.post(
-                name: walletUpdatedNotification,
-                object: self,
-                userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-            )
 
             await walletUpdateSender.send()
         }.eraseToAnyCancellable()
@@ -464,12 +451,6 @@ extension KlyWalletService {
                 isNewApi: true
             )
             self.klyWallet = wallet
-
-            NotificationCenter.default.post(
-                name: walletUpdatedNotification,
-                object: self,
-                userInfo: [AdamantUserInfoKey.WalletService.wallet: wallet]
-            )
 
             await walletUpdateSender.send()
         } catch {

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
@@ -314,8 +314,8 @@ extension KlyWalletService {
         wallet.isBalanceInitialized = true
 
         balanceInvalidationSubscription = Task { [weak self] in
-            try await Task.sleep(interval: Self.balanceLifetime, pauseInBackground: true)
-            guard let self else { return }
+            guard let self = self else { return }
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? 50000) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             NotificationCenter.default.post(

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
@@ -48,6 +48,14 @@ final class KlyWalletService: WalletCoreProtocol, WalletStaticCoreProtocol, @unc
             )
         } ?? []
     }
+    
+    var balanceCheckInterval: Int? {
+        Self.balanceCheckInterval
+    }
+    
+    var balanceValidInterval: Int? {
+        Self.balanceValidInterval
+    }
 
     @MainActor
     var hasEnabledNode: Bool {

--- a/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
+++ b/Adamant/Modules/Wallets/Klayr/WalletService/KlyWalletService.swift
@@ -308,7 +308,7 @@ extension KlyWalletService {
 
         balanceInvalidationSubscription = Task { [weak self] in
             guard let self = self else { return }
-            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceLifetime) / 1000, pauseInBackground: true)
+            try await Task.sleep(interval: Double(self.balanceValidInterval ?? Self.balanceCheckIntervalDefault) / 1000, pauseInBackground: true)
             wallet.isBalanceInitialized = false
 
             await walletUpdateSender.send()

--- a/Adamant/Modules/Wallets/TransferViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/TransferViewControllerBase.swift
@@ -410,8 +410,7 @@ class TransferViewControllerBase: FormViewController {
             }
             .store(in: &subscriptions)
 
-        NotificationCenter.default
-            .notifications(named: walletCore.walletUpdatedNotification)
+        walletCore.walletUpdatePublisher
             .sink { @MainActor [weak self] _ in
                 self?.reloadFormData()
             }

--- a/Adamant/Modules/Wallets/WalletViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/WalletViewControllerBase.swift
@@ -424,8 +424,7 @@ extension WalletViewControllerBase {
             }
             .store(in: &subscriptions)
 
-        NotificationCenter.default
-            .notifications(named: service.core.walletUpdatedNotification)
+        service.core.walletUpdatePublisher
             .sink { @MainActor [weak self] _ in
                 self?.updateWalletUI()
             }

--- a/Adamant/Modules/Wallets/WalletViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/WalletViewControllerBase.swift
@@ -425,6 +425,7 @@ extension WalletViewControllerBase {
             .store(in: &subscriptions)
 
         service.core.walletUpdatePublisher
+            .receive(on: DispatchQueue.main)
             .sink { @MainActor [weak self] _ in
                 self?.updateWalletUI()
             }
@@ -451,6 +452,7 @@ extension WalletViewControllerBase {
             .store(in: &subscriptions)
     }
 
+    @MainActor
     fileprivate func updateWalletUI() {
         guard let service = service else { return }
 

--- a/Adamant/Modules/Wallets/WalletsService/WalletCoreProtocol.swift
+++ b/Adamant/Modules/Wallets/WalletsService/WalletCoreProtocol.swift
@@ -405,7 +405,3 @@ protocol WalletServiceTwoStepSend: WalletCoreProtocol {
 protocol RawTransaction {
     var txHash: String? { get }
 }
-
-extension WalletCoreProtocol {
-    static var balanceLifetime: TimeInterval { 300 }
-}

--- a/Adamant/Modules/Wallets/WalletsService/WalletCoreProtocol.swift
+++ b/Adamant/Modules/Wallets/WalletsService/WalletCoreProtocol.swift
@@ -275,10 +275,6 @@ protocol WalletCoreProtocol: AnyObject, Sendable {
 
     // MARK: Notifications
 
-    /// Wallet updated.
-    /// UserInfo contains new wallet at AdamantUserInfoKey.WalletService.wallet
-    var walletUpdatedNotification: Notification.Name { get }
-
     /// Enabled state changed
     var serviceEnabledChanged: Notification.Name { get }
 

--- a/Adamant/Modules/Wallets/WalletsService/WalletCoreProtocol.swift
+++ b/Adamant/Modules/Wallets/WalletsService/WalletCoreProtocol.swift
@@ -323,6 +323,8 @@ protocol WalletCoreProtocol: AnyObject, Sendable {
     var transactionFeeUpdated: Notification.Name { get }
 
     var qqPrefix: String { get }
+    var balanceCheckInterval: Int? { get }
+    var balanceValidInterval: Int? { get }
     var blockchainSymbol: String { get }
     var isDynamicFee: Bool { get }
     var diplayTransactionFee: Decimal { get }

--- a/Adamant/Modules/Wallets/WalletsService/WalletCoreProtocol.swift
+++ b/Adamant/Modules/Wallets/WalletsService/WalletCoreProtocol.swift
@@ -403,5 +403,5 @@ protocol RawTransaction {
 }
 
 extension WalletCoreProtocol {
-    static var balanceLifetime: Int { 300000 } // 5 minutes
+    static var balanceCheckIntervalDefault: Int { 300000 } // 5 minutes
 }

--- a/Adamant/Modules/Wallets/WalletsService/WalletStaticCoreProtocol.swift
+++ b/Adamant/Modules/Wallets/WalletsService/WalletStaticCoreProtocol.swift
@@ -31,6 +31,7 @@ extension WalletStaticCoreProtocol {
     static var qqPrefix: String {
         coinInfo?.qqPrefix ?? ""
     }
+    
     static var healthCheckParameters: CoinHealthCheckParameters {
         let coinInfoNH = coinInfo?.nodes?.healthCheck
         let coinInfoSIH = coinInfo?.services?.infoService?.healthCheck
@@ -84,6 +85,14 @@ extension WalletStaticCoreProtocol {
 
     static var oldPendingAttempts: Int {
         coinInfo?.txFetchInfo?.oldPendingAttempts ?? 0
+    }
+    
+    static var balanceCheckInterval: Int? {
+        Self.coinInfo?.balanceCheckInterval
+    }
+    
+    static var balanceValidInterval: Int? {
+        Self.coinInfo?.balanceValidInterval
     }
 
     var tokenName: String {

--- a/Adamant/ServiceProtocols/AccountService.swift
+++ b/Adamant/ServiceProtocols/AccountService.swift
@@ -27,14 +27,16 @@ extension Notification.Name {
         /// Raised on account info (balance) updated.
         static let forceUpdateBalance = Notification.Name("adamant.accountService.forceUpdateBalance")
 
-        /// Raised on account info (balance) updated.
-        static let forceUpdateAllBalances = Notification.Name("adamant.accountService.forceUpdateAllBalances")
-
         /// Raised when user changed Stay In option.
         ///
         /// UserInfo:
         /// - Adamant.AccountService.newStayInState with new state
         static let stayInChanged = Notification.Name("adamant.accountService.stayInChanged")
+
+        /// Raised when wallets collection updated
+        ///
+        /// Use only for communication between AdmanatAccountService and AdamantWalletService.
+        static let walletUpdated = Notification.Name("adamant.accountService.walletUpdated")
 
         private init() {}
     }
@@ -155,8 +157,7 @@ protocol AccountService: AnyObject, Sendable {
 
     /// Update logged account info
     func update()
-    func updateOnlyADM()
-    func updateWithRefreshUI()
+    func update(shouldUpdateUIBalance: Bool, updateOnlyADM: Bool, updateOnlyVisible: Bool)
     func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?)
 
     /// Login into Adamant using passphrase.

--- a/Adamant/ServiceProtocols/AccountService.swift
+++ b/Adamant/ServiceProtocols/AccountService.swift
@@ -36,13 +36,6 @@ extension Notification.Name {
         /// - Adamant.AccountService.newStayInState with new state
         static let stayInChanged = Notification.Name("adamant.accountService.stayInChanged")
 
-        /// Raised when wallets collection updated
-        ///
-        /// UserInfo:
-        /// - AdamantUserInfoKey.AccountService.updatedWallet: wallet object
-        /// - AdamantUserInfoKey.AccountService.updatedWalletIndex: wallet index in AccountService.wallets collection
-        static let walletUpdated = Notification.Name("adamant.accountService.walletUpdated")
-
         private init() {}
     }
 }

--- a/Adamant/Services/AdamantAccountService.swift
+++ b/Adamant/Services/AdamantAccountService.swift
@@ -59,11 +59,6 @@ final class AdamantAccountService: AccountService, @unchecked Sendable {
             self?.update()
         }
         
-        NotificationCenter.default.addObserver(forName: .AdamantAccountService.forceUpdateAllBalances, object: nil, queue: OperationQueue.main) {
-            [weak self] _ in
-            self?.updateAll()
-        }
-        
         NotificationCenter.default
             .notifications(named: UIApplication.didBecomeActiveNotification, object: nil)
             .sink { @MainActor [weak self] _ in
@@ -164,7 +159,7 @@ extension AdamantAccountService {
         balanceInvalidationSubscription = Task { [weak self] in
             guard let self = self else { return }
             try await Task.sleep(
-                interval: Double(wallet?.core.balanceValidInterval ?? AdmWalletService.balanceLifetime) / 1000,
+                interval: Double(wallet?.core.balanceValidInterval ?? AdmWalletService.balanceCheckIntervalDefault) / 1000,
                 pauseInBackground: true
             )
             
@@ -228,20 +223,12 @@ extension AdamantAccountService {
         self.update(nil)
     }
     
-    func updateOnlyADM() {
-        self.update(nil, updateOnlyADM: true)
-    }
-    
-    func updateAll() {
-        update(nil, updateOnlyVisible: false)
-    }
-    
     func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?) {
         update(completion, updateOnlyVisible: true)
     }
     
-    func updateWithRefreshUI() {
-        update(nil, updateOnlyVisible: true, shouldUpdateUIBalance: true)
+    func update(shouldUpdateUIBalance: Bool = false, updateOnlyADM: Bool = false, updateOnlyVisible: Bool = true) {
+        update(nil, updateOnlyVisible: updateOnlyVisible, shouldUpdateUIBalance: true, updateOnlyADM: updateOnlyADM)
     }
     
     func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?, updateOnlyVisible: Bool = true, shouldUpdateUIBalance: Bool = false, updateOnlyADM: Bool = false) {

--- a/Adamant/Services/AdamantAccountService.swift
+++ b/Adamant/Services/AdamantAccountService.swift
@@ -12,22 +12,22 @@ import Foundation
 import UIKit
 
 final class AdamantAccountService: AccountService, @unchecked Sendable {
-
+    
     // MARK: Dependencies
-
+    
     private let apiService: AdamantApiServiceProtocol
     private let adamantCore: AdamantCore
     private let SecureStore: SecureStore
     private let walletServiceCompose: WalletServiceCompose
     private let currencyInfoService: InfoServiceProtocol
     private let coreDataStack: CoreDataStack
-
+    
     weak var notificationsService: NotificationsService?
     weak var pushNotificationsTokenService: PushNotificationsTokenService?
     var walletsStoreService: WalletStoreServiceProtocol?
-
+    
     // MARK: Properties
-
+    
     @Atomic private(set) var state: AccountServiceState = .notLogged
     @Atomic private(set) var isBalanceExpired = true
     @Atomic private(set) var account: AdamantAccount?
@@ -38,7 +38,7 @@ final class AdamantAccountService: AccountService, @unchecked Sendable {
     @Atomic private var previousAppState: UIApplication.State?
     @Atomic private var subscriptions = Set<AnyCancellable>()
     @Atomic private var balanceInvalidationSubscription: AnyCancellable?
-
+    
     init(
         apiService: AdamantApiServiceProtocol,
         adamantCore: AdamantCore,
@@ -54,16 +54,16 @@ final class AdamantAccountService: AccountService, @unchecked Sendable {
         self.walletServiceCompose = walletServiceCompose
         self.currencyInfoService = currencyInfoService
         self.coreDataStack = coreDataStack
-
+        
         NotificationCenter.default.addObserver(forName: .AdamantAccountService.forceUpdateBalance, object: nil, queue: OperationQueue.main) { [weak self] _ in
             self?.update()
         }
-
+        
         NotificationCenter.default.addObserver(forName: .AdamantAccountService.forceUpdateAllBalances, object: nil, queue: OperationQueue.main) {
             [weak self] _ in
             self?.updateAll()
         }
-
+        
         NotificationCenter.default
             .notifications(named: UIApplication.didBecomeActiveNotification, object: nil)
             .sink { @MainActor [weak self] _ in
@@ -72,20 +72,20 @@ final class AdamantAccountService: AccountService, @unchecked Sendable {
                 self?.update()
             }
             .store(in: &subscriptions)
-
+        
         NotificationCenter.default
             .notifications(named: UIApplication.willResignActiveNotification, object: nil)
             .sink { @MainActor [weak self] _ in
                 self?.previousAppState = .background
             }
             .store(in: &subscriptions)
-
+        
         connection.filter { $0 }.sink { [weak self] _ in
             self?.update()
         }.store(in: &subscriptions)
-
+        
         setupSecureStore()
-    }
+    }    
 }
 
 // MARK: - Saved data
@@ -95,21 +95,21 @@ extension AdamantAccountService {
             completion(.failure(.userNotLogged))
             return
         }
-
+        
         if hasStayInAccount {
             completion(.failure(.internalError(message: "Already has account", error: nil)))
             return
         }
-
+        
         SecureStore.set(pin, for: .pin)
-
+        
         if let passphrase = passphrase {
             SecureStore.set(passphrase, for: .passphrase)
         } else {
             SecureStore.set(keypair.publicKey, for: .publicKey)
             SecureStore.set(keypair.privateKey, for: .privateKey)
         }
-
+        
         hasStayInAccount = true
         NotificationCenter.default.post(
             name: Notification.Name.AdamantAccountService.stayInChanged,
@@ -118,54 +118,56 @@ extension AdamantAccountService {
         )
         completion(.success(account: account, alert: nil))
     }
-
+    
     func validatePin(_ pin: String) -> Bool {
         guard let savedPin = SecureStore.get(.pin) else {
             return false
         }
-
+        
         return pin == savedPin
     }
-
+    
     private func getSavedKeypair() -> Keypair? {
         if let publicKey = SecureStore.get(.publicKey), let privateKey = SecureStore.get(.privateKey) {
             return Keypair(publicKey: publicKey, privateKey: privateKey)
         }
-
+        
         return nil
     }
-
+    
     private func getSavedPassphrase() -> String? {
         return SecureStore.get(.passphrase)
     }
-
+    
     func dropSavedAccount() {
         useBiometry = false
         isBalanceExpired = true
         pushNotificationsTokenService?.removeCurrentToken()
         balanceInvalidationSubscription = nil
         Key.allCases.forEach(SecureStore.remove)
-
+        
         hasStayInAccount = false
         NotificationCenter.default.post(
             name: Notification.Name.AdamantAccountService.stayInChanged,
             object: self,
             userInfo: [AdamantUserInfoKey.AccountService.newStayInState: false]
         )
-
+        
         Task { @MainActor in notificationsService?.setNotificationsMode(.disabled, completion: nil) }
     }
-
+    
     private func markBalanceAsFresh() {
         isBalanceExpired = false
-
+        
+        let wallet = walletServiceCompose.getWallets().first(where: { $0.core is AdmWalletService })
+        
         balanceInvalidationSubscription = Task { [weak self] in
+            guard let self = self else { return }
             try await Task.sleep(
-                interval: AdmWalletService.balanceLifetime,
+                interval: Double(wallet?.core.balanceValidInterval ?? 50000) / 1000,
                 pauseInBackground: true
             )
-
-            guard let self else { return }
+            
             isBalanceExpired = true
             NotificationCenter.default.post(
                 name: .AdamantAccountService.accountDataUpdated,
@@ -173,29 +175,29 @@ extension AdamantAccountService {
             )
         }.eraseToAnyCancellable()
     }
-
+    
     private func setupSecureStore() {
         if SecureStore.get(.passphrase) != nil {
             hasStayInAccount = true
             useBiometry = SecureStore.get(.useBiometry) != nil
         } else if SecureStore.get(.publicKey) != nil,
-            SecureStore.get(.privateKey) != nil,
-            SecureStore.get(.pin) != nil
+                  SecureStore.get(.privateKey) != nil,
+                  SecureStore.get(.pin) != nil
         {
             hasStayInAccount = true
-
+            
             useBiometry = SecureStore.get(.useBiometry) != nil
         } else {
             hasStayInAccount = false
             useBiometry = false
         }
-
+        
         NotificationCenter.default.addObserver(forName: Notification.Name.SecureStore.SecureStorePurged, object: SecureStore, queue: OperationQueue.main) {
             [weak self] notification in
             guard let store = notification.object as? SecureStore else {
                 return
             }
-
+            
             if store.get(.passphrase) != nil {
                 self?.hasStayInAccount = true
                 self?.useBiometry = store.get(.useBiometry) != nil
@@ -205,11 +207,11 @@ extension AdamantAccountService {
             }
         }
     }
-
+    
     func updateUseBiometry(_ newValue: Bool) {
         $useBiometry.mutate {
             $0 = newValue && hasStayInAccount
-
+            
             if $0 {
                 SecureStore.set(String($0), for: .useBiometry)
             } else {
@@ -229,11 +231,11 @@ extension AdamantAccountService {
     func updateOnlyADM() {
         self.update(nil, updateOnlyADM: true)
     }
-
+    
     func updateAll() {
         update(nil, updateOnlyVisible: false)
     }
-
+    
     func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?) {
         update(completion, updateOnlyVisible: true)
     }
@@ -241,49 +243,49 @@ extension AdamantAccountService {
     func updateWithRefreshUI() {
         update(nil, updateOnlyVisible: true, shouldUpdateUIBalance: true)
     }
-
+    
     func update(_ completion: (@Sendable (AccountServiceResult) -> Void)?, updateOnlyVisible: Bool = true, shouldUpdateUIBalance: Bool = false, updateOnlyADM: Bool = false) {
         switch state {
-        case .notLogged, .isLoggingIn, .updating:
-            return
-
-        case .loggedIn:
-            break
+            case .notLogged, .isLoggingIn, .updating:
+                return
+                
+            case .loggedIn:
+                break
         }
-
+        
         let prevState = state
         state = .updating
-
+        
         guard let loggedAccount = account, let publicKey = loggedAccount.publicKey else {
             return
         }
-
+        
         Task { @Sendable in
             let result = await apiService.getAccount(byPublicKey: publicKey)
-
+            
             switch result {
-            case .success(let account):
-                guard let acc = self.account, acc.address == account.address else {
-                    // User has logged out, we not interested anymore
-                    state = .notLogged
-                    return
-                }
-
-                markBalanceAsFresh()
-                self.account = account
-
-                NotificationCenter.default.post(
-                    name: .AdamantAccountService.accountDataUpdated,
-                    object: self
-                )
-
-                state = .loggedIn
-                completion?(.success(account: account, alert: nil))
-
-            case .failure(let error):
-                completion?(.failure(.apiError(error: error)))
-                isBalanceExpired = true
-                state = prevState
+                case .success(let account):
+                    guard let acc = self.account, acc.address == account.address else {
+                        // User has logged out, we not interested anymore
+                        state = .notLogged
+                        return
+                    }
+                    
+                    markBalanceAsFresh()
+                    self.account = account
+                    
+                    NotificationCenter.default.post(
+                        name: .AdamantAccountService.accountDataUpdated,
+                        object: self
+                    )
+                    
+                    state = .loggedIn
+                    completion?(.success(account: account, alert: nil))
+                    
+                case .failure(let error):
+                    completion?(.failure(.apiError(error: error)))
+                    isBalanceExpired = true
+                    state = prevState
             }
         }
         
@@ -311,47 +313,47 @@ extension AdamantAccountService {
         guard AdamantUtilities.validateAdamantPassphrase(passphrase: passphrase) else {
             throw AccountServiceError.invalidPassphrase
         }
-
+        
         guard let keypair = adamantCore.createKeypairFor(passphrase: passphrase, password: password) else {
             throw AccountServiceError.internalError(message: "Failed to generate keypair for passphrase", error: nil)
         }
-
+        
         let account = try await loginWith(keypair: keypair)
-
+        
         // MARK: Drop saved accs
         if let storedPassphrase = self.getSavedPassphrase(),
-            storedPassphrase != passphrase
+           storedPassphrase != passphrase
         {
             dropSavedAccount()
         }
-
+        
         if let storedKeypair = self.getSavedKeypair(),
-            storedKeypair != self.keypair
+           storedKeypair != self.keypair
         {
             dropSavedAccount()
         }
-
+        
         // Update and initiate wallet services
         self.passphrase = passphrase
-
+        
         _ = await initWallets()
-
+        
         return .success(account: account, alert: nil)
     }
-
+    
     // MARK: Pincode
     func loginWith(pincode: String) async throws -> AccountServiceResult {
         guard let storePin = SecureStore.get(.pin) else {
             throw AccountServiceError.invalidPassphrase
         }
-
+        
         guard storePin == pincode else {
             throw AccountServiceError.invalidPassphrase
         }
-
+        
         return try await loginWithStoredAccount()
     }
-
+    
     // MARK: Biometry
     @MainActor
     func loginWithStoredAccount() async throws -> AccountServiceResult {
@@ -359,10 +361,10 @@ extension AdamantAccountService {
             let account = try await loginWith(passphrase: passphrase, password: .empty)
             return account
         }
-
+        
         if let keypair = getSavedKeypair() {
             let account = try await loginWith(keypair: keypair)
-
+            
             let alert: (title: String, message: String)?
             if SecureStore.get(.showedV12) != nil {
                 alert = nil
@@ -373,75 +375,75 @@ extension AdamantAccountService {
                     message: String.adamant.accountService.updateAlertMessageV12
                 )
             }
-
+            
             for wallet in walletServiceCompose.getWallets() {
                 wallet.core.setInitiationFailed(reason: .adamant.accountService.reloginToInitiateWallets)
             }
-
+            
             return .success(account: account, alert: alert)
         }
-
+        
         throw AccountServiceError.invalidPassphrase
     }
-
+    
     // MARK: Keypair
     private func loginWith(keypair: Keypair) async throws -> AdamantAccount {
         switch state {
-        case .isLoggingIn:
-            throw AccountServiceError.internalError(message: "Service is busy", error: nil)
-
-        // Logout first
-        case .updating, .loggedIn:
-            await logout()
-
-        // Go login
-        case .notLogged:
-            break
+            case .isLoggingIn:
+                throw AccountServiceError.internalError(message: "Service is busy", error: nil)
+                
+                // Logout first
+            case .updating, .loggedIn:
+                await logout()
+                
+                // Go login
+            case .notLogged:
+                break
         }
-
+        
         state = .isLoggingIn
-
+        
         do {
             let account = try await apiService.getAccount(byPublicKey: keypair.publicKey).get()
             self.account = account
             self.keypair = keypair
             markBalanceAsFresh()
-
+            
             let userInfo = [AdamantUserInfoKey.AccountService.loggedAccountAddress: account.address]
-
+            
             NotificationCenter.default.post(
                 name: Notification.Name.AdamantAccountService.userLoggedIn,
                 object: self,
                 userInfo: userInfo
             )
-
+            
             self.state = .loggedIn
             return account
         } catch let error as ApiServiceError {
             self.state = .notLogged
-
+            
             switch error {
-            case .accountNotFound:
-                throw AccountServiceError.wrongPassphrase
-
-            default:
-                throw AccountServiceError.apiError(error: error)
+                case .accountNotFound:
+                    throw AccountServiceError.wrongPassphrase
+                    
+                default:
+                    throw AccountServiceError.apiError(error: error)
             }
         } catch {
             throw AccountServiceError.internalError(message: error.localizedDescription, error: error)
         }
     }
-
+    
     func reloadWallets() async {
         _ = await initWallets()
     }
-
+    
     func initWallets() async -> [WalletAccount?] {
         guard let passphrase = passphrase else {
             print("No passphrase found")
             return []
         }
-
+        
         return await withTaskGroup(of: WalletAccount?.self) { group in
             for wallet in walletServiceCompose.getWallets() {
                 group.addTask {
@@ -452,13 +454,13 @@ extension AdamantAccountService {
                     return result
                 }
             }
-
+            
             var wallets: [WalletAccount?] = []
-
+            
             for await wallet in group {
                 wallets.append(wallet)
             }
-
+            
             return wallets
         }
     }
@@ -496,17 +498,17 @@ private enum Key: CaseIterable {
     case showedV12
     case blockListKey
     case removedMessages
-
+    
     var stringValue: String {
         switch self {
-        case .publicKey: return StoreKey.accountService.publicKey
-        case .privateKey: return StoreKey.accountService.privateKey
-        case .pin: return StoreKey.accountService.pin
-        case .useBiometry: return StoreKey.accountService.useBiometry
-        case .passphrase: return StoreKey.accountService.passphrase
-        case .showedV12: return StoreKey.accountService.showedV12
-        case .blockListKey: return StoreKey.accountService.blockList
-        case .removedMessages: return StoreKey.accountService.removedMessages
+            case .publicKey: return StoreKey.accountService.publicKey
+            case .privateKey: return StoreKey.accountService.privateKey
+            case .pin: return StoreKey.accountService.pin
+            case .useBiometry: return StoreKey.accountService.useBiometry
+            case .passphrase: return StoreKey.accountService.passphrase
+            case .showedV12: return StoreKey.accountService.showedV12
+            case .blockListKey: return StoreKey.accountService.blockList
+            case .removedMessages: return StoreKey.accountService.removedMessages
         }
     }
 }
@@ -515,11 +517,11 @@ extension SecureStore {
     fileprivate func set(_ value: String, for key: Key) {
         set(value, for: key.stringValue)
     }
-
+    
     fileprivate func get(_ key: Key) -> String? {
         return get(key.stringValue)
     }
-
+    
     fileprivate func remove(_ key: Key) {
         remove(key.stringValue)
     }

--- a/Adamant/Services/WalletAutoUpdaterService.swift
+++ b/Adamant/Services/WalletAutoUpdaterService.swift
@@ -109,6 +109,9 @@ actor WalletAutoUpdateService {
                 interval: getTimeIntervalFor(wallet: core),
                 queue: .global(qos: .utility),
                 callback: {
+                    if wallet.core is AdmWalletService{
+                        self.accountService.update()
+                    }
                     core.update()
                 }
             )

--- a/Adamant/Services/WalletAutoUpdaterService.swift
+++ b/Adamant/Services/WalletAutoUpdaterService.swift
@@ -133,41 +133,11 @@ actor WalletAutoUpdateService {
     }
     
     private func getTimeIntervalFor(wallet: WalletCoreProtocol) -> TimeInterval {
-        switch wallet {
-            case is AdmWalletService:
-                if let isNewAccount = accountService.account?.isNewAccount, isNewAccount {
-                    return WalletsUpdateConstants.admNewAccount.interval
-                }
-                return WalletsUpdateConstants.adm.interval
-            case is EthWalletService:
-                return WalletsUpdateConstants.erc20.interval
-            case is ERC20WalletService:
-                return WalletsUpdateConstants.erc20.interval
-            case is DashWalletService:
-                return WalletsUpdateConstants.dash.interval
-            case is DogeWalletService:
-                return WalletsUpdateConstants.doge.interval
-            case is BtcWalletService:
-                return WalletsUpdateConstants.btc.interval
-            case is KlyWalletService:
-                return WalletsUpdateConstants.kly.interval
-            default:
-                return 50
-        }
-    }
-    
-    private enum WalletsUpdateConstants {
-        case adm, erc20, dash, doge, btc, kly, admNewAccount
-        
-        var interval: TimeInterval {
-            switch self {
-                case .adm:              return 5
-                case .erc20, .dash:     return 25
-                case .doge:             return 30
-                case .btc, .kly:        return 50
-                case .admNewAccount:    return 2
+        if let isNewAccount = accountService.account?.isNewAccount, isNewAccount {
+            if let wallet = wallet as? AdmWalletService {
+                return Double(wallet.balanceCheckIntervalNewAccount ?? 50000) / 1000
             }
         }
+        return Double(wallet.balanceCheckInterval ?? 50000) / 1000
     }
-
 }

--- a/AdamantWalletsKit/Scripts/CopyScript.sh
+++ b/AdamantWalletsKit/Scripts/CopyScript.sh
@@ -16,7 +16,7 @@ if [ -d "$TARGET_DIR" ]; then
 fi
 
 echo "Cloning $PACKAGE_NAME from GitHub..."
-git clone --depth 1 --branch master "$GITHUB_REPO" "$TARGET_DIR"
+git clone --depth 1 --branch dev "$GITHUB_REPO" "$TARGET_DIR"
 
 # Check if cloning was successful
 if [ ! -d "$TARGET_DIR" ]; then

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/Decoders/CoinInfoDTO.swift
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/Decoders/CoinInfoDTO.swift
@@ -31,6 +31,9 @@ public struct CoinInfoDTO: Codable {
     public let defaultGasLimit: Int?
     public let warningGasPriceGwei: Int?
     public let blockTimeAvg: Int?
+    public let balanceCheckInterval: Int?
+    public let balanceCheckIntervalNewAccount: Int? // Only for ADM
+    public let balanceValidInterval: Int?
     public let nodes: Nodes?
     public let services: Services?
     public let links: [Link]?

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/Decoders/CoinsMapper.swift
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/Decoders/CoinsMapper.swift
@@ -5,7 +5,8 @@
 //  Created by Sergei Veretennikov on 25.03.2025.
 //
 
-// Everything here goes synchronousely here's no data races or race conditions
+// Everything here goes synchronousely.
+// There are no data races or race conditions.
 
 import Foundation
 

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/adamant/info.json
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/adamant/info.json
@@ -19,6 +19,9 @@
   "defaultOrdinalLevel": 0,
   "consensus": "dPoS",
   "blockTimeFixed": 5000,
+  "balanceCheckInterval": 5000,
+  "balanceCheckIntervalNewAccount": 2000,
+  "balanceValidInterval": 300000,
   "txFetchInfo": {
     "newPendingInterval": 4000,
     "oldPendingInterval": 4000,
@@ -155,6 +158,93 @@
       "url": "https://adamant.im/whitepaper/adamant-whitepaper-en.pdf"
     }
   ],
+  "testnet": {
+    "website": "https://adamant.im",
+    "explorer": "https://testnet.adamant.im",
+    "explorerTx": "https://testnet.adamant.im/tx/${ID}",
+    "explorerAddress": "https://testnet.adamant.im/address/${ID}",
+    "nodes": {
+      "displayName": "adm-node",
+      "list": [
+        {
+          "url": "https://testnode1.adamant.im",
+          "alt_ip": "http://162.55.32.80:36667"
+        },
+        {
+          "url": "http://81.0.247.181:36667"
+        },
+        {
+          "url": "http://95.217.19.144:36667"
+        },
+        {
+          "url": "https://testnode4.adm.im",
+          "alt_ip": "http://157.90.229.236:36667"
+        }
+      ],
+      "healthCheck": {
+        "normalUpdateInterval": 300000,
+        "crucialUpdateInterval": 30000,
+        "onScreenUpdateInterval": 10000,
+        "threshold": 10
+      },
+      "minVersion": "0.9.0",
+      "nodeTimeCorrection": 500
+    },
+    "services": {
+      "infoService": {
+        "displayName": "rates-info",
+        "description": {
+          "software": "adamant-currencyinfo-services",
+          "github": "https://github.com/Adamant-im/adamant-currencyinfo-services",
+          "docs": "https://github.com/Adamant-im/adamant-currencyinfo-services/wiki/InfoServices-API-documentation"
+        },
+        "list": [
+          {
+            "url": "https://info.adamant.im",
+            "alt_ip": "http://5.161.98.136:33088"
+          },
+          {
+            "url": "https://info2.adm.im",
+            "alt_ip": "http://207.180.210.95:33088"
+          }
+        ],
+        "healthCheck": {
+          "normalUpdateInterval": 300000,
+          "crucialUpdateInterval": 30000,
+          "onScreenUpdateInterval": 10000,
+          "threshold": 6000000
+        }
+      },
+      "ipfsNode": {
+        "displayName": "ipfs-node",
+        "description": {
+          "software": "ipfs-node",
+          "github": "https://github.com/Adamant-im/ipfs-node",
+          "docs": "https://github.com/Adamant-im/ipfs-node/blob/master/README.md"
+        },
+        "list": [
+          {
+            "url": "https://ipfs4.adm.im",
+            "alt_ip": "http://95.216.45.88:44099"
+          },
+          {
+            "url": "https://ipfs5.adamant.im",
+            "alt_ip": "http://62.72.43.99:44099"
+          },
+          {
+            "url": "https://ipfs6.adamant.business",
+            "alt_ip": "http://75.119.138.235:44099"
+          }
+        ],
+        "healthCheck": {
+          "normalUpdateInterval": 300000,
+          "crucialUpdateInterval": 30000,
+          "onScreenUpdateInterval": 10000,
+          "threshold": 6000000
+        }
+      }
+    }
+  },
   "tor": {
     "website": "http://adamantim24okpwfr4wxjgsh6vtw4odoiabhsfaqaktnfqzrjrspjuid.onion",
     "explorer": "http://srovpmanmrbmbqe63vp5nycsa3j3g6be3bz46ksmo35u5pw7jjtjamid.onion",
@@ -205,6 +295,9 @@
         "list": [
           {
             "url": "http://czjsawp2crjmnkliw2h2kpk7wwd3a36zvvnvqgvzmi4t4vc2yzm7j2qd.onion"
+          },
+          {
+            "url": "http://oygscq5p3yfyyi52u2pgdcrgog7vkvtrmayjggxai72tvgftlwkp6lyd.onion"
           }
         ],
         "healthCheck": {

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/bitcoin/info.json
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/bitcoin/info.json
@@ -20,6 +20,8 @@
   "defaultOrdinalLevel": 10,
   "consensus": "PoW",
   "blockTimeAvg": 600000,
+  "balanceCheckInterval": 50000,
+  "balanceValidInterval": 300000,
   "txFetchInfo": {
     "newPendingInterval": 10000,
     "oldPendingInterval": 3000,

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/dash/info.json
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/dash/info.json
@@ -21,6 +21,8 @@
   "defaultOrdinalLevel": 70,
   "consensus": "PoW",
   "blockTimeAvg": 160000,
+  "balanceCheckInterval": 25000,
+  "balanceValidInterval": 300000,
   "txFetchInfo": {
     "newPendingInterval": 5000,
     "oldPendingInterval": 3000,

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/doge/info.json
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/doge/info.json
@@ -20,6 +20,8 @@
   "defaultOrdinalLevel": 70,
   "consensus": "PoW",
   "blockTimeAvg": 60000,
+  "balanceCheckInterval": 30000,
+  "balanceValidInterval": 300000,
   "txFetchInfo": {
     "newPendingInterval": 5000,
     "oldPendingInterval": 3000,

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/ethereum/info.json
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/ethereum/info.json
@@ -18,6 +18,8 @@
   "defaultOrdinalLevel": 20,
   "consensus": "PoS",
   "blockTimeFixed": 12000,
+  "balanceCheckInterval": 25000,
+  "balanceValidInterval": 300000,
   "txFetchInfo": {
     "newPendingInterval": 4000,
     "oldPendingInterval": 3000,

--- a/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/klayr/info.json
+++ b/AdamantWalletsKit/Sources/AdamantWalletsKit/JsonStore/general/klayr/info.json
@@ -15,10 +15,12 @@
   "qqPrefix": "klayr",
   "status": "active",
   "createCoin": true,
-  "defaultVisibility": true,
+  "defaultVisibility": false,
   "defaultOrdinalLevel": 50,
   "consensus": "dPoS",
   "blockTimeFixed": 10000,
+  "balanceCheckInterval": 50000,
+  "balanceValidInterval": 300000,
   "txFetchInfo": {
     "newPendingInterval": 3000,
     "oldPendingInterval": 3000,


### PR DESCRIPTION
* Use intervals from wallets-script instead of hardcode. 
* Improve overall logic.
* Remove `forceUpdateAllBalances` and `walletUpdatedNotification`.