### PR TITLE
Verify/update coin tx sending algorithm

### DIFF
--- a/Adamant/Modules/TransactionsStatusService/Services/TxStatusService.swift
+++ b/Adamant/Modules/TransactionsStatusService/Services/TxStatusService.swift
@@ -61,10 +61,21 @@ final class TxStatusService: TxStatusServiceProtocol {
     }
 
     func forceUpdate(transaction: CoinTransaction) async {
+        subscription?.cancel()
+        
         status = .notInitiated
         saveStatuses()
+        
         await updateStatus()
+        
+        subscription = Task { [weak self] in
+            while await self?.observationIteration() == true {
+                try Task.checkCancellation()
+            }
+        }
+        .eraseToAnyCancellable()
     }
+
 }
 
 extension TxStatusService {


### PR DESCRIPTION
Previously, force-update simply triggered an update without taking into account our scenario, PR added so that the force-update also followed the scenario