### PR TITLE
Fix incorrect display of unavailable attachments in chat

### DIFF
--- a/Adamant/Modules/Chat/View/Managers/ChatAction.swift
+++ b/Adamant/Modules/Chat/View/Managers/ChatAction.swift
@@ -24,4 +24,5 @@ enum ChatAction {
     case cancelUploading(messageId: String)
     case autoDownloadContentIfNeeded(messageId: String, files: [ChatFile])
     case forceDownloadAllFiles(messageId: String, files: [ChatFile])
+    case showDialog(title: String)
 }

--- a/Adamant/Modules/Chat/View/Managers/ChatDataSourceManager.swift
+++ b/Adamant/Modules/Chat/View/Managers/ChatDataSourceManager.swift
@@ -223,6 +223,8 @@ extension ChatDataSourceManager {
             )
         case let .forceDownloadAllFiles(messageId, files):
             viewModel.forceDownloadAllFiles(messageId: messageId, files: files)
+        case let .showDialog(title):
+            viewModel.dialog.send(.warning(title))
         }
     }
 }

--- a/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
+++ b/Adamant/Modules/Chat/View/Subviews/ChatMedia/Container/ChatMediaContainerView.swift
@@ -154,6 +154,11 @@ final class ChatMediaContainerView: UIView {
             actionHandler(.openFile(messageId: model.id, file: file))
             return
         }
+        
+        if model.status == .unableToDownload {
+            actionHandler(.showDialog(title: FileManagerError.unableToDownloadCorrupted.localizedDescription))
+            return
+        }
 
         guard case .needToDownload = model.status else {
             return

--- a/Adamant/Services/FilesNetworkManager/Models/FileManagerError.swift
+++ b/Adamant/Services/FilesNetworkManager/Models/FileManagerError.swift
@@ -18,22 +18,25 @@ enum FileManagerError: Error {
     case cantUploadFile
     case cantEncryptFile
     case cantDecryptFile
+    case unableToDownloadCorrupted
     case apiError(error: ApiServiceError)
 }
 
 extension FileManagerError: LocalizedError {
     var errorDescription: String? {
         switch self {
-        case .cantDownloadFile:
-            return .localized("FileManagerError.CantDownloadFile")
-        case .cantUploadFile:
-            return .localized("FileManagerError.CantUploadFile")
-        case .cantEncryptFile:
-            return .localized("FileManagerError.CantEncryptFile")
-        case .cantDecryptFile:
-            return .localized("FileManagerError.CantDecryptFile")
-        case let .apiError(error: error):
-            return error.localizedDescription
+            case .cantDownloadFile:
+                return .localized("FileManagerError.CantDownloadFile")
+            case .cantUploadFile:
+                return .localized("FileManagerError.CantUploadFile")
+            case .cantEncryptFile:
+                return .localized("FileManagerError.CantEncryptFile")
+            case .cantDecryptFile:
+                return .localized("FileManagerError.CantDecryptFile")
+            case .unableToDownloadCorrupted:
+                return .localized("FileManagerError.FilesUnaccessible")
+            case let .apiError(error: error):
+                return error.localizedDescription
         }
     }
 }

--- a/CommonKit/Sources/CommonKit/Assets/Localization/de.lproj/Localizable.strings
+++ b/CommonKit/Sources/CommonKit/Assets/Localization/de.lproj/Localizable.strings
@@ -1354,6 +1354,9 @@
 /* FileManager error 'Can't decrypt file' */
 "FileManagerError.CantDecryptFile" = "Datei kann nicht entschlüsselt werden";
 
+/* FileManager error 'Unable to download corrupted file' */
+"FileManagerError.FilesUnaccessible" = "Dateien sind derzeit nicht zugänglich";
+
 /* File validation error 'Too many files' */
 "FileValidationError.TooManyFiles" = "Zu viele Dateien. Höchstens erlaubt: %lld";
 

--- a/CommonKit/Sources/CommonKit/Assets/Localization/en.lproj/Localizable.strings
+++ b/CommonKit/Sources/CommonKit/Assets/Localization/en.lproj/Localizable.strings
@@ -1330,6 +1330,9 @@
 /* FileManager error 'Can't decrypt file' */
 "FileManagerError.CantDecryptFile" = "Can't decrypt file";
 
+/* FileManager error 'Unable to download corrupted file' */
+"FileManagerError.FilesUnaccessible" = "Files are not currently accessible";
+
 /* File validation error 'Too many files' */
 "FileValidationError.TooManyFiles" = "Too many files. Maximum allowed: %lld";
 

--- a/CommonKit/Sources/CommonKit/Assets/Localization/ru.lproj/Localizable.strings
+++ b/CommonKit/Sources/CommonKit/Assets/Localization/ru.lproj/Localizable.strings
@@ -1334,6 +1334,9 @@
 /* FileManager error 'Can't decrypt file' */
 "FileManagerError.CantDecryptFile" = "Не удалось расшифровать файл";
 
+/* FileManager error 'Unable to download corrupted file' */
+"FileManagerError.FilesUnaccessible" = "Файлы недоступны";
+
 /* File validation error 'Too many files' */
 "FileValidationError.TooManyFiles" = "Превышено максимально допустимое количество файлов (%lld)";
 

--- a/CommonKit/Sources/CommonKit/Assets/Localization/zh.lproj/Localizable.strings
+++ b/CommonKit/Sources/CommonKit/Assets/Localization/zh.lproj/Localizable.strings
@@ -1325,6 +1325,9 @@
 /* FileManager error 'Can't decrypt file' */
 "FileManagerError.CantDecryptFile" = "无法解密文件";
 
+/* FileManager error 'Unable to download corrupted file' */
+"FileManagerError.FilesUnaccessible" = "文件目前无法访问";
+
 /* File validation error 'Too many files' */
 "FileValidationError.TooManyFiles" = "文件太多。 最大允许：%lld";
 


### PR DESCRIPTION
## Description

I was trying to adopt it to the download flow as discussed in https://github.com/Adamant-im/adamant-iOS/issues/921#issuecomment-3364303022 , but finally decided to just show pop-up because the flow require some additional refactor to make.

## Related issue

[Closes #<issue-number>](https://github.com/Adamant-im/adamant-iOS/issues/921)

## Screenshots or videos (optional)

<img width="300" height="700" alt="Simulator Screenshot - iPhone 16e - 2025-10-07 at 19 52 08" src="https://github.com/user-attachments/assets/72fb4bd8-cb4e-457c-abf4-1c14e5e0b70f" />
<img width="300" height="700" alt="Simulator Screenshot - iPhone 16e - 2025-10-07 at 19 52 20" src="https://github.com/user-attachments/assets/b5e032e8-ad9d-4761-9df5-18931befa709" />


## How to test

Make sure that pop-ip appears correctly and that translation is handling properly