### PR TITLE
Save chat position after reloading the app

### DIFF
--- a/Adamant/Modules/Chat/View/ChatViewController.swift
+++ b/Adamant/Modules/Chat/View/ChatViewController.swift
@@ -179,6 +179,7 @@ final class ChatViewController: MessagesViewController {
             state.isFirstTimeViewAppeared = true
             state.isViewDissappeared = false
             updateUnreadMessages()
+            setupBackgroundObservers()
         }
         inputBar.isUserInteractionEnabled = true
         chatMessagesCollectionView.fixedBottomOffset = nil
@@ -199,20 +200,8 @@ final class ChatViewController: MessagesViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        viewModel.preserveMessage(inputBar.text)
         
-        var bottomOffset = chatMessagesCollectionView.bottomOffset
-        var collectionHeight: CGFloat = messagesCollectionView.contentSize.height
-        if viewModel.separatorState.separatorIndex != nil {
-            collectionHeight -= separatorHeight
-            bottomOffset -= separatorHeight
-        }
-        
-        viewModel.saveChatOffset(
-            state.isScrollPositionNearlyTheBottom
-                ? nil
-            : bottomOffset, collectionHeight: collectionHeight
-        )
+        saveChatScrollPosition()
             
         state.isViewDissappeared = true
     }
@@ -289,6 +278,25 @@ extension ChatViewController {
     
     fileprivate func handleAppWillEnterBackground() {
         inputBar.inputTextView.resignFirstResponder()
+        saveChatScrollPosition()
+    }
+    
+    fileprivate func saveChatScrollPosition() {
+        viewModel.preserveMessage(inputBar.text)
+        
+        var bottomOffset = chatMessagesCollectionView.bottomOffset
+        var collectionHeight: CGFloat = messagesCollectionView.contentSize.height
+        if viewModel.separatorState.separatorIndex != nil {
+            bottomOffset -= separatorHeight
+            collectionHeight -= separatorHeight
+        }
+        
+        viewModel.saveChatOffset(
+            state.isScrollPositionNearlyTheBottom
+            ? nil
+            : bottomOffset,
+            collectionHeight: collectionHeight
+        )
     }
     
     fileprivate func handleAppWillEnterForeground() {

--- a/Adamant/Services/DataProviders/AdamantChatsProvider.swift
+++ b/Adamant/Services/DataProviders/AdamantChatsProvider.swift
@@ -323,6 +323,7 @@ extension AdamantChatsProvider {
         SecureStore.remove(StoreKey.chatProvider.receivedLastHeight)
         SecureStore.remove(StoreKey.chatProvider.readedLastHeight)
         SecureStore.remove(StoreKey.chatProvider.markedChatsAsUnread)
+        UserDefaultsManager.chatPositions = nil
         UserDefaultsManager.lastReceivedId = nil
 
         // Set State
@@ -796,16 +797,30 @@ extension AdamantChatsProvider {
         return transaction
     }
 
-    @MainActor func removeChatPosition(for address: String) {
-        chatPositon.removeValue(forKey: address)
+    func removeChatPosition(for address: String) {
+        var positions = UserDefaultsManager.chatPositions ?? [:]
+        positions.removeValue(forKey: address)
+        UserDefaultsManager.chatPositions = positions
     }
-
-    @MainActor func setChatPositon(for address: String, position: CGFloat?, collectionHeight: CGFloat?) {
-        chatPositon[address] = (position, collectionHeight) as? (CGFloat, CGFloat)
+    
+    func setChatPositon(for address: String, position: CGFloat?, collectionHeight: CGFloat?) {
+        var positions = UserDefaultsManager.chatPositions ?? [:]
+        if let position = position, let collectionHeight = collectionHeight {
+            positions[address] = [Double(position), Double(collectionHeight)]
+        } else {
+            positions.removeValue(forKey: address)
+        }
+        UserDefaultsManager.chatPositions = positions
     }
-
-    @MainActor func getChatPositon(for address: String) -> (CGFloat, CGFloat)? {
-        return chatPositon[address]
+    
+    func getChatPositon(for address: String) -> (CGFloat, CGFloat)? {
+        guard
+            let values = UserDefaultsManager.chatPositions?[address],
+            values.count == 2
+        else {
+            return nil
+        }
+        return (CGFloat(values[0]), CGFloat(values[1]))
     }
 
     /// Logic:

--- a/CommonKit/Sources/CommonKit/Core/UserDefaultsKeys.swift
+++ b/CommonKit/Sources/CommonKit/Core/UserDefaultsKeys.swift
@@ -11,4 +11,5 @@ public enum UserDefaultsKey: String {
     case leftSplitViewController
     case rightSplitViewController
     case lastReceivedId
+    case chatPositions
 }

--- a/CommonKit/Sources/CommonKit/Core/UserDefaultsManager.swift
+++ b/CommonKit/Sources/CommonKit/Core/UserDefaultsManager.swift
@@ -7,10 +7,13 @@
 public struct UserDefaultsManager {
     @UserDefaultsStorage(.needsToShowNoActiveNodesAlert)
     static var needsToShowNoActiveNodesAlert: Bool?
-
+    
     @UserDefaultsStorage(.lastReceivedId)
     public static var lastReceivedId: [String]?
-
+    
+    @UserDefaultsStorage(.chatPositions)
+    public static var chatPositions: [String: [Double]]?
+    
     public static func setInitialUserDefaults() {
         needsToShowNoActiveNodesAlert = true
     }


### PR DESCRIPTION
## Description

Save chat position after restartring the app. Positions will be deleted on a logout.

## Related issue

[910](https://github.com/Adamant-im/adamant-iOS/issues/910)

## Notes for reviewers

Initially tried to reuse CoreData chatroom, but was not able to implement this approach and decided to use UserDefaults instead.