### PR TITLE
[trello.com/c/jKqpxiCa] show newMessage separator after enter from remote notify

### DIFF
--- a/Adamant/App/AppDelegate.swift
+++ b/Adamant/App/AppDelegate.swift
@@ -414,7 +414,7 @@ extension AppDelegate {
         chatListNav.dismiss(animated: true, completion: nil)
         tabbar.selectedIndex = 0
 
-        let vc = chatListVC.chatViewController(for: chatroom, with: transactionID)
+        let vc = chatListVC.chatViewController(for: chatroom, with: transactionID, enterFromNotification: true)
 
         vc.hidesBottomBarWhenPushed = true
 

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -227,9 +227,11 @@ final class ChatViewModel: NSObject {
         account: AdamantAccount?,
         chatroom: Chatroom,
         messageIdToShow: String?,
-        isNewChat: Bool = false
+        isNewChat: Bool = false,
+        isEnterFromNotification: Bool = false
     ) {
         setUpMessagetoShow(messageId: messageIdToShow)
+        self.separatorState.isEnterFromRemoteNotifivation = isEnterFromNotification
         assert(self.chatroom == nil, "Can't setup several times")
         self.chatroom = chatroom
         self.chatroom?.updateLastTransaction()
@@ -1831,7 +1833,7 @@ extension ChatViewModel {
     fileprivate func updateSeparatorId() {
         guard !separatorState.didAddSeparator, !messages.isEmpty else { return }
         
-        if separatorState.isFirstUpdate || !separatorState.isScrollPositionNearlyTheBottom {
+        if separatorState.shouldUpdateSeparator {
             separatorState.isFirstUpdate = false
             guard let firstUnreadId = unreadMessagesIds?.first else {
                 separatorState.separatorId = nil
@@ -1841,6 +1843,7 @@ extension ChatViewModel {
             
             separatorState.didAddSeparator = true
             separatorState.separatorId = firstUnreadId
+            separatorState.isEnterFromRemoteNotifivation = false
             updateSeparatorIndex()
         }
     }

--- a/Adamant/Modules/Chat/ViewModel/Models/NewMessageSeparatorState.swift
+++ b/Adamant/Modules/Chat/ViewModel/Models/NewMessageSeparatorState.swift
@@ -14,4 +14,11 @@ struct NewMessageSeparatorState {
     var isFirstUpdate: Bool = true
     var didAddSeparator: Bool = false
     var isScrollPositionNearlyTheBottom = true
+    var isEnterFromRemoteNotifivation: Bool = false
+    
+    var shouldUpdateSeparator: Bool {
+        isFirstUpdate
+        || !isScrollPositionNearlyTheBottom
+        || isEnterFromRemoteNotifivation
+    }
 }

--- a/Adamant/Modules/ChatsList/ChatListViewController.swift
+++ b/Adamant/Modules/ChatsList/ChatListViewController.swift
@@ -459,7 +459,8 @@ final class ChatListViewController: KeyboardObservingViewController {
     func chatViewController(
         for chatroom: Chatroom,
         with messageId: String? = nil,
-        newChat: Bool = false
+        newChat: Bool = false,
+        enterFromNotification: Bool = false
     ) -> ChatViewController {
         let vc = screensFactory.makeChat()
         vc.hidesBottomBarWhenPushed = true
@@ -468,7 +469,8 @@ final class ChatListViewController: KeyboardObservingViewController {
             account: accountService.account,
             chatroom: chatroom,
             messageIdToShow: messageId,
-            isNewChat: newChat
+            isNewChat: newChat,
+            isEnterFromNotification: enterFromNotification
         )
 
         return vc


### PR DESCRIPTION
The problem is that the messages do not have time to be loaded into the database before we open the screen and set the marker not to show the new message separator in the visible area of ​​the screen. 
I made an additional marker for the login scene via remote push, it will not conflict with other scenarios because we are sure that the user has definitely received a new message and the separator will need to be shown 100%