### PR TITLE
[trello.com/c/m0k5mrQR] remove hard frame setting and extra fullScreen setting

### DIFF
--- a/CommonKit/Sources/CommonKit/Helpers/SwiftUI/View+Extension.swift
+++ b/CommonKit/Sources/CommonKit/Helpers/SwiftUI/View+Extension.swift
@@ -41,9 +41,8 @@ extension View {
         return resultView
     }
 
-    // TODO: Remove this function (or fix)
     public func fullScreen() -> some View {
-        return frame(width: .infinity, height: .infinity)
+       return frame(maxWidth: .infinity, maxHeight: .infinity)
             .ignoresSafeArea()
     }
 

--- a/pckg/AdvancedContextMenuKit/Sources/AdvancedContextMenuKit/Implementation/ContextMenuOverlayView.swift
+++ b/pckg/AdvancedContextMenuKit/Sources/AdvancedContextMenuKit/Implementation/ContextMenuOverlayView.swift
@@ -126,7 +126,6 @@ extension ContextMenuOverlayView {
                 .padding(.leading, viewModel.contentViewLocation.x)
             Spacer()
         }
-        .fullScreen()
         .transition(.opacity)
     }
 
@@ -154,8 +153,8 @@ extension ContextMenuOverlayView {
             }
         }
         .frame(
-            width: .infinity,
-            height: viewModel.menuSize.height
+            maxWidth: .infinity,
+            maxHeight: viewModel.menuSize.height
         )
         .offset(y: viewModel.menuLocation.y)
         .ignoresSafeArea()
@@ -167,7 +166,6 @@ extension ContextMenuOverlayView {
                 .onTapGesture {}
             Spacer()
         }
-        .fullScreen()
         .transition(.opacity)
     }
 
@@ -187,9 +185,7 @@ extension ContextMenuOverlayView {
                 .padding(.leading, viewModel.upperContentViewLocation.x)
             Spacer()
         }
-        .fullScreen()
     }
-
 }
 
 private let minBottomOffset: CGFloat = 50

--- a/pckg/AdvancedContextMenuKit/Sources/AdvancedContextMenuKit/Implementation/MacOSOverlay/ContextMenuOverlayViewMac.swift
+++ b/pckg/AdvancedContextMenuKit/Sources/AdvancedContextMenuKit/Implementation/MacOSOverlay/ContextMenuOverlayViewMac.swift
@@ -70,7 +70,6 @@ extension ContextMenuOverlayViewMac {
             }
             Spacer()
         }
-        .fullScreen()
         .transition(.opacity)
     }
 
@@ -94,7 +93,6 @@ extension ContextMenuOverlayViewMac {
                 .padding(.leading, viewModel.contentLocation.x)
             Spacer()
         }
-        .fullScreen()
         .transition(.opacity)
     }
 
@@ -110,7 +108,6 @@ extension ContextMenuOverlayViewMac {
             }
             Spacer()
         }
-        .fullScreen()
         .transition(.opacity)
     }
 
@@ -120,7 +117,6 @@ extension ContextMenuOverlayViewMac {
                 .onTapGesture {}
             Spacer()
         }
-        .fullScreen()
         .transition(.opacity)
     }
 
@@ -135,7 +131,6 @@ extension ContextMenuOverlayViewMac {
                 .padding(.leading, viewModel.upperContentViewLocation.x)
             Spacer()
         }
-        .fullScreen()
         .transition(.opacity)
     }
 }


### PR DESCRIPTION
Previously, the layout worked magically forcing all views to occupy the maximum available space, instead of using only Spacer() and offset to change the position of the view, which is contrary to the principles of swiftui. Also, during the build, an error Invalid frame dimension (negative or non-finite) occurred. Which could potentially lead to bugs