### PR TITLE
[trello.com/c/Rk7q1v1P] fix Pasting image from Pasteboard

### DIFF
--- a/FilesStorageKit/Sources/FilesStorageKit/FilesStorageKit.swift
+++ b/FilesStorageKit/Sources/FilesStorageKit/FilesStorageKit.swift
@@ -191,8 +191,13 @@ public final class FilesStorageKit: FilesStorageProtocol, @unchecked Sendable {
 
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
 
-        let fileURL = folder.appendingPathComponent(name)
-
+        let fileURL: URL
+        if name.lowercased().hasSuffix(".jpeg") {
+            fileURL = folder.appendingPathComponent(name)
+        } else {
+            fileURL = folder.appendingPathComponent(name).appendingPathExtension("jpeg")
+        }
+        
         try data.write(to: fileURL, options: [.atomic, .completeFileProtection])
 
         return fileURL


### PR DESCRIPTION
images inserted into inpurbar might not have the required format or lose it when converted to UIImage, now images that do not have a format will have .jpeg added to the end