### PR TITLE
[trello.com/c/7YVA2NTe] update cancel file uploading

### DIFF
--- a/Adamant/Modules/Chat/View/Helpers/FileMessageStatus.swift
+++ b/Adamant/Modules/Chat/View/Helpers/FileMessageStatus.swift
@@ -17,7 +17,7 @@ enum FileMessageStatus: Equatable {
 
     var image: UIImage {
         switch self {
-        case .busy: return .asset(named: "status_pending") ?? .init()
+        case .busy: return .asset(named: "status_failed") ?? .init()
         case .success: return .asset(named: "status_success") ?? .init()
         case .failed: return .asset(named: "status_failed") ?? .init()
         case let .needToDownload(failed):

--- a/Adamant/Modules/Chat/View/Managers/ChatAction.swift
+++ b/Adamant/Modules/Chat/View/Managers/ChatAction.swift
@@ -21,7 +21,7 @@ enum ChatAction {
     case react(id: String, emoji: String)
     case presentMenu(arg: ChatContextMenuArguments)
     case openFile(messageId: String, file: ChatFile)
-    case cancelUploading(messageId: String, file: ChatFile)
+    case cancelUploading(messageId: String)
     case autoDownloadContentIfNeeded(messageId: String, files: [ChatFile])
     case forceDownloadAllFiles(messageId: String, files: [ChatFile])
 }

--- a/Adamant/Modules/Chat/View/Managers/ChatDataSourceManager.swift
+++ b/Adamant/Modules/Chat/View/Managers/ChatDataSourceManager.swift
@@ -214,8 +214,8 @@ extension ChatDataSourceManager {
             viewModel.copyTextInPartAction(text)
         case let .openFile(messageId, file):
             viewModel.openFile(messageId: messageId, file: file)
-        case let .cancelUploading(messageId, file):
-            viewModel.cancelFileUploading(messageId: messageId, file: file)
+        case let .cancelUploading(messageId):
+            viewModel.cancelFileUploading(messageId: messageId)
         case let .autoDownloadContentIfNeeded(messageId, files):
             viewModel.autoDownloadContentIfNeeded(
                 messageId: messageId,

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
@@ -9,6 +9,7 @@
 import Combine
 import CommonKit
 import UIKit
+import SwiftUI
 
 final class ChatMediaContainerView: UIView {
     private let spacingView: UIView = {
@@ -88,9 +89,28 @@ final class ChatMediaContainerView: UIView {
         button.addTarget(self, action: #selector(onStatusButtonTap), for: .touchUpInside)
         return button
     }()
+    
+    private lazy var progressRingHostingView: UIView = {
+        let progressBar = CircularProgressView { [weak self] in
+            guard let self else { return .init(progress: .zero, hidden: true) }
+            return self.statusProgressState
+        }
+        let hosting = UIHostingController(rootView: progressBar)
+        hosting.view.backgroundColor = .clear
+        hosting.view.isUserInteractionEnabled = false
+        return hosting.view
+    }()
 
     private lazy var contentView = ChatMediaContentView()
     private lazy var chatMenuManager = ChatMenuManager(delegate: self)
+    
+    private var statusProgressState = CircularProgressState(
+        lineWidth: 2.0,
+        backgroundColor: .clear,
+        progressColor: .adamant.primary,
+        progress: .zero,
+        hidden: true
+    )
 
     // MARK: Dependencies
 
@@ -123,6 +143,11 @@ final class ChatMediaContainerView: UIView {
     }
 
     @objc func onStatusButtonTap() {
+        if model.status == .busy {
+            actionHandler(.cancelUploading(messageId: model.id))
+            return
+        }
+        
         if model.status == .failed,
             let file = model.content.fileModel.files.first
         {
@@ -153,9 +178,15 @@ extension ChatMediaContainerView {
             $0.verticalEdges.equalToSuperview()
             $0.horizontalEdges.equalToSuperview().inset(4)
         }
-
+        
         reactionsStack.snp.makeConstraints { $0.width.equalTo(reactionsWidth) }
         chatMenuManager.setup(for: contentView)
+        
+        reactionsStack.insertSubview(progressRingHostingView, aboveSubview: statusButton)
+        progressRingHostingView.snp.makeConstraints { make in
+            make.center.equalTo(statusButton)
+            make.size.equalTo(31)
+        }
     }
 
     func update() {
@@ -166,12 +197,34 @@ extension ChatMediaContainerView {
         updateOwnReaction()
         updateOpponentReaction()
         updateStatus(model.status)
+        updateProgressRing()
     }
 
     func updateStatus(_ status: FileMessageStatus) {
         statusButton.setImage(status.image, for: .normal)
         statusButton.tintColor = status.imageTintColor
         statusButton.isHidden = status == .success
+    }
+    
+    func averageUploadProgress() -> Double {
+        let files = model.content.fileModel.files
+        
+        let progresses = files
+            .compactMap { $0.progress }
+        
+        guard !progresses.isEmpty else {
+            return 0.0
+        }
+        
+        let totalProgress = progresses.reduce(0, +)
+        return Double(totalProgress) / Double(progresses.count)
+    }
+    
+    func updateProgressRing() {
+        let averageProgress = averageUploadProgress()
+
+        statusProgressState.progress = averageProgress / 100
+        statusProgressState.hidden = averageProgress == 0 || averageProgress == 100
     }
 
     func updateLayout() {

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/ChatFileContainerView/FileListContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/ChatFileContainerView/FileListContainerView.swift
@@ -85,18 +85,12 @@ extension FileListContainerView {
                 txStatus: model.txStatus
             )
             view?.buttonActionHandler = { [weak self, file, model] in
-                if file.isBusy, file.isUploading {
-                    self?.actionHandler(
-                        .cancelUploading(messageId: model.messageId, file: file)
+                self?.actionHandler(
+                    .openFile(
+                        messageId: model.messageId,
+                        file: file
                     )
-                } else {
-                    self?.actionHandler(
-                        .openFile(
-                            messageId: model.messageId,
-                            file: file
-                        )
-                    )
-                }
+                )
             }
         }
     }

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/MediaContainerView/MediaContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/MediaContainerView/MediaContainerView.swift
@@ -133,19 +133,12 @@ extension MediaContainerView {
                         txStatus: model.txStatus
                     )
                     mediaView.buttonActionHandler = { [weak self, file, model] in
-                        let action: ChatAction =
-                            if file.isBusy, file.isUploading {
-                                .cancelUploading(
-                                    messageId: model.messageId,
-                                    file: file
-                                )
-                            } else {
-                                .openFile(
-                                    messageId: model.messageId,
-                                    file: file
-                                )
-                            }
-                        self?.actionHandler(action)
+                        self?.actionHandler(
+                            .openFile(
+                                messageId: model.messageId,
+                                file: file
+                            )
+                        )
                     }
 
                     if let resolution = file.file.resolution,

--- a/Adamant/Modules/Chat/ViewModel/ChatFileService.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatFileService.swift
@@ -49,9 +49,11 @@ final class ChatFileService: ChatFileProtocol, Sendable {
     private var fileDownloadAttemptsCount: [String: Int] = [:]
     private var uploadingFilesDictionary: [String: FileMessage] = [:]
     private var previewDownloadsAttemps: [String: Int] = [:]
-    private var uploadTasks: [String: [String: Task<UploadFileResult, Error>]] = [:]
     private let synchronizer = AsyncStreamSender<@MainActor () -> Void>()
     private let _updateFileFields = ObservableSender<FileUpdateProperties>()
+    
+    // [messageId: [fileID: Task]] we can cancel all tasks for one message by messageId, uploading is managing by fileID
+    private var uploadTasks: [String: [String: Task<UploadFileResult, Error>]] = [:]
 
     private var subscriptions = Set<AnyCancellable>()
     private let maxDownloadAttemptsCount = 3

--- a/Adamant/Modules/Chat/ViewModel/ChatFileService.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatFileService.swift
@@ -49,7 +49,7 @@ final class ChatFileService: ChatFileProtocol, Sendable {
     private var fileDownloadAttemptsCount: [String: Int] = [:]
     private var uploadingFilesDictionary: [String: FileMessage] = [:]
     private var previewDownloadsAttemps: [String: Int] = [:]
-    private var uploadTasks: [String: Task<UploadFileResult, Error>] = [:]
+    private var uploadTasks: [String: [String: Task<UploadFileResult, Error>]] = [:]
     private let synchronizer = AsyncStreamSender<@MainActor () -> Void>()
     private let _updateFileFields = ObservableSender<FileUpdateProperties>()
 
@@ -204,17 +204,24 @@ final class ChatFileService: ChatFileProtocol, Sendable {
         return decodedData
     }
 
-    func cancelUpload(messageId: String, fileId: String) async {
-        if let task = uploadTasks[fileId] {
+    func cancelUpload(messageId: String) async {
+        guard let tasks = uploadTasks[messageId] else { return }
+
+        var fileIdsToRemove: [String] = []
+        
+        for (fileId, task) in tasks {
             task.cancel()
-            uploadTasks[fileId] = nil
             uploadingFiles.removeAll { $0 == fileId }
-        } else {
-            await removeFromRichFile(
-                oldId: fileId,
-                txId: messageId
-            )
+            fileIdsToRemove.append(fileId)
         }
+
+        await removeFilesFromRichFile(
+            oldIds: fileIdsToRemove,
+            txId: messageId
+        )
+
+        uploadTasks[messageId] = nil
+        uploadingFilesDictionary[messageId] = nil
     }
 
     func isDownloadPreviewLimitReached(for fileId: String) -> Bool {
@@ -973,10 +980,13 @@ extension ChatFileService {
                 saveEncrypted: saveEncrypted
             )
 
-            uploadTasks[file.url.absoluteString] = uploadTask
+            if uploadTasks[txId] == nil {
+                uploadTasks[txId] = [:]
+            }
+            uploadTasks[txId]?[file.url.absoluteString] = uploadTask
 
             defer {
-                uploadTasks[file.url.absoluteString] = nil
+                uploadTasks[txId]?[file.url.absoluteString] = nil
             }
 
             do {
@@ -1004,6 +1014,12 @@ extension ChatFileService {
                     txId: txId
                 )
             } catch is CancellationError {
+                guard let (fileMessage, _) = uploadingFilesDictionary[richMessageId: txId],
+                      fileMessage.files.contains(where: { $0.file.url.absoluteString == file.url.absoluteString })
+                else {
+                    return
+                }
+
                 await removeFromRichFile(
                     oldId: file.url.absoluteString,
                     txId: txId
@@ -1134,9 +1150,41 @@ extension ChatFileService {
         uploadingFilesDictionary[txId] = fileMessage
 
         if !updatedFiles.isEmpty {
-            // skip double update which causes bugs
-            // first update: here
-            // second update: if fileMessages is empty in sendFile method
+//             skip double update which causes bugs
+//             first update: here
+//             second update: if fileMessages is empty in sendFile method
+            try? await chatsProvider.updateTxMessageContent(
+                txId: txId,
+                richMessage: richMessage
+            )
+        }
+    }
+    
+    fileprivate func removeFilesFromRichFile(
+        oldIds: [String],
+        txId: String
+    ) async {
+        oldIds.forEach { oldId in
+            uploadingFiles.removeAll { $0 == oldId }
+        }
+
+        guard var (fileMessage, richMessage) = uploadingFilesDictionary[richMessageId: txId]
+        else { return }
+
+        richMessage.files = richMessage.files.filter { file in
+            !oldIds.contains(file.id)
+        }
+        fileMessage.adamantMessage = .richMessage(payload: richMessage)
+
+        let updatedFiles = fileMessage.files.filter { file in
+            let url = file.file.url
+            return !oldIds.contains(url.absoluteString)
+        }
+
+        fileMessage.files = updatedFiles
+        uploadingFilesDictionary[txId] = fileMessage
+
+        if !updatedFiles.isEmpty {
             try? await chatsProvider.updateTxMessageContent(
                 txId: txId,
                 richMessage: richMessage

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -743,9 +743,9 @@ final class ChatViewModel: NSObject {
         updateMessages(resetLoadingProperty: false)
     }
 
-    func cancelFileUploading(messageId: String, file: ChatFile) {
+    func cancelFileUploading(messageId: String) {
         Task {
-            await chatFileService.cancelUpload(messageId: messageId, fileId: file.file.id)
+            await chatFileService.cancelUpload(messageId: messageId)
         }
     }
 

--- a/Adamant/ServiceProtocols/ChatFileProtocol.swift
+++ b/Adamant/ServiceProtocols/ChatFileProtocol.swift
@@ -71,7 +71,7 @@ protocol ChatFileProtocol: Sendable {
 
     func isDownloadPreviewLimitReached(for fileId: String) -> Bool
 
-    func cancelUpload(messageId: String, fileId: String) async
+    func cancelUpload(messageId: String) async
 
     func isPreviewAutoDownloadAllowedByPolicy(
         hasPartnerName: Bool,


### PR DESCRIPTION
Now the entire loading of a message with a file is canceled by one click on the cross next to the message. Animation of the general progress of file loading has been added.
