### PR TITLE
[trello.com/c/7YVA2NTe] cancel uploading update

### DIFF
--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
@@ -214,9 +214,7 @@ extension ChatMediaContainerView {
     func totalUploadProgress() -> Double {
         let files = model.content.fileModel.files
 
-        let totalBytes: Int64 = files.reduce(0) { result, file in
-            result + file.file.size
-        }
+        let totalBytes = files.map { $0.file.size }.reduce(0, +)
 
         let uploadedBytes: Int64 = files.reduce(0) { result, file in
             let progress = Double(file.progress ?? 0) / 100.0

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
@@ -184,7 +184,12 @@ extension ChatMediaContainerView {
         
         reactionsStack.insertSubview(progressRingHostingView, aboveSubview: statusButton)
         progressRingHostingView.snp.makeConstraints { make in
-            make.center.equalTo(statusButton)
+            if isMacOS {
+                make.centerX.equalTo(statusButton).offset(-1)
+            } else {
+                make.centerX.equalTo(statusButton)
+            }
+            make.centerY.equalTo(statusButton)
             make.size.equalTo(29)
         }
     }

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
@@ -211,29 +211,35 @@ extension ChatMediaContainerView {
         statusButton.isHidden = status == .success
     }
     
-    func averageUploadProgress() -> Double {
+    func totalUploadProgress() -> Double {
         let files = model.content.fileModel.files
-        
-        let progresses = files
-            .compactMap { $0.progress }
-        
-        guard !progresses.isEmpty else {
+
+        let totalBytes: Int64 = files.reduce(0) { result, file in
+            result + file.file.size
+        }
+
+        let uploadedBytes: Int64 = files.reduce(0) { result, file in
+            let progress = Double(file.progress ?? 0) / 100.0
+            return result + Int64(Double(file.file.size) * progress)
+        }
+
+        guard totalBytes > 0 else {
             return 0.0
         }
-        
-        let totalProgress = progresses.reduce(0, +)
-        return Double(totalProgress) / Double(progresses.count)
+
+        return Double(uploadedBytes) / Double(totalBytes) * 100.0
     }
     
     func updateProgressRing() {
-        let averageProgress = averageUploadProgress()
+        let averageProgress = totalUploadProgress()
         
         if averageProgress == 0 {
             statusProgressState.backgroundGradient = LinearGradient(
                 gradient: Gradient(colors: [.white, Color(.adamant.sendingFileAnimationGrayColor)]),
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
-        )} else {
+            )
+        } else {
             statusProgressState.backgroundGradient = nil
         }
         statusProgressState.progress = averageProgress / 100


### PR DESCRIPTION
- fix progressRing macos layout
- progress ring animation show total upload volume instead of avarage volume