### PR TITLE
[trello.com/c/x0o1aqih] fix media cell layout

### DIFF
--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/ChatMediaContnentView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/ChatMediaContnentView.swift
@@ -102,7 +102,8 @@ final class ChatMediaContentView: UIView {
         view.addSubview(commentLabel)
 
         commentLabel.snp.makeConstraints { make in
-            make.verticalEdges.equalToSuperview().inset(verticalInsets)
+            make.top.equalToSuperview().inset(verticalInsets / 2)
+            make.bottom.equalToSuperview().inset(verticalInsets)
             make.horizontalEdges.equalToSuperview().inset(horizontalInsets)
         }
 
@@ -278,7 +279,11 @@ extension ChatMediaContentView.Model {
 
         var spaceCount: CGFloat = fileModel.isMediaFilesOnly ? .zero : 1
 
-        if isReply || !comment.string.isEmpty{
+        if isReply {
+            spaceCount += 2
+        }
+        
+        if !comment.string.isEmpty {
             spaceCount += 2
         }
 


### PR DESCRIPTION
return separate extra space for reply + comment
reduced the top indent for comment label to avoid unnecessary space between media and text, and to make sure the text fits on devices with small screens
tested on Iphone SE, iphone 16 pro and MacOS