### PR TITLE
Fix toast appearance and interaction behavior

### DIFF
--- a/PopupKit/Sources/PopupKit/Implementation/Services/AutoDismissManager.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Services/AutoDismissManager.swift
@@ -54,4 +54,4 @@ extension AutoDismissManager {
     }
 }
 
-private let autoDismissTimeInterval: TimeInterval = 3
+private let autoDismissTimeInterval: TimeInterval = 4

--- a/PopupKit/Sources/PopupKit/Implementation/Views/PopupCoordinatorView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/PopupCoordinatorView.swift
@@ -73,10 +73,15 @@ extension PopupCoordinatorView {
         VStack {
             Spacer()
             if let message = model.toastMessage {
-                ToastView(message: message)
-                    .padding(.bottom, safeAreaInsets.bottom)
-                    .id(model.toastMessage?.hashValue)
-                    .transition(.move(edge: .bottom))
+                ToastView(
+                    message: message,
+                    dismissAction: { [weak model] in
+                        model?.toastMessage = nil
+                    }
+                )
+                .padding(.bottom, safeAreaInsets.bottom)
+                .id(model.toastMessage?.hashValue)
+                .transition(.move(edge: .bottom))
             }
         }
         .animation(.easeInOut(duration: animationDuration), value: model.toastMessage?.hashValue)

--- a/PopupKit/Sources/PopupKit/Implementation/Views/ToastView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/ToastView.swift
@@ -9,15 +9,71 @@ import CommonKit
 import SwiftUI
 
 struct ToastView: View {
+    @State private var offset: CGSize = .zero
+    @State private var isExpanded: Bool = false
+    @State private var isTruncated: Bool = false
+
     let message: String
+    let dismissAction: () -> Void
 
     var body: some View {
-        Text(message)
-            .multilineTextAlignment(.center)
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
-            .background(Blur(style: Constants.blurStyle))
-            .cornerRadius(Constants.cornerRadius)
-            .padding(Constants.borderPadding)
+        VStack(spacing: 4) {
+            Text(message)
+                .multilineTextAlignment(.center)
+                .lineLimit(isExpanded ? nil : 3)
+                .background(
+                    GeometryReader { textGeometry in
+                        Text(message)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .hidden()
+                            .background(
+                                GeometryReader { fullGeometry in
+                                    Color.clear.onAppear {
+                                        isTruncated = fullGeometry.size.height > textGeometry.size.height + 1
+                                    }
+                                }
+                            )
+                    }
+                )
+
+            if isTruncated && !isExpanded {
+                Image(systemName: "chevron.compact.down")
+                    .foregroundColor(.gray)
+            } else if isExpanded {
+                Image(systemName: "chevron.compact.up")
+                    .foregroundColor(.gray)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .background(Blur(style: Constants.blurStyle))
+        .cornerRadius(Constants.cornerRadius)
+        .padding(Constants.borderPadding)
+        .contentShape(Rectangle())
+        .offset(y: offset.height)
+        .gesture(
+            DragGesture()
+                .onChanged { value in
+                    if value.translation.height > 0 {
+                        offset = CGSize(
+                            width: 0,
+                            height: min(value.translation.height, 30)
+                        )
+                    } else {
+                        offset = CGSize(width: 0, height: value.translation.height)
+                    }
+                }
+                .onEnded { value in
+                    if value.translation.height < -30 {
+                        dismissAction()
+                    } else if value.translation.height > 25 && isTruncated {
+                        isExpanded = true
+                    }
+                    offset = .zero
+                }
+        )
+        .animation(.interactiveSpring(), value: offset)
     }
 }


### PR DESCRIPTION
## Summary

Addresses the toast UX issues reported in #933:

- **Swipe up to dismiss**: Added `DragGesture` to `ToastView` — swiping up (> 30pt) dismisses the toast
- **Swipe down to expand**: Swiping down (> 25pt) expands truncated text, matching notification behavior
- **Expand indicator**: Shows a chevron.compact.down only when the message text is truncated (3-line limit), and chevron.compact.up when expanded
- **Tap pass-through blocked**: Added `.contentShape(Rectangle())` so taps on the toast don't pass through to the underlying UI
- **Display duration**: Increased auto-dismiss timer from 3s to 4s as requested in the issue

## Changes

| File | Change |
|------|--------|
| `ToastView.swift` | Added drag gesture (swipe up/down), text truncation detection, expand/collapse chevron, contentShape |
| `PopupCoordinatorView.swift` | Pass `dismissAction` closure to `ToastView` |
| `AutoDismissManager.swift` | Changed `autoDismissTimeInterval` from 3 to 4 seconds |

## Test plan
- [ ] Toast appears at bottom and auto-dismisses after ~4 seconds
- [ ] Swipe up on toast dismisses it immediately
- [ ] Long toast text shows truncated with chevron indicator
- [ ] Swipe down on truncated toast expands full text
- [ ] Tapping the toast area does not trigger UI elements behind it
- [ ] Short toast text does not show expand chevron

Fixes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)