### PR TITLE
Fix: Incorrect pop-up while sending btc again

### DIFF
--- a/Adamant/Modules/Wallets/Bitcoin/BtcTransferViewController.swift
+++ b/Adamant/Modules/Wallets/Bitcoin/BtcTransferViewController.swift
@@ -39,17 +39,17 @@ final class BtcTransferViewController: TransferViewControllerBase {
 
         Task {
             do {
+                if await !doesNotContainSendingTx() {
+                    presentSendingError()
+                    return
+                }
+                
                 let transaction = try await service.createTransaction(
                     recipient: recipient,
                     amount: amount,
                     fee: transactionFee,
                     comment: nil
                 )
-
-                if await !doesNotContainSendingTx() {
-                    presentSendingError()
-                    return
-                }
 
                 // Send adm report
                 if let reportRecipient = admReportRecipient,


### PR DESCRIPTION
## Description

Fix #919 

## How to test

Described in the issue 

## Notes for reviewers

Before we were creating transaction and only after this checking if we have a pending one. I changed the order to check first.
It some magic inside `createTransaction` on BTC and somehow it calculate weird (i don't correct or not) when we have pending transaction.