### PR TITLE
fix in-app notification navigation

### DIFF
--- a/CommonKit/Sources/CommonKit/Helpers/UIHelpers/InteractiveBackgroundView.swift
+++ b/CommonKit/Sources/CommonKit/Helpers/UIHelpers/InteractiveBackgroundView.swift
@@ -1,6 +1,6 @@
 //
 //  InteractiveBackgroundView.swift
-//
+//  CommonKit
 //
 //  Created by Dmitrij Meidus on 06.03.2026.
 //
@@ -11,15 +11,19 @@ import UIKit
 /// A UIViewRepresentable that wraps a real UIView with a background color.
 /// Unlike SwiftUI's Color, this creates an actual UIKit subview
 /// that TransparentWindow._hitTest can detect for proper hit testing.
-struct InteractiveBackgroundView: UIViewRepresentable {
-    let color: UIColor
+public struct InteractiveBackgroundView: UIViewRepresentable {
+    public let color: UIColor
 
-    func makeUIView(context: Context) -> UIView {
+    public init(color: UIColor) {
+        self.color = color
+    }
+
+    public func makeUIView(context: Context) -> UIView {
         let view = UIView()
         view.backgroundColor = color
         view.isUserInteractionEnabled = true
         return view
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {}
+    public func updateUIView(_ uiView: UIView, context: Context) {}
 }

--- a/PopupKit/Sources/PopupKit/Implementation/Views/NotificationPresenterView.swift
+++ b/PopupKit/Sources/PopupKit/Implementation/Views/NotificationPresenterView.swift
@@ -62,7 +62,7 @@ struct NotificationPresenterView: View {
 }
 extension NotificationPresenterView {
     fileprivate func processGeometry(_ geometry: GeometryProxy) -> some View {
-        return Color.init(uiColor: .adamant.swipeBlockColor)
+        return InteractiveBackgroundView(color: .adamant.swipeBlockColor)
             .cornerRadius(10)
     }
     fileprivate func onTap() {


### PR DESCRIPTION
## Description

Issue was because initial `Color.init(uiColor: .adamant.swipeBlockColor)` did not provide tap to the responder instead was created `InteractiveBackgroundView` which use `Color` under the hood, however UIKit version instead of SwiftUI, which does not have the limitation.

## Related issue

Closes #910 

## Testing

Just receive an in-app notification and make sure it tappable and provides you to the sender chat.