### PR TITLE
[trello.com/c/ouNP4Ezx] Show clock icon (before was `pending`) while transactions are loading in the transaction list

### DIFF
--- a/Adamant/Modules/Wallets/TransactionTableViewCell.swift
+++ b/Adamant/Modules/Wallets/TransactionTableViewCell.swift
@@ -187,18 +187,20 @@ final class TransactionTableViewCell: UITableViewCell {
         dateLabel.textColor = transaction.transactionStatus?.color ?? .adamant.secondary
 
         switch transaction.transactionStatus {
-        case .success, .inconsistent:
-            if let date = transaction.dateValue {
-                dateLabel.text = date.humanizedDateTime()
-            } else {
-                dateLabel.text = nil
-            }
-        case .failed:
-            dateLabel.text = TransactionStatus.failed.localized
-        case .pending, .registered, .notInitiated:
-            dateLabel.text = TransactionStatus.pending.localized
-        default:
-            dateLabel.text = TransactionDetailsViewControllerBase.awaitingValueString
+            case .success, .inconsistent:
+                if let date = transaction.dateValue {
+                    dateLabel.text = date.humanizedDateTime()
+                } else {
+                    dateLabel.text = nil
+                }
+            case .failed:
+                dateLabel.text = TransactionStatus.failed.localized
+            case .pending, .registered:
+                dateLabel.text = TransactionStatus.pending.localized
+            case .notInitiated:
+                dateLabel.text = TransactionDetailsViewControllerBase.awaitingValueString
+            default:
+                dateLabel.text = TransactionDetailsViewControllerBase.awaitingValueString
         }
 
         if let partnerName = transaction.partnerName {


### PR DESCRIPTION
## Description

Show clock icon (before was `pending`) while transactions are loading in the transaction list

## Screenshots or videos (optional)

<img width="500" height="1250" alt="Simulator Screenshot - iPhone 16e - 2025-09-22 at 20 55 10 2" src="https://github.com/user-attachments/assets/ddce3a7d-d8cd-4ac4-a103-de22ab4d95b9" />

## How to test

Make sure UI was changed and status handling is correct
