### PR TITLE
[trello.com/c/sG80IZan] fix reading while TransactionDetails on screen

### DIFF
--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -320,6 +320,22 @@ extension ChatViewController {
                 self?.state.isAppActive = false
             }
             .store(in: &subscriptions)
+        
+        NotificationCenter.default
+            .publisher(for: .controllerPresentedLifecycleNotification)
+            .sink { [weak self] notification in
+                guard let self,
+                      let id = notification.userInfo?["id"] as? String,
+                      let isPresented = notification.userInfo?["isPresented"] as? Bool else { return }
+
+                if isPresented {
+                    self.state.presentedControllerIDs.insert(id)
+                } else {
+                    self.state.presentedControllerIDs.remove(id)
+                    updateUnreadMessages()
+                }
+            }
+            .store(in: &subscriptions)
 
         viewModel.didTapAdmNodesList
             .sink { [weak self] in

--- a/Adamant/Modules/Chat/View/ChatViewControllerState.swift
+++ b/Adamant/Modules/Chat/View/ChatViewControllerState.swift
@@ -20,12 +20,17 @@ struct ChatViewControllerState {
     var isAppActive = true
     var isScrollingToBottom = false
     var shouldScrollToNewMessagesOrSavedPosition = true
+    var presentedControllerIDs: Set<String> = [] {
+        didSet {
+            print("can read:", presentedControllerIDs.isEmpty)
+        }
+    }
     
     //calculation for animation, might use for something else in the future
     var isAnimationAllowed: Bool {
         isMessagesLoaded && !isAutoScrolling && !isScrollingToBottom
     }
     var canReadChat: Bool {
-        !isAutoScrolling && isViewAppeared && (!isMacOS || isAppActive)
+        !isAutoScrolling && isViewAppeared && (!isMacOS || isAppActive) && presentedControllerIDs.isEmpty
     }
 }

--- a/Adamant/Modules/Chat/View/ChatViewControllerState.swift
+++ b/Adamant/Modules/Chat/View/ChatViewControllerState.swift
@@ -20,11 +20,7 @@ struct ChatViewControllerState {
     var isAppActive = true
     var isScrollingToBottom = false
     var shouldScrollToNewMessagesOrSavedPosition = true
-    var presentedControllerIDs: Set<String> = [] {
-        didSet {
-            print("can read:", presentedControllerIDs.isEmpty)
-        }
-    }
+    var presentedControllerIDs: Set<String> = []
     
     //calculation for animation, might use for something else in the future
     var isAnimationAllowed: Bool {

--- a/Adamant/Modules/ChatsList/ComplexTransferViewController.swift
+++ b/Adamant/Modules/ChatsList/ComplexTransferViewController.swift
@@ -57,6 +57,7 @@ final class ComplexTransferViewController: UIViewController {
         self.nodesStorage = nodesStorage
 
         super.init(nibName: nil, bundle: nil)
+        self.postLifecycleNotification(isPresented: true)
     }
 
     required init?(coder: NSCoder) {
@@ -93,6 +94,7 @@ final class ComplexTransferViewController: UIViewController {
     }
 
     deinit {
+        self.postLifecycleNotification(isPresented: false)
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -112,6 +114,14 @@ final class ComplexTransferViewController: UIViewController {
 
     @objc func cancel() {
         transferDelegate?.complexTransferViewController(self, didFinishWithTransfer: nil, detailsViewController: nil)
+    }
+    
+    private func postLifecycleNotification(isPresented: Bool) {
+        NotificationCenter.default.post(
+            name: .controllerPresentedLifecycleNotification,
+            object: nil,
+            userInfo: ["id": controllerIdKey, "isPresented": isPresented]
+        )
     }
 }
 
@@ -266,3 +276,9 @@ extension ComplexTransferViewController {
         super.pressesBegan(presses, with: event)
     }
 }
+
+extension Notification.Name {
+    static let controllerPresentedLifecycleNotification = Notification.Name("controllerPresentedLifecycleNotification")
+}
+
+fileprivate let controllerIdKey: String = "complexTransferViewController"

--- a/Adamant/Modules/Wallets/TransactionDetailsViewControllerBase.swift
+++ b/Adamant/Modules/Wallets/TransactionDetailsViewControllerBase.swift
@@ -269,6 +269,7 @@ class TransactionDetailsViewControllerBase: FormViewController {
         self.languageService = languageService
 
         super.init(style: .grouped)
+        postLifecycleNotification(isPresented: true)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -834,6 +835,7 @@ class TransactionDetailsViewControllerBase: FormViewController {
     }
 
     deinit {
+        postLifecycleNotification(isPresented: false)
         refreshTask?.cancel()
     }
 
@@ -954,6 +956,14 @@ class TransactionDetailsViewControllerBase: FormViewController {
 
         row.value = getFeeValue()
         row.updateCell()
+    }
+    
+    private func postLifecycleNotification(isPresented: Bool) {
+        NotificationCenter.default.post(
+            name: .controllerPresentedLifecycleNotification,
+            object: nil,
+            userInfo: ["id": controllerIdKey, "isPresented": isPresented]
+        )
     }
 
     func getFeeValue() -> String {
@@ -1105,3 +1115,5 @@ class TransactionDetailsViewControllerBase: FormViewController {
         )
     }
 }
+
+fileprivate let controllerIdKey: String = "transactionDetailsController"


### PR DESCRIPTION
now if we have TransactionDetails or TransferViewController on top оf the chat, messages in chat will not be available to read and reeding will be triggered after dissmiss