### PR TITLE
[trello.com/c/pRsTtPYQ] marked each failed files

### DIFF
--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/ChatFileContainerView/FileListContentView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/ChatFileContainerView/FileListContentView.swift
@@ -14,6 +14,7 @@ final class FileListContentView: UIView {
     private lazy var iconImageView: UIImageView = UIImageView()
     private lazy var downloadImageView = UIImageView(image: .asset(named: "downloadIcon"))
     private lazy var videoIconIV = UIImageView(image: .asset(named: "playVideoIcon"))
+    private var usedFileIds: Set<String> = []
 
     private lazy var spinner: UIActivityIndicatorView = {
         let view = UIActivityIndicatorView(style: .medium)
@@ -196,10 +197,18 @@ extension FileListContentView {
         }
 
         downloadImageView.isHidden =
-            chatFile.isCached
-            || chatFile.isBusy
-            || model.txStatus == .failed
-            || (chatFile.fileType.isMedia && chatFile.previewImage == nil)
+        chatFile.isCached
+        || chatFile.isBusy
+        || model.txStatus == .failed
+        
+        let fileId = chatFile.file.id
+        let isDuplicate = !usedFileIds.insert(fileId).inserted
+        
+        if isDuplicate || chatFile.file.nonce.isEmpty {
+            downloadImageView.tintColor = .adamant.warning
+            downloadImageView.image = UIImage(systemName: "exclamationmark.triangle")
+            downloadImageView.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
+        }
 
         if chatFile.isDownloading {
             if chatFile.previewImage == nil,

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/MediaContainerView/MediaContentView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Content/Views/MediaContainerView/MediaContentView.swift
@@ -14,6 +14,7 @@ final class MediaContentView: UIView {
     private lazy var imageView: UIImageView = UIImageView()
     private lazy var downloadImageView = UIImageView(image: .asset(named: "downloadIcon"))
     private lazy var videoIconIV = UIImageView(image: .asset(named: "playVideoIcon"))
+    private var usedFileIds: Set<String> = []
 
     private lazy var spinner: UIActivityIndicatorView = {
         let view = UIActivityIndicatorView(style: .medium)
@@ -156,8 +157,16 @@ extension MediaContentView {
             chatFile.isCached
             || chatFile.isBusy
             || model.txStatus == .failed
-            || chatFile.previewImage == nil
 
+        let fileId = chatFile.file.id
+        let isDuplicate = !usedFileIds.insert(fileId).inserted
+        
+        if isDuplicate || chatFile.file.nonce.isEmpty {
+            downloadImageView.tintColor = .adamant.warning
+            downloadImageView.image = UIImage(systemName: "exclamationmark.triangle")
+            downloadImageView.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
+        }
+        
         videoIconIV.isHidden =
             !(chatFile.isCached
             && !chatFile.isBusy

--- a/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
+++ b/Adamant/Modules/Chat/ViewModel/ChatViewModel.swift
@@ -1758,6 +1758,14 @@ extension ChatViewModel {
             if model.content.fileModel.files.contains(where: { $0.file.nonce.isEmpty }) {
                 return .unableToDownload
             }
+            
+            if model.content.fileModel.files.count > 1 {
+                let ids = model.content.fileModel.files.map { $0.file.id }
+                let uniqueIds = Set(ids)
+                if uniqueIds.count == 1 {
+                    return .unableToDownload
+                }
+            }
 
             return .needToDownload(failed: failed)
         }


### PR DESCRIPTION
most of the time I was trying to figure out what was wrong with the files. It turned out that the message simply contained the ID of only the very first file and assigned it to all the others.
now to display this in the ui I made a check whether a specific id had already been used, this may look like a hard code, but the bug itself is very strange and our architecture with models of individual files does not really suggest that the service could check this when loading. it simply searches for files by 1 and the same id, although in fact all the files that were needed have already been downloaded.